### PR TITLE
fix: 테스트 코드 컴파일 에러 수정

### DIFF
--- a/.cotor/stats/conditional.json
+++ b/.cotor/stats/conditional.json
@@ -98,10 +98,112 @@
                     "retries": 0
                 }
             ]
+        },
+        {
+            "pipelineName": "conditional",
+            "timestamp": "2025-12-10T23:52:12.300247Z",
+            "totalDuration": 16,
+            "successCount": 4,
+            "failureCount": 0,
+            "totalAgents": 4,
+            "stages": [
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "decision:quality-check",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
+        },
+        {
+            "pipelineName": "conditional",
+            "timestamp": "2025-12-10T23:52:26.257268Z",
+            "totalDuration": 15,
+            "successCount": 4,
+            "failureCount": 0,
+            "totalAgents": 4,
+            "stages": [
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "decision:quality-check",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
+        },
+        {
+            "pipelineName": "conditional",
+            "timestamp": "2025-12-10T23:52:46.803766Z",
+            "totalDuration": 16,
+            "successCount": 4,
+            "failureCount": 0,
+            "totalAgents": 4,
+            "stages": [
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "decision:quality-check",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
         }
     ],
-    "totalExecutions": 9,
-    "totalSuccesses": 36,
-    "totalDuration": 534,
-    "lastExecuted": "2025-12-03T02:36:02.678191038Z"
+    "totalExecutions": 12,
+    "totalSuccesses": 48,
+    "totalDuration": 581,
+    "lastExecuted": "2025-12-10T23:52:46.803766Z"
 }

--- a/.cotor/stats/looping.json
+++ b/.cotor/stats/looping.json
@@ -92,10 +92,94 @@
                     "retries": 0
                 }
             ]
+        },
+        {
+            "pipelineName": "looping",
+            "timestamp": "2025-12-10T23:52:12.330409Z",
+            "totalDuration": 4,
+            "successCount": 7,
+            "failureCount": 0,
+            "totalAgents": 7,
+            "stages": [
+                {
+                    "name": "loop:loop-controller",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
+        },
+        {
+            "pipelineName": "looping",
+            "timestamp": "2025-12-10T23:52:26.284043Z",
+            "totalDuration": 5,
+            "successCount": 7,
+            "failureCount": 0,
+            "totalAgents": 7,
+            "stages": [
+                {
+                    "name": "loop:loop-controller",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
+        },
+        {
+            "pipelineName": "looping",
+            "timestamp": "2025-12-10T23:52:46.830391Z",
+            "totalDuration": 4,
+            "successCount": 7,
+            "failureCount": 0,
+            "totalAgents": 7,
+            "stages": [
+                {
+                    "name": "loop:loop-controller",
+                    "duration": 0,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                },
+                {
+                    "name": "alpha",
+                    "duration": 5,
+                    "status": "SUCCESS",
+                    "retries": 0
+                }
+            ]
         }
     ],
-    "totalExecutions": 9,
-    "totalSuccesses": 63,
-    "totalDuration": 135,
-    "lastExecuted": "2025-12-03T02:36:02.832866718Z"
+    "totalExecutions": 12,
+    "totalSuccesses": 84,
+    "totalDuration": 148,
+    "lastExecuted": "2025-12-10T23:52:46.830391Z"
 }

--- a/src/test/kotlin/com.cotor.validation/TemplateValidatorTest.kt
+++ b/src/test/kotlin/com.cotor.validation/TemplateValidatorTest.kt
@@ -1,10 +1,12 @@
 package com.cotor.validation
 
 import com.cotor.context.TemplateEngine
-import com.cotor.model.*
+import com.cotor.model.AgentReference
+import com.cotor.model.Pipeline
+import com.cotor.model.PipelineStage
+import com.cotor.model.ValidationResult
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class TemplateValidatorTest : StringSpec({
@@ -17,11 +19,9 @@ class TemplateValidatorTest : StringSpec({
                 PipelineStage(id = "step2", agent = AgentReference("agent2"), input = "\${stages.step1.output}")
             )
         )
-        val context = PipelineContext("test", "test", 2)
-        context.addStageResult("step1", AgentResult("agent1", true, "output", null, 0, emptyMap()))
 
         val validator = PipelineTemplateValidator(TemplateEngine())
-        val result = validator.validate(pipeline, context)
+        val result = validator.validate(pipeline)
 
         result.shouldBeInstanceOf<ValidationResult.Success>()
     }
@@ -34,13 +34,11 @@ class TemplateValidatorTest : StringSpec({
                 PipelineStage(id = "step2", agent = AgentReference("agent2"), input = "\${stages.nonexistent.output}")
             )
         )
-        val context = PipelineContext("test", "test", 2)
-        context.addStageResult("step1", AgentResult("agent1", true, "output", null, 0, emptyMap()))
 
         val validator = PipelineTemplateValidator(TemplateEngine())
-        val result = validator.validate(pipeline, context)
+        val result = validator.validate(pipeline)
 
         result.shouldBeInstanceOf<ValidationResult.Failure>()
-        (result as ValidationResult.Failure).errors shouldContainExactly listOf("[stage 'nonexistent' not found or not yet executed in expression: \${stages.nonexistent.output}]")
+        (result as ValidationResult.Failure).errors shouldContainExactly listOf("Invalid stage reference in stage 'step2': Stage 'nonexistent' not found in pipeline.")
     }
 })

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorTemplatingTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorTemplatingTest.kt
@@ -56,7 +56,7 @@ class PipelineOrchestratorTemplatingTest : StringSpec({
         )
 
         coEvery { agentRegistry.getAgent("echo-agent") } returns AgentConfig("echo-agent", "com.cotor.agents.EchoAgent")
-        coEvery { templateValidator.validate(any(), any()) } returns com.cotor.model.ValidationResult.Success
+        coEvery { templateValidator.validate(any()) } returns com.cotor.model.ValidationResult.Success
 
         coEvery { agentExecutor.executeAgent(any(), any(), any()) } coAnswers {
             val input = secondArg<String?>()


### PR DESCRIPTION
## 수정 내용

### 테스트 코드 수정
- `TemplateValidatorTest.kt`: `validate(pipeline, context)` → `validate(pipeline)`
- `PipelineOrchestratorTemplatingTest.kt`: `validate(any(), any())` → `validate(any())`
- 불필요한 import 정리
- 예상 에러 메시지 업데이트

## 참고
`FileConfigRepositoryTest`의 'can override with empty list' 테스트는 기존 merge 로직 문제로 별도 이슈로 처리 필요

## 테스트 결과
```
✅ TemplateValidatorTest 통과
✅ PipelineOrchestratorTemplatingTest 통과
```

Closes #86