### PR TITLE
fix: shell completion에 누락된 명령어 추가

### DIFF
--- a/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
@@ -439,7 +439,7 @@ class CompletionCommand : CliktCommand(
     }
 
     private val commonSubcommands = listOf(
-        "init", "list", "run", "validate", "template", "dash", "web", "resume", "checkpoint", "stats", "doctor", "version", "completion"
+        "init", "list", "run", "validate", "template", "dash", "web", "resume", "checkpoint", "stats", "doctor", "status", "lint", "explain", "version", "completion"
     )
 
     private val bashCompletion: String


### PR DESCRIPTION
## 수정 내용
`cotor completion` 명령어에서 생성되는 shell completion에 누락된 명령어 추가

### 추가된 명령어
- `status`
- `lint`
- `explain`

## 테스트
```bash
$ cotor completion bash | grep -o 'status\|lint\|explain'
status
lint
explain
```

Closes #93