### PR TITLE
fix: VersionCommand에서 하드코딩된 버전 제거

### DIFF
--- a/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.path
 import com.cotor.data.config.ConfigRepository
+import com.cotor.data.config.CotorProperties
 import com.cotor.data.registry.AgentRegistry
 import com.cotor.domain.orchestrator.PipelineOrchestrator
 import com.cotor.presentation.formatter.OutputFormatter
@@ -412,7 +413,7 @@ class VersionCommand : CliktCommand(
     help = "Show version information"
 ) {
     override fun run() {
-        echo("Cotor version 1.0.0")
+        echo("Cotor version ${CotorProperties.version}")
         echo("Kotlin ${KotlinVersion.CURRENT}")
         echo("JVM ${System.getProperty("java.version")}")
     }


### PR DESCRIPTION
## 수정 내용
`VersionCommand`에서 하드코딩된 버전을 `CotorProperties.version`으로 변경

## 변경 전
```kotlin
echo("Cotor version 1.0.0")
```

## 변경 후
```kotlin
echo("Cotor version ${CotorProperties.version}")
```

## 이점
- 버전 관리가 한 곳에서 이루어짐
- build.gradle.kts에서 버전 변경 시 자동 반영

Closes #95