### PR TITLE
fix: Empty list override and Ktor 3.0.3 upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,12 +36,12 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
 
     // Web Server (Ktor)
-    implementation("io.ktor:ktor-server-core:3.0.0-beta-1")
-    implementation("io.ktor:ktor-server-netty:3.0.0-beta-1")
-    implementation("io.ktor:ktor-server-content-negotiation:3.0.0-beta-1")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.0-beta-1")
-    implementation("io.ktor:ktor-server-cors:3.0.0-beta-1")
-    implementation("io.ktor:ktor-server-sse:3.0.0-beta-1")
+    implementation("io.ktor:ktor-server-core:3.0.3")
+    implementation("io.ktor:ktor-server-netty:3.0.3")
+    implementation("io.ktor:ktor-server-content-negotiation:3.0.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.3")
+    implementation("io.ktor:ktor-server-cors:3.0.3")
+    implementation("io.ktor:ktor-server-sse:3.0.3")
 
     // Testing
     testImplementation("io.kotest:kotest-runner-junit5:5.8.0")


### PR DESCRIPTION
## Summary
This PR fixes two issues found during code review and testing:

### Issue #97: Empty list override not working in config merge
- **Problem**: When using config merging from `.cotor/` directory, explicitly setting an empty list like `allowedExecutables: []` did not override the base config's populated list.
- **Root Cause**: The `mergeConfigs` function compared override values with default values. Since empty list and default are both `[]`, explicit empty overrides were ignored.
- **Solution**: Added `mergeCollection` helper function that properly handles explicit empty overrides. When override is empty but base has items, it's treated as an intentional override to empty.

### Issue #98: Upgrade Ktor from beta to stable version
- **Problem**: Project used Ktor 3.0.0-beta-1 (pre-release version)
- **Solution**: Upgraded to Ktor 3.0.3 (latest stable, released Dec 19, 2024)

## Changes
- `ConfigRepository.kt`: Added `mergeCollection` helper function for proper collection merging
- `build.gradle.kts`: Updated Ktor dependencies from 3.0.0-beta-1 to 3.0.3

## Testing
- All 69 tests pass
- `FileConfigRepositoryTest > can ove- **Root Cause**: The `mergeConfigs` function compared ov runs successfully
- Example pipeline execution verified

Fixes #97
Fixes #98