### PR TITLE
feat: codex-first TUI defaults + model switch + spinner

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -123,7 +123,8 @@ cotor --help       # 전체 명령어 도움말
 ### 기본 TUI 진입
 - 인자 없이 `cotor`를 실행하면 interactive TUI로 바로 진입합니다.
 - 현재 폴더에 `cotor.yaml`이 없으면 starter 설정 파일을 자동 생성합니다.
-  (claude/gemini/codex 설치 여부를 감지해 가능한 AI 에이전트를 우선 선택)
+  (기본 우선순위: codex → gemini → claude → openai → echo)
+- Interactive TUI에서 `:model <name>`으로 모델(에이전트) 전환 가능
 - `cotor tui`도 `cotor interactive`와 동일하게 동작합니다.
 
 ## 📦 예제

--- a/README.md
+++ b/README.md
@@ -883,7 +883,8 @@ cotor --help       # Full command help
 ### Default TUI Entry
 - Running `cotor` with no arguments opens the interactive TUI directly.
 - If `cotor.yaml` does not exist, Cotor auto-creates a starter config in the current directory.
-  (It prefers detected AI CLIs like claude/gemini/codex over Echo.)
+  (Default preference: codex → gemini → claude → openai → echo.)
+- In Interactive TUI, use `:model <name>` to switch the active model/agent quickly.
 - `cotor tui` is also supported as an alias for `cotor interactive`.
 
 ## 📦 Examples

--- a/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
@@ -149,9 +149,9 @@ performance:
         terminal.println("🧭 대화형 설정을 시작합니다. 기본값은 Enter 로 유지하세요.")
 
         val agentType = prompt(
-            label = "에이전트 종류 선택 (claude, gemini, openai, echo)",
-            default = "claude",
-            options = setOf("claude", "gemini", "openai", "echo")
+            label = "에이전트 종류 선택 (codex, claude, gemini, openai, echo)",
+            default = "codex",
+            options = setOf("codex", "claude", "gemini", "openai", "echo")
         )
         val pipelineName = prompt("파이프라인 이름", "my-pipeline")
         val description = prompt("파이프라인 설명", "An interactive-generated pipeline")
@@ -163,6 +163,7 @@ performance:
         val promptText = prompt("첫 단계 프롬프트", "Hello, Cotor!")
 
         val (agentName, pluginClass) = when (agentType.lowercase()) {
+            "codex" -> "codex" to "com.cotor.data.plugin.CodexPlugin"
             "gemini" -> "gemini" to "com.cotor.data.plugin.GeminiPlugin"
             "openai" -> "openai" to "com.cotor.data.plugin.OpenAIPlugin"
             "echo" -> "echo-agent" to "com.cotor.data.plugin.EchoPlugin"


### PR DESCRIPTION
## What
- Make starter agent selection codex-first (`codex -> gemini -> claude -> openai -> echo`)
- Auto-upgrade legacy starter configs to codex when available
- Add `:model <name>` command in interactive TUI (alias of `:use`)
- Add spinner while waiting for interactive responses
- Improve Codex plugin execution to non-interactive mode (`codex exec`) and capture final response only
- Update interactive init default agent to codex

## Why
User-facing TUI should be immediate and feel like Codex UX, with model switching and clear waiting feedback.

## Validation
- ./gradlew test shadowJar --no-daemon
- Global install + real run in ~/Desktop/cotor test
- cotor interactive --prompt '안녕' now returns a natural answer (not Echo/system prompt text)
