### PR TITLE
chore: ignore accidental root shell artifact files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,10 @@ pids
 *.seed
 *.pid.lock
 /.cotor/stats/
+
+# Accidental shell-redirection artifacts at repo root
+/claude
+/codex
+/gemini
+/openai
+/echo


### PR DESCRIPTION
## What
- Add root-only ignore entries for accidental files:
  - /claude /codex /gemini /openai /echo

## Why
During CLI experiments/shell parse mistakes, these empty files can appear at repo root and pollute git status. This keeps working tree clean and prevents accidental commits.
