### PR TITLE
feat(build): add Dockerfile, GH Actions workflow and .dockerignore for official image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gradle
+build
+out
+bin
+.idea
+.vscode
+*.iml
+*.log
+test-results
+coverage

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,57 @@
+name: Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: cotor/cli
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+FROM gradle:8.10.2-jdk17 AS build
+WORKDIR /workspace
+
+COPY build.gradle.kts settings.gradle.kts gradle.properties ./
+COPY src src
+
+RUN gradle --no-daemon shadowJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+COPY --from=build /workspace/build/libs/cotor-*-all.jar /app/cotor.jar
+
+ENTRYPOINT ["java", "-jar", "/app/cotor.jar"]
+CMD ["version"]

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@ chmod +x shell/cotor
 ./shell/cotor version
 ```
 
-### 방법 3: Docker (준비 중)
+### 방법 3: Docker
 
 ```bash
 docker run -it cotor/cli version

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ chmod +x shell/cotor
 ./shell/cotor version
 ```
 
-### Option 3: Docker (Coming Soon)
+### Option 3: Docker
 
 ```bash
 docker run -it cotor/cli version
@@ -817,7 +817,7 @@ chmod +x shell/cotor
 ./shell/cotor version
 ```
 
-### Option 3: Docker (Coming Soon)
+### Option 3: Docker
 
 ```bash
 docker run -it cotor/cli version


### PR DESCRIPTION
### Motivation
- Provide an official, reproducible Docker image for `cotor/cli` so users can run `docker run -it cotor/cli version` as documented. 
- Automate building and publishing of multi-architecture images to Docker Hub via CI to keep releases consistent. 
- Reduce Docker build context size by excluding unnecessary files and update README to reflect the available Docker option.

### Description
- Add a multi-stage `Dockerfile` that builds the `shadowJar` in a Gradle build stage and produces a runtime image that runs `java -jar /app/cotor.jar` with default command `version`.
- Add `.dockerignore` to exclude `.git`, build artifacts, IDE files, test results, and other unnecessary files from the Docker build context.
- Add a GitHub Actions workflow at `.github/workflows/docker-image.yml` that sets up QEMU and Buildx, uses `docker/metadata-action` to generate tags, builds for `linux/amd64` and `linux/arm64`, and only pushes when the event is not a pull request (push to `main` or `v*.*.*` tags); `latest` is emitted only for the default branch.
- Update `README.md` and `README.ko.md` to remove the “Coming Soon / 준비 중” wording for the Docker section and show the actual `docker run -it cotor/cli version` usage.

### Testing
- Ran `gradle shadowJar` locally and it completed successfully (`BUILD SUCCESSFUL`).
- Running `./gradlew shadowJar` failed due to a missing Gradle wrapper class (`org.gradle.wrapper.GradleWrapperMain`).
- `docker --version` could not be executed in this environment because the Docker CLI is not available, so local `docker build`/`run` verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67eb287f88333a0b58758739f97f2)