### PR TITLE
[dx] Spotless/ktlint 코드 포맷팅 파이프라인 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{kt,kts}]
+ktlint_standard_max-line-length = disabled
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_value-parameter-comment = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Format check
+        run: gradle formatCheck
+
+      - name: Test
+        run: gradle test

--- a/README.ko.md
+++ b/README.ko.md
@@ -285,6 +285,13 @@ cotor/
 ./gradlew jacocoTestReport  # 커버리지 리포트
 ```
 
+### 코드 포맷팅
+
+```bash
+./gradlew format       # Spotless + ktlint 포맷 적용
+./gradlew formatCheck  # 포맷 위반이 있으면 실패
+```
+
 ## 📈 로드맵
 
 ### v1.1.0 (다음 버전)

--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,13 @@ cotor/
 ./gradlew jacocoTestReport  # Coverage report
 ```
 
+### Code Formatting
+
+```bash
+./gradlew format       # Apply ktlint formatting via Spotless
+./gradlew formatCheck  # Fail if formatting violations exist
+```
+
 ## 📈 Roadmap
 
 ### v1.1.0 (Next)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     application
     id("com.gradleup.shadow") version "8.3.5"
     jacoco
+    id("com.diffplug.spotless") version "6.25.0"
 }
 
 group = "com.cotor"
@@ -55,9 +56,53 @@ application {
     mainClass.set("com.cotor.MainKt")
 }
 
+
+spotless {
+    kotlin {
+        target("src/**/*.kt")
+        ktlint().editorConfigOverride(
+            mapOf(
+                "ktlint_standard_max-line-length" to "disabled",
+                "ktlint_standard_no-wildcard-imports" to "disabled",
+                "ktlint_standard_value-parameter-comment" to "disabled",
+                "ktlint_standard_trailing-comma-on-call-site" to "disabled",
+                "ktlint_standard_trailing-comma-on-declaration-site" to "disabled",
+            ),
+        )
+    }
+    kotlinGradle {
+        target("*.gradle.kts")
+        ktlint().editorConfigOverride(
+            mapOf(
+                "ktlint_standard_max-line-length" to "disabled",
+                "ktlint_standard_no-wildcard-imports" to "disabled",
+                "ktlint_standard_value-parameter-comment" to "disabled",
+                "ktlint_standard_trailing-comma-on-call-site" to "disabled",
+                "ktlint_standard_trailing-comma-on-declaration-site" to "disabled",
+            ),
+        )
+    }
+}
+
+tasks.register("format") {
+    group = "formatting"
+    description = "Formats Kotlin and Gradle Kotlin files with Spotless."
+    dependsOn("spotlessApply")
+}
+
+tasks.register("formatCheck") {
+    group = "verification"
+    description = "Checks whether Kotlin and Gradle Kotlin files are properly formatted."
+    dependsOn("spotlessCheck")
+}
+
 tasks.test {
     useJUnitPlatform()
     finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.named("check") {
+    dependsOn("spotlessCheck")
 }
 
 tasks.jacocoTestReport {


### PR DESCRIPTION
### Motivation
- Kotlin 코드에 일관된 스타일을 강제하고 개발자가 `./gradlew format`로 일괄 포맷을 적용할 수 있는 단일 파이프라인을 도입했습니다.
- 포맷 검사(`formatCheck`)를 CI 단계에 연결해 포맷 위반이 머지 게이트에서 실패하도록 하기 위함입니다.
- 기존 코드베이스의 포맷 위반을 점진적으로 정리할 수 있도록 포맷/검사 작업과 문서화를 먼저 도입했습니다.

### Description
- `build.gradle.kts`에 `com.diffplug.spotless` 플러그인과 `spotless` 설정을 추가하고 `format`/`formatCheck` 태스크를 등록했으며 `check`가 `spotlessCheck`에 의존하도록 연결했습니다.
- 리포지터리 루트에 `.editorconfig`를 추가해 기본 에디터 규칙과 일부 `ktlint` 룰(예: 길이/와일드카드/주석/트레일링 콤마 관련)을 override/비활성화하도록 설정했습니다.
- GitHub Actions 워크플로 `.github/workflows/ci.yml`을 추가해 `gradle formatCheck`와 `gradle test`를 CI에서 실행하도록 구성했습니다.
- `README.md` 및 `README.ko.md`의 개발 섹션에 `./gradlew format` / `./gradlew formatCheck` 사용법을 문서화했습니다.

### Testing
- `gradle format` (자동화): 실패 — 저장소의 기존 ktlint 규칙 위반(예: `RealtimeEvents.kt` 파일명 규칙 등)으로 `spotlessKotlin` 단계에서 실패했습니다.
- `gradle formatCheck` (자동화): 실패 — 동일한 형식 규칙 위반으로 검사 단계에서 실패했습니다.
- `gradle test` (자동화): 실패 — 기존 단위 테스트 하나가 실패하여(`TemplateEngineTest > should interpolate environment variables()`), 전체 `test` 단계가 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e4d542483338dc67f281aedb714)