### PR TITLE
[docs] Add repository description, homepage, and topics via .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,4 @@
+repository:
+  description: "Kotlin CLI for orchestrating AI multi-agent workflows."
+  homepage: "https://github.com/heodongun/cotor/tree/main/docs"
+  topics: kotlin, cli, ai-agents, multi-agent, workflow-automation


### PR DESCRIPTION
### Motivation
- Provide repository metadata so the GitHub header shows a concise description, docs homepage, and topics to improve discoverability and repository presentation.

### Description
- Add `.github/settings.yml` that sets `repository.description` to "Kotlin CLI for orchestrating AI multi-agent workflows.", `repository.homepage` to `https://github.com/heodongun/cotor/tree/main/docs`, and `repository.topics` to `kotlin, cli, ai-agents, multi-agent, workflow-automation`.

### Testing
- Ran `cat .github/settings.yml`, `git status --short`, and `curl -Ls https://raw.githubusercontent.com/probot/settings/master/docs/plugins/repository.md | head -n 180`, and each command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e42c8e483338ba9e2176a74f3b0)