### PR TITLE
[build] Apply Gradle version catalog for dependency and plugin versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm") version "2.1.0"
-    kotlin("plugin.serialization") version "2.1.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
     application
-    id("com.gradleup.shadow") version "8.3.5"
+    alias(libs.plugins.shadow)
     jacoco
 }
 
@@ -16,39 +16,39 @@ repositories {
 dependencies {
     // Kotlin
     implementation(kotlin("stdlib"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation(libs.kotlinx.coroutines.core)
 
     // CLI
-    implementation("com.github.ajalt.clikt:clikt:4.2.1")
-    implementation("com.github.ajalt.mordant:mordant:2.2.0")  // Terminal UI
-    implementation("me.tongfei:progressbar:0.9.5")            // Progress bar
+    implementation(libs.clikt)
+    implementation(libs.mordant)  // Terminal UI
+    implementation(libs.progressbar)            // Progress bar
 
     // Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-    implementation("com.charleskorn.kaml:kaml:0.55.0")
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kaml)
 
     // Dependency Injection
-    implementation("io.insert-koin:koin-core:3.5.0")
+    implementation(libs.koin.core)
 
     // Logging
-    implementation("org.slf4j:slf4j-api:2.0.9")
-    implementation("ch.qos.logback:logback-classic:1.4.11")
-    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+    implementation(libs.slf4j.api)
+    implementation(libs.logback.classic)
+    implementation(libs.kotlin.logging.jvm)
 
     // Web Server (Ktor)
-    implementation("io.ktor:ktor-server-core:3.0.3")
-    implementation("io.ktor:ktor-server-netty:3.0.3")
-    implementation("io.ktor:ktor-server-content-negotiation:3.0.3")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.3")
-    implementation("io.ktor:ktor-server-cors:3.0.3")
-    implementation("io.ktor:ktor-server-sse:3.0.3")
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.server.cors)
+    implementation(libs.ktor.server.sse)
 
     // Testing
-    testImplementation("io.kotest:kotest-runner-junit5:5.8.0")
-    testImplementation("io.kotest:kotest-assertions-core:5.8.0")
-    testImplementation("io.kotest:kotest-property:5.8.0")
-    testImplementation("io.mockk:mockk:1.13.8")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,46 @@
+[versions]
+kotlin = "2.1.0"
+shadow = "8.3.5"
+foojayResolver = "0.8.0"
+coroutines = "1.7.3"
+clikt = "4.2.1"
+mordant = "2.2.0"
+progressbar = "0.9.5"
+serializationJson = "1.6.0"
+kaml = "0.55.0"
+koin = "3.5.0"
+slf4j = "2.0.9"
+logback = "1.4.11"
+kotlinLogging = "3.0.5"
+ktor = "3.0.3"
+kotest = "5.8.0"
+mockk = "1.13.8"
+
+[libraries]
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+mordant = { module = "com.github.ajalt.mordant:mordant", version.ref = "mordant" }
+progressbar = { module = "me.tongfei:progressbar", version.ref = "progressbar" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+kotlin-logging-jvm = { module = "io.github.microutils:kotlin-logging-jvm", version.ref = "kotlinLogging" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
+ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojayResolver" }


### PR DESCRIPTION
### Motivation
- Centralize plugin and dependency version management into a Gradle version catalog to remove hard-coded numeric versions from the build script.
- Make future upgrades and consistency checks easier by referencing versions from a single `libs.versions.toml` file.

### Description
- Add `gradle/libs.versions.toml` containing version entries, library coordinates under `[libraries]`, and plugin aliases under `[plugins]`.
- Migrate `build.gradle.kts` to use the version catalog by replacing inline plugin versions with `alias(libs.plugins...)` and dependencies with `libs.*` references.
- Only project build files were changed: `gradle/libs.versions.toml` (new) and `build.gradle.kts` (modified) to adopt the catalog.

### Testing
- Ran `./gradlew help`, which failed due to the Gradle wrapper JAR being absent (`org.gradle.wrapper.GradleWrapperMain`).
- Ran `gradle help`, which completed successfully.
- Ran `gradle test`, which executed the test suite (82 tests) and failed due to one existing failing test: `TemplateEngineTest > should interpolate environment variables()`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e3c231483338ec0a70e6b3b8412)