### PR TITLE
[test] Add golden snapshot tests for key CLI stdout commands

### DIFF
--- a/src/main/kotlin/com/cotor/presentation/cli/DoctorCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/DoctorCommand.kt
@@ -11,13 +11,15 @@ import kotlin.io.path.exists
 /**
  * Doctor command: checks environment readiness and gives quick tips
  */
-class DoctorCommand : CliktCommand(
+class DoctorCommand(
+    private val terminal: Terminal = Terminal(),
+    private val projectRootProvider: () -> Path = { Path(".").toAbsolutePath().normalize() },
+    private val javaVersionProvider: () -> String = { System.getProperty("java.version") ?: "unknown" },
+    private val commandAvailable: (String) -> Boolean = ::defaultCommandAvailable
+) : CliktCommand(
     name = "doctor",
     help = "Check environment, prerequisites, and examples"
 ) {
-    private val terminal = Terminal()
-    private val projectRoot = Path(".").toAbsolutePath().normalize()
-
     override fun run() {
         terminal.println(bold("🩺 Cotor Doctor"))
         terminal.println(dim("환경 점검을 수행합니다. OK 항목이 하나라도 실패해도 명령은 계속됩니다."))
@@ -49,7 +51,7 @@ class DoctorCommand : CliktCommand(
     }
 
     private fun checkJava(): Triple<String, Boolean, String?> {
-        val version = System.getProperty("java.version") ?: "unknown"
+        val version = javaVersionProvider()
         val major = version.substringBefore(".").toIntOrNull() ?: 0
         val ok = major >= 17
         val hint = if (!ok) "Java 17 이상이 필요합니다. 현재: $version" else "Java $version"
@@ -57,20 +59,21 @@ class DoctorCommand : CliktCommand(
     }
 
     private fun checkJar(): Triple<String, Boolean, String?> {
-        val jarPath = projectRoot.resolve("build/libs/cotor-1.0.0-all.jar")
+        val jarPath = projectRootProvider().resolve("build/libs/cotor-1.0.0-all.jar")
         val ok = jarPath.exists()
         val hint = if (ok) "빌드 결과 발견: ${jarPath.fileName}" else "shadowJar 실행 필요: ./gradlew shadowJar"
         return Triple("CLI JAR 존재 여부", ok, hint)
     }
 
     private fun checkConfig(): Triple<String, Boolean, String?> {
-        val path = projectRoot.resolve("cotor.yaml")
+        val path = projectRootProvider().resolve("cotor.yaml")
         val ok = path.exists()
         val hint = if (ok) "구성 파일 발견: cotor.yaml" else "구성이 없습니다. cotor init 또는 cotor init --interactive 실행"
         return Triple("cotor.yaml 확인", ok, hint)
     }
 
     private fun checkExamples(): Triple<String, Boolean, String?> {
+        val projectRoot = projectRootProvider()
         val required = listOf(
             "examples/single-agent.yaml",
             "examples/parallel-compare.yaml",
@@ -84,21 +87,23 @@ class DoctorCommand : CliktCommand(
     }
 
     private fun checkBinary(name: String): Triple<String, Boolean, String?> {
-        val ok = isCommandAvailable(name)
+        val ok = commandAvailable(name)
         val label = "$name 명령 확인"
         val hint = if (ok) "$name 사용 가능" else "$name 가 PATH에 없습니다 (필요시 설치)"
         return Triple(label, ok, hint)
     }
 
-    private fun isCommandAvailable(name: String): Boolean {
-        val cmd = if (isWindows()) listOf("where", name) else listOf("which", name)
-        return try {
-            ProcessBuilder(cmd).start().waitFor() == 0
-        } catch (_: Exception) {
-            false
+    companion object {
+        private fun defaultCommandAvailable(name: String): Boolean {
+            val cmd = if (isWindows()) listOf("where", name) else listOf("which", name)
+            return try {
+                ProcessBuilder(cmd).start().waitFor() == 0
+            } catch (_: Exception) {
+                false
+            }
         }
-    }
 
-    private fun isWindows(): Boolean =
-        System.getProperty("os.name").lowercase().contains("win")
+        private fun isWindows(): Boolean =
+            System.getProperty("os.name").lowercase().contains("win")
+    }
 }

--- a/src/main/kotlin/com/cotor/presentation/cli/TemplateCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/TemplateCommand.kt
@@ -15,7 +15,9 @@ import java.io.File
 /**
  * Command to generate pipeline templates
  */
-class TemplateCommand : CliktCommand(
+class TemplateCommand(
+    private val terminal: Terminal = Terminal()
+) : CliktCommand(
     name = "template",
     help = "Generate pipeline templates from pre-defined patterns"
 ) {
@@ -44,7 +46,6 @@ class TemplateCommand : CliktCommand(
 
     private val fills by option("--fill", "-F", help = "Replace placeholders: key=value").multiple()
 
-    private val terminal = Terminal()
 
     override fun run() {
         if (list && templateType == null && preview == null) {

--- a/src/test/kotlin/com/cotor/presentation/cli/CliGoldenSnapshotTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/CliGoldenSnapshotTest.kt
@@ -1,0 +1,169 @@
+package com.cotor.presentation.cli
+
+import com.cotor.data.config.ConfigRepository
+import com.cotor.data.registry.AgentRegistry
+import com.cotor.model.AgentConfig
+import com.cotor.model.CotorConfig
+import com.cotor.stats.PerformanceTrend
+import com.cotor.stats.StatsManager
+import com.cotor.stats.StatsSummary
+import com.github.ajalt.clikt.testing.test
+import com.github.ajalt.mordant.terminal.Terminal
+import com.github.ajalt.mordant.terminal.TerminalRecorder
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class CliGoldenSnapshotTest : FunSpec({
+    val updateGolden = System.getenv("UPDATE_GOLDEN") == "1"
+
+    lateinit var configRepository: ConfigRepository
+    lateinit var agentRegistry: AgentRegistry
+    lateinit var statsManager: StatsManager
+
+    beforeSpec {
+        configRepository = mockk()
+        agentRegistry = mockk()
+        statsManager = mockk()
+
+        startKoin {
+            modules(
+                module {
+                    single { configRepository }
+                    single { agentRegistry }
+                    single { statsManager }
+                }
+            )
+        }
+    }
+
+    afterSpec {
+        stopKoin()
+    }
+
+    test("golden snapshot: list") {
+        val cotorConfig = CotorConfig(
+            agents = listOf(
+                AgentConfig(
+                    name = "claude",
+                    pluginClass = "com.cotor.data.plugin.ClaudePlugin",
+                    timeout = 60000,
+                    tags = listOf("primary", "reasoning")
+                ),
+                AgentConfig(
+                    name = "gemini",
+                    pluginClass = "com.cotor.data.plugin.GeminiPlugin",
+                    timeout = 45000,
+                    tags = listOf("secondary")
+                )
+            )
+        )
+
+        coEvery { configRepository.loadConfig(any()) } returns cotorConfig
+        every { agentRegistry.registerAgent(any()) } just runs
+        every { agentRegistry.getAllAgents() } returns cotorConfig.agents
+
+        val result = ListCommand().test(emptyList())
+
+        assertSnapshot(
+            name = "list",
+            content = normalize(result.stdout),
+            updateGolden = updateGolden
+        )
+    }
+
+    test("golden snapshot: stats") {
+        every { statsManager.listAllStats() } returns listOf(
+            StatsSummary(
+                pipelineName = "compare-solutions",
+                totalExecutions = 12,
+                successRate = 91.7,
+                avgDuration = 2350,
+                avgRecentDuration = 2100,
+                lastExecuted = "2026-02-28T09:30:00Z",
+                trend = PerformanceTrend.IMPROVING
+            )
+        )
+
+        val result = StatsCommand().test(emptyList())
+
+        assertSnapshot(
+            name = "stats",
+            content = normalize(result.stdout),
+            updateGolden = updateGolden
+        )
+    }
+
+    test("golden snapshot: doctor") {
+        val projectRoot = Files.createTempDirectory("doctor-snapshot")
+        createDoctorFixture(projectRoot)
+
+        val recorder = TerminalRecorder()
+        val terminal = Terminal(recorder)
+
+        DoctorCommand(
+            terminal = terminal,
+            projectRootProvider = { projectRoot },
+            javaVersionProvider = { "21.0.2" },
+            commandAvailable = { it == "cotor" }
+        ).test(emptyList())
+
+        assertSnapshot(
+            name = "doctor",
+            content = normalize(recorder.output()),
+            updateGolden = updateGolden
+        )
+    }
+
+    test("golden snapshot: template --list") {
+        val recorder = TerminalRecorder()
+        val terminal = Terminal(recorder)
+
+        TemplateCommand(terminal = terminal).test("--list")
+
+        assertSnapshot(
+            name = "template-list",
+            content = normalize(recorder.output()),
+            updateGolden = updateGolden
+        )
+    }
+})
+
+private fun createDoctorFixture(projectRoot: Path) {
+    projectRoot.resolve("build/libs").createDirectories()
+    projectRoot.resolve("build/libs/cotor-1.0.0-all.jar").writeText("jar")
+    projectRoot.resolve("cotor.yaml").writeText("version: \"1.0\"")
+
+    projectRoot.resolve("examples").createDirectories()
+    projectRoot.resolve("examples/single-agent.yaml").writeText("single")
+    projectRoot.resolve("examples/parallel-compare.yaml").writeText("parallel")
+    projectRoot.resolve("examples/decision-loop.yaml").writeText("loop")
+    projectRoot.resolve("examples/run-examples.sh").writeText("#!/usr/bin/env bash")
+}
+
+private fun normalize(value: String): String = value
+    .replace("\r\n", "\n")
+    .trimEnd() + "\n"
+
+private fun assertSnapshot(name: String, content: String, updateGolden: Boolean) {
+    val snapshotPath = Paths.get("src/test/resources/snapshots/cli/$name.txt")
+
+    if (updateGolden || !Files.exists(snapshotPath)) {
+        snapshotPath.parent?.createDirectories()
+        snapshotPath.writeText(content)
+    }
+
+    Files.readString(snapshotPath) shouldBe content
+}

--- a/src/test/resources/snapshots/cli/doctor.txt
+++ b/src/test/resources/snapshots/cli/doctor.txt
@@ -1,0 +1,22 @@
+[1m🩺 Cotor Doctor[22m
+[2m환경 점검을 수행합니다. OK 항목이 하나라도 실패해도 명령은 계속됩니다.[22m
+
+[32m✓[39m Java 버전 확인
+[2m   Java 21.0.2[22m
+[32m✓[39m CLI JAR 존재 여부
+[2m   빌드 결과 발견: cotor-1.0.0-all.jar[22m
+[32m✓[39m cotor.yaml 확인
+[2m   구성 파일 발견: cotor.yaml[22m
+[32m✓[39m 예제 번들 확인
+[2m   예제 준비 완료[22m
+[33m⚠[39m claude 명령 확인
+[2m   claude 가 PATH에 없습니다 (필요시 설치)[22m
+[33m⚠[39m gemini 명령 확인
+[2m   gemini 가 PATH에 없습니다 (필요시 설치)[22m
+[32m✓[39m cotor 명령 확인
+[2m   cotor 사용 가능[22m
+
+[2m팁:[22m
+[2m  - 자동완성: cotor completion zsh|bash|fish > /tmp/cotor && source /tmp/cotor[22m
+[2m  - 샘플 실행: examples/run-examples.sh[22m
+[2m  - Claude 연동: ./shell/install-claude-integration.sh[22m

--- a/src/test/resources/snapshots/cli/list.txt
+++ b/src/test/resources/snapshots/cli/list.txt
@@ -1,0 +1,7 @@
+Registered Agents (2):
+  - claude (com.cotor.data.plugin.ClaudePlugin)
+    Timeout: 60000ms
+    Tags: primary, reasoning
+  - gemini (com.cotor.data.plugin.GeminiPlugin)
+    Timeout: 45000ms
+    Tags: secondary

--- a/src/test/resources/snapshots/cli/stats.txt
+++ b/src/test/resources/snapshots/cli/stats.txt
@@ -1,0 +1,9 @@
+📊 Pipeline Statistics Overview
+────────────────────────────────────────────────────────────────────────────────
+
+Pipeline                       Executions    Success     Avg Time    Trend
+────────────────────────────────────────────────────────────────────────────────
+compare-solutions                      12      91.7%           2s ↗
+────────────────────────────────────────────────────────────────────────────────
+
+Usage: cotor stats <pipeline-name> for detailed statistics

--- a/src/test/resources/snapshots/cli/template-list.txt
+++ b/src/test/resources/snapshots/cli/template-list.txt
@@ -1,0 +1,15 @@
+[34;1m📋 Available Pipeline Templates[39;22m
+
+  compare      - Multiple AIs solve the same problem in parallel for comparison
+  chain        - Sequential processing chain (generate → review → optimize)
+  review       - Parallel multi-perspective code review (security, performance, best practices)
+  consensus    - Multiple AIs provide opinions to reach consensus
+  fanout       - DAG fan-out/fan-in merge pattern
+  selfheal     - Loop-based self-healing/retry pattern
+  verified     - Generate → test/verify → fix loop (uses CommandPlugin to run a command)
+  custom       - Customizable template with common patterns
+
+[2mUsage: cotor template <type> [output-file] [--preview] [--fill key=value][22m
+[2mExample: cotor template compare my-pipeline.yaml --fill prompt="Write tests"[22m
+[2mPreview: cotor template --preview chain[22m
+[2mList:    cotor template --list[22m


### PR DESCRIPTION
### Motivation
- Ensure major CLI outputs (list, stats, doctor, template --list) are stable and that unexpected ANSI/format changes are visible in PRs via golden snapshot diffs.
- Make `DoctorCommand` and `TemplateCommand` deterministic/testable by allowing injection of terminal, project root, Java version and command-availability checks.

### Description
- Add `CliGoldenSnapshotTest` under `src/test/kotlin/com/cotor/presentation/cli/` which captures and asserts stdout snapshots for `list`, `stats`, `doctor`, and `template --list` using `TerminalRecorder`.
- Add snapshot helpers `normalize` and `assertSnapshot` that write/update goldens when `UPDATE_GOLDEN=1` and compare content against files under `src/test/resources/snapshots/cli/`.
- Make `DoctorCommand` constructor accept injectable `terminal`, `projectRootProvider`, `javaVersionProvider`, and `commandAvailable` while preserving default runtime behavior.
- Make `TemplateCommand` accept an injectable `terminal` so ANSI/styled output can be deterministically captured in tests, and add the four snapshot files (`doctor.txt`, `list.txt`, `stats.txt`, `template-list.txt`).

### Testing
- Ran `UPDATE_GOLDEN=1 gradle test --tests com.cotor.presentation.cli.CliGoldenSnapshotTest` to generate/refresh snapshot artifacts and it completed successfully.
- Ran `gradle test --tests com.cotor.presentation.cli.CliGoldenSnapshotTest` to verify tests against the stored goldens and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e37b1ec83338767b3c5fe9ff51f)