### PR TITLE
fix(config): honor explicit empty collection overrides in merge

### DIFF
--- a/src/main/kotlin/com/cotor/data/config/ConfigRepository.kt
+++ b/src/main/kotlin/com/cotor/data/config/ConfigRepository.kt
@@ -4,6 +4,8 @@ import com.cotor.model.ConfigurationException
 import com.cotor.model.CotorConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
@@ -25,12 +27,17 @@ class FileConfigRepository(
     private val jsonParser: JsonParser
 ) : ConfigRepository {
 
+    private data class ParsedConfig(
+        val config: CotorConfig,
+        val explicitCollections: Set<String>,
+    )
+
     override suspend fun loadConfig(path: Path): CotorConfig = withContext(Dispatchers.IO) {
         val baseConfig = parseConfig(path)
         val cotorDir = path.parent?.resolve(".cotor")
 
         if (cotorDir == null || !cotorDir.isDirectory()) {
-            return@withContext baseConfig
+            return@withContext baseConfig.config
         }
 
         val overrideFiles = Files.walk(cotorDir)
@@ -38,66 +45,75 @@ class FileConfigRepository(
             .sorted()
             .toList()
 
-        overrideFiles.fold(baseConfig) { acc, overrideFile ->
+        overrideFiles.fold(baseConfig.config) { acc, overrideFile ->
             val overrideConfig = parseConfig(overrideFile)
             mergeConfigs(acc, overrideConfig)
         }
     }
 
-    private fun parseConfig(path: Path): CotorConfig {
+    private fun parseConfig(path: Path): ParsedConfig {
         if (!path.exists()) {
             throw ConfigurationException("Configuration file not found: $path")
         }
         val content = path.readText()
         return when (path.extension.lowercase()) {
-            "yaml", "yml" -> yamlParser.parse(content, path.toString())
-            "json" -> jsonParser.parse(content)
+            "yaml", "yml" -> ParsedConfig(
+                config = yamlParser.parse(content, path.toString()),
+                explicitCollections = detectExplicitCollectionsFromYaml(content),
+            )
+            "json" -> ParsedConfig(
+                config = jsonParser.parse(content),
+                explicitCollections = detectExplicitCollectionsFromJson(content),
+            )
             else -> throw ConfigurationException("Unsupported config format: ${path.extension}")
         }
     }
 
-    private fun mergeConfigs(base: CotorConfig, override: CotorConfig): CotorConfig {
-        val mergedAgents = (base.agents + override.agents)
+    private fun mergeConfigs(base: CotorConfig, override: ParsedConfig): CotorConfig {
+        val overrideConfig = override.config
+        val mergedAgents = (base.agents + overrideConfig.agents)
             .groupBy { it.name }
             .map { (_, agents) -> agents.last() }
 
-        val mergedPipelines = (base.pipelines + override.pipelines)
+        val mergedPipelines = (base.pipelines + overrideConfig.pipelines)
             .groupBy { it.name }
             .map { (_, pipelines) -> pipelines.last() }
 
         val defaultConfig = CotorConfig()
 
         return base.copy(
-            version = if (override.version != defaultConfig.version) override.version else base.version,
+            version = if (overrideConfig.version != defaultConfig.version) overrideConfig.version else base.version,
             agents = mergedAgents,
             pipelines = mergedPipelines,
             security = base.security.copy(
-                useWhitelist = if (override.security.useWhitelist != defaultConfig.security.useWhitelist) override.security.useWhitelist else base.security.useWhitelist,
+                useWhitelist = if (overrideConfig.security.useWhitelist != defaultConfig.security.useWhitelist) overrideConfig.security.useWhitelist else base.security.useWhitelist,
                 // For collection types: treat empty override as explicit empty when base has items
                 allowedExecutables = mergeCollection(
                     base.security.allowedExecutables,
-                    override.security.allowedExecutables,
-                    defaultConfig.security.allowedExecutables
+                    overrideConfig.security.allowedExecutables,
+                    defaultConfig.security.allowedExecutables,
+                    "security.allowedExecutables" in override.explicitCollections,
                 ),
                 allowedDirectories = mergeCollection(
                     base.security.allowedDirectories,
-                    override.security.allowedDirectories,
-                    defaultConfig.security.allowedDirectories
+                    overrideConfig.security.allowedDirectories,
+                    defaultConfig.security.allowedDirectories,
+                    "security.allowedDirectories" in override.explicitCollections,
                 ),
-                maxCommandLength = if (override.security.maxCommandLength != defaultConfig.security.maxCommandLength) override.security.maxCommandLength else base.security.maxCommandLength,
-                enablePathValidation = if (override.security.enablePathValidation != defaultConfig.security.enablePathValidation) override.security.enablePathValidation else base.security.enablePathValidation
+                maxCommandLength = if (overrideConfig.security.maxCommandLength != defaultConfig.security.maxCommandLength) overrideConfig.security.maxCommandLength else base.security.maxCommandLength,
+                enablePathValidation = if (overrideConfig.security.enablePathValidation != defaultConfig.security.enablePathValidation) overrideConfig.security.enablePathValidation else base.security.enablePathValidation
             ),
             logging = base.logging.copy(
-                level = if (override.logging.level != defaultConfig.logging.level) override.logging.level else base.logging.level,
-                file = if (override.logging.file != defaultConfig.logging.file) override.logging.file else base.logging.file,
-                maxFileSize = if (override.logging.maxFileSize != defaultConfig.logging.maxFileSize) override.logging.maxFileSize else base.logging.maxFileSize,
-                maxHistory = if (override.logging.maxHistory != defaultConfig.logging.maxHistory) override.logging.maxHistory else base.logging.maxHistory,
-                format = if (override.logging.format != defaultConfig.logging.format) override.logging.format else base.logging.format
+                level = if (overrideConfig.logging.level != defaultConfig.logging.level) overrideConfig.logging.level else base.logging.level,
+                file = if (overrideConfig.logging.file != defaultConfig.logging.file) overrideConfig.logging.file else base.logging.file,
+                maxFileSize = if (overrideConfig.logging.maxFileSize != defaultConfig.logging.maxFileSize) overrideConfig.logging.maxFileSize else base.logging.maxFileSize,
+                maxHistory = if (overrideConfig.logging.maxHistory != defaultConfig.logging.maxHistory) overrideConfig.logging.maxHistory else base.logging.maxHistory,
+                format = if (overrideConfig.logging.format != defaultConfig.logging.format) overrideConfig.logging.format else base.logging.format
             ),
             performance = base.performance.copy(
-                maxConcurrentAgents = if (override.performance.maxConcurrentAgents != defaultConfig.performance.maxConcurrentAgents) override.performance.maxConcurrentAgents else base.performance.maxConcurrentAgents,
-                coroutinePoolSize = if (override.performance.coroutinePoolSize != defaultConfig.performance.coroutinePoolSize) override.performance.coroutinePoolSize else base.performance.coroutinePoolSize,
-                memoryThresholdMB = if (override.performance.memoryThresholdMB != defaultConfig.performance.memoryThresholdMB) override.performance.memoryThresholdMB else base.performance.memoryThresholdMB
+                maxConcurrentAgents = if (overrideConfig.performance.maxConcurrentAgents != defaultConfig.performance.maxConcurrentAgents) overrideConfig.performance.maxConcurrentAgents else base.performance.maxConcurrentAgents,
+                coroutinePoolSize = if (overrideConfig.performance.coroutinePoolSize != defaultConfig.performance.coroutinePoolSize) overrideConfig.performance.coroutinePoolSize else base.performance.coroutinePoolSize,
+                memoryThresholdMB = if (overrideConfig.performance.memoryThresholdMB != defaultConfig.performance.memoryThresholdMB) overrideConfig.performance.memoryThresholdMB else base.performance.memoryThresholdMB
             )
         )
     }
@@ -108,12 +124,66 @@ class FileConfigRepository(
      * If override has items, use override.
      * If both are empty (default), use base (which is also empty).
      */
-    private fun <T, C : Collection<T>> mergeCollection(base: C, override: C, default: C): C {
+    private fun <T, C : Collection<T>> mergeCollection(base: C, override: C, default: C, explicitOverride: Boolean): C {
         return when {
-            override.isNotEmpty() -> override  // Override has items, use it
-            override.isEmpty() && base.isNotEmpty() -> override  // Explicit empty override
-            else -> base  // Both empty or override matches default
+            explicitOverride -> override
+            override != default -> override
+            else -> base
         }
+    }
+
+    private fun detectExplicitCollectionsFromYaml(content: String): Set<String> = buildSet {
+        if (hasYamlNestedKey(content, "security", "allowedExecutables")) {
+            add("security.allowedExecutables")
+        }
+        if (hasYamlNestedKey(content, "security", "allowedDirectories")) {
+            add("security.allowedDirectories")
+        }
+    }
+
+    private fun detectExplicitCollectionsFromJson(content: String): Set<String> {
+        return runCatching {
+            val root = Json.parseToJsonElement(content).jsonObject
+            val security = root["security"]?.jsonObject ?: return emptySet()
+
+            buildSet {
+                if ("allowedExecutables" in security) add("security.allowedExecutables")
+                if ("allowedDirectories" in security) add("security.allowedDirectories")
+            }
+        }.getOrElse { emptySet() }
+    }
+
+    private fun hasYamlNestedKey(content: String, parentKey: String, childKey: String): Boolean {
+        var parentIndent: Int? = null
+
+        for (line in content.lines()) {
+            val withoutComments = line.substringBefore('#').trimEnd()
+            if (withoutComments.isBlank()) continue
+
+            val indent = line.takeWhile { it == ' ' || it == '\t' }.length
+            val trimmed = withoutComments.trimStart()
+
+            if (parentIndent == null) {
+                if (trimmed.matches(Regex("^${Regex.escape(parentKey)}\\s*:\\s*$"))) {
+                    parentIndent = indent
+                }
+                continue
+            }
+
+            if (indent <= parentIndent) {
+                parentIndent = null
+                if (trimmed.matches(Regex("^${Regex.escape(parentKey)}\\s*:\\s*$"))) {
+                    parentIndent = indent
+                }
+                continue
+            }
+
+            if (trimmed.matches(Regex("^${Regex.escape(childKey)}\\s*:.*$"))) {
+                return true
+            }
+        }
+
+        return false
     }
 
     override suspend fun saveConfig(config: CotorConfig, path: Path) = withContext(Dispatchers.IO) {

--- a/src/test/kotlin/com/cotor/data/config/FileConfigRepositoryTest.kt
+++ b/src/test/kotlin/com/cotor/data/config/FileConfigRepositoryTest.kt
@@ -121,6 +121,32 @@ class FileConfigRepositoryTest : FunSpec({
         loadedConfig.security.allowedExecutables.size shouldBe 0
     }
 
+
+    test("keeps base list when override omits collection field") {
+        val repo = FileConfigRepository(yamlParser, jsonParser)
+        val baseDir = Files.createTempDirectory("config-omit-list")
+        val cotorDir = baseDir.resolve(".cotor").createDirectory()
+
+        val mainConfigPath = baseDir.resolve("cotor.yaml")
+        mainConfigPath.writeText("""
+            security:
+              allowedExecutables:
+                - "bash"
+                - "python"
+        """.trimIndent())
+
+        val overrideConfigPath = cotorDir.resolve("dev.yaml")
+        overrideConfigPath.writeText("""
+            logging:
+              level: "DEBUG"
+        """.trimIndent())
+
+        val loadedConfig = runBlocking { repo.loadConfig(mainConfigPath) }
+
+        loadedConfig.security.allowedExecutables shouldBe listOf("bash", "python")
+        loadedConfig.logging.level shouldBe "DEBUG"
+    }
+
     test("can override List<Path> with empty list") {
         val repo = FileConfigRepository(yamlParser, jsonParser)
         val baseDir = Files.createTempDirectory("config-empty-path-list")


### PR DESCRIPTION
### Motivation
- The merge logic treated override collection fields equal to defaults as "not provided", causing intentional empty list overrides (e.g. `security.allowedExecutables: []`) to be ignored and leaving base values in place.
- The change distinguishes an omitted field from an explicitly provided empty collection so intentional overrides are applied correctly.

### Description
- Introduced `ParsedConfig` to carry the parsed `CotorConfig` plus a set of `explicitCollections` detected from the source file.
- Updated `parseConfig` to return `ParsedConfig` and added `detectExplicitCollectionsFromYaml`, `detectExplicitCollectionsFromJson` and `hasYamlNestedKey` helpers to detect whether collection keys like `security.allowedExecutables` and `security.allowedDirectories` were explicitly present.
- Changed `mergeConfigs` and `mergeCollection` to accept an `explicitOverride` flag so empty collections in override files are honored when the key was explicitly defined.
- Added a regression test `keeps base list when override omits collection field` to ensure base lists are preserved when override files omit the collection key.

### Testing
- Ran `gradle test --tests com.cotor.data.config.FileConfigRepositoryTest` and the test suite completed successfully (`BUILD SUCCESSFUL`).
- An earlier attempt with `./gradlew test --tests com.cotor.data.config.FileConfigRepositoryTest` failed due to missing Gradle wrapper class (`org.gradle.wrapper.GradleWrapperMain`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e22aa708333ba68c1bdc0c2ac70)