### PR TITLE
test: 체크포인트 + resume 통합 테스트 추가

### DIFF
--- a/src/test/kotlin/com/cotor/integration/CheckpointFixtureProcess.kt
+++ b/src/test/kotlin/com/cotor/integration/CheckpointFixtureProcess.kt
@@ -1,0 +1,46 @@
+package com.cotor.integration
+
+import com.cotor.checkpoint.CheckpointManager
+import com.cotor.checkpoint.StageCheckpoint
+import java.time.Instant
+
+/**
+ * Separate JVM process used by integration tests to create a checkpoint file
+ * and keep running until forcibly terminated.
+ */
+object CheckpointFixtureProcess {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        require(args.size >= 2) { "Usage: CheckpointFixtureProcess <checkpointDir> <pipelineId>" }
+
+        val checkpointDir = args[0]
+        val pipelineId = args[1]
+        val checkpointManager = CheckpointManager(checkpointDir)
+
+        checkpointManager.saveCheckpoint(
+            pipelineId = pipelineId,
+            pipelineName = "checkpoint-resume-integration",
+            completedStages = listOf(
+                StageCheckpoint(
+                    stageId = "stage-1",
+                    agentName = "echo-agent",
+                    output = "stage-1-output",
+                    isSuccess = true,
+                    duration = 10,
+                    timestamp = Instant.now().toString()
+                )
+            ),
+            cotorVersion = "test-version",
+            gitCommit = "test-commit",
+            os = System.getProperty("os.name"),
+            jvm = System.getProperty("java.version")
+        )
+
+        println("CHECKPOINT_READY")
+        System.out.flush()
+
+        while (true) {
+            Thread.sleep(1_000)
+        }
+    }
+}

--- a/src/test/kotlin/com/cotor/integration/CheckpointResumeIntegrationTest.kt
+++ b/src/test/kotlin/com/cotor/integration/CheckpointResumeIntegrationTest.kt
@@ -1,0 +1,180 @@
+package com.cotor.integration
+
+import com.cotor.checkpoint.CheckpointManager
+import com.cotor.domain.aggregator.ResultAggregator
+import com.cotor.domain.executor.AgentExecutor
+import com.cotor.domain.orchestrator.DefaultPipelineOrchestrator
+import com.cotor.event.EventBus
+import com.cotor.model.AgentConfig
+import com.cotor.model.AgentReference
+import com.cotor.model.AgentResult
+import com.cotor.model.AggregatedResult
+import com.cotor.model.ExecutionMode
+import com.cotor.model.Pipeline
+import com.cotor.model.PipelineContext
+import com.cotor.model.PipelineStage
+import com.cotor.model.ValidationResult
+import com.cotor.stats.StatsManager
+import com.cotor.validation.PipelineTemplateValidator
+import com.cotor.validation.output.OutputValidator
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.nio.file.Files
+import java.time.Instant
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+
+class CheckpointResumeIntegrationTest : StringSpec({
+
+    "should resume from checkpoint after forced process termination" {
+        val checkpointDir = Files.createTempDirectory("checkpoint-resume-it").toFile()
+        val pipelineId = "resume-it-${UUID.randomUUID()}"
+        val checkpointManager = CheckpointManager(checkpointDir.absolutePath)
+
+        val javaBin = "${System.getProperty("java.home")}/bin/java"
+        val classPath = System.getProperty("java.class.path")
+        val process = ProcessBuilder(
+            javaBin,
+            "-cp",
+            classPath,
+            "com.cotor.integration.CheckpointFixtureProcess",
+            checkpointDir.absolutePath,
+            pipelineId
+        )
+            .redirectErrorStream(true)
+            .start()
+
+        try {
+            waitForCheckpoint(checkpointManager, pipelineId)
+            process.destroyForcibly()
+            process.waitFor()
+
+            val checkpoint = checkpointManager.loadCheckpoint(pipelineId)
+            checkpoint shouldNotBe null
+            checkpoint!!.completedStages shouldHaveSize 1
+            checkpoint.completedStages.first().stageId shouldBe "stage-1"
+
+            val restoredContext = PipelineContext(
+                pipelineId = pipelineId,
+                pipelineName = checkpoint.pipelineName,
+                totalStages = 2
+            )
+            checkpoint.completedStages.forEach { stage ->
+                restoredContext.addStageResult(
+                    stage.stageId,
+                    AgentResult(
+                        agentName = stage.agentName,
+                        isSuccess = stage.isSuccess,
+                        output = stage.output,
+                        error = null,
+                        duration = stage.duration,
+                        metadata = emptyMap()
+                    )
+                )
+            }
+
+            val pipeline = Pipeline(
+                name = checkpoint.pipelineName,
+                executionMode = ExecutionMode.SEQUENTIAL,
+                stages = listOf(
+                    PipelineStage(id = "stage-1", agent = AgentReference("echo-agent"), input = "seed"),
+                    PipelineStage(id = "stage-2", agent = AgentReference("echo-agent"))
+                )
+            )
+
+            val agentExecutor = mockk<AgentExecutor>()
+            val resultAggregator = mockk<ResultAggregator>()
+            val eventBus = mockk<EventBus>(relaxed = true)
+            val logger = mockk<Logger>(relaxed = true)
+            val agentRegistry = mockk<com.cotor.data.registry.AgentRegistry>()
+            val outputValidator = mockk<OutputValidator>(relaxed = true)
+            val statsManager = mockk<StatsManager>(relaxed = true)
+            val templateValidator = mockk<PipelineTemplateValidator>()
+
+            coEvery { templateValidator.validate(any()) } returns ValidationResult.Success
+            coEvery { agentRegistry.getAgent("echo-agent") } returns AgentConfig("echo-agent", "test.EchoAgent")
+            coEvery { agentExecutor.executeAgent(any(), any(), any()) } answers {
+                AgentResult(
+                    agentName = "echo-agent",
+                    isSuccess = true,
+                    output = secondArg<String?>(),
+                    error = null,
+                    duration = 5,
+                    metadata = emptyMap()
+                )
+            }
+            coEvery { resultAggregator.aggregate(any()) } answers {
+                val results = firstArg<List<AgentResult>>()
+                AggregatedResult(
+                    totalAgents = results.size,
+                    successCount = results.count { it.isSuccess },
+                    failureCount = results.count { !it.isSuccess },
+                    totalDuration = results.sumOf { it.duration },
+                    results = results,
+                    aggregatedOutput = results.last().output ?: "",
+                    timestamp = Instant.now()
+                )
+            }
+
+            val orchestrator = DefaultPipelineOrchestrator(
+                agentExecutor,
+                resultAggregator,
+                eventBus,
+                logger,
+                agentRegistry,
+                outputValidator,
+                statsManager,
+                checkpointManager,
+                templateValidator
+            )
+
+            val resumedResult = runBlocking {
+                orchestrator.executePipeline(
+                    pipeline = pipeline,
+                    fromStageId = "stage-2",
+                    context = restoredContext
+                )
+            }
+
+            resumedResult.totalAgents shouldBe 2
+            resumedResult.successCount shouldBe 2
+            resumedResult.aggregatedOutput shouldBe "stage-1-output"
+
+            coVerify(exactly = 1) {
+                agentExecutor.executeAgent(
+                    any(),
+                    "stage-1-output",
+                    any()
+                )
+            }
+
+            val updatedCheckpoint = checkpointManager.loadCheckpoint(pipelineId)
+            updatedCheckpoint shouldNotBe null
+            updatedCheckpoint!!.completedStages shouldHaveSize 2
+            updatedCheckpoint.completedStages.map { it.stageId } shouldBe listOf("stage-1", "stage-2")
+        } finally {
+            if (process.isAlive) {
+                process.destroyForcibly()
+                process.waitFor()
+            }
+            checkpointDir.deleteRecursively()
+        }
+    }
+})
+
+private fun waitForCheckpoint(checkpointManager: CheckpointManager, pipelineId: String) {
+    val deadline = System.currentTimeMillis() + 10_000
+    while (System.currentTimeMillis() < deadline) {
+        if (checkpointManager.loadCheckpoint(pipelineId) != null) {
+            return
+        }
+        Thread.sleep(100)
+    }
+    error("Timed out waiting for checkpoint file to be created")
+}


### PR DESCRIPTION
### Motivation

- CI에서 체크포인트 기반 `resume` 기능이 실제 파일 생성/프로세스 중단 시나리오에서도 잘 동작하는지 검증하기 위해 통합 테스트를 추가했습니다.
- 실제로 체크포인트 파일을 만든 뒤 프로세스를 강제 종료하고 복구 시나리오를 재현할 수 있는 별도 JVM 엔트리포인트가 필요했습니다.

### Description

- 테스트 전용 JVM 엔트리포인트 `CheckpointFixtureProcess`를 추가해 지정한 체크포인트 디렉터리에 `stage-1` 체크포인트를 기록하고 대기하도록 구현했습니다 (`src/test/kotlin/com/cotor/integration/CheckpointFixtureProcess.kt`).
- `CheckpointResumeIntegrationTest`를 추가해 (1) 별도 프로세스에서 체크포인트 생성, (2) 프로세스 강제 종료, (3) 체크포인트 로드 및 `PipelineContext` 복원, (4) `fromStageId = "stage-2"`로 재실행 및 정상 완료, (5) 업데이트된 체크포인트에 `stage-2`가 추가되는 것을 검증하도록 구현했습니다 (`src/test/kotlin/com/cotor/integration/CheckpointResumeIntegrationTest.kt`).
- 테스트 코드에서 컴파일 문제를 회피하기 위해 일부 검증을 `shouldNotBe null`으로 변경하고, Mock 검증은 타입/매처 제약으로 인해 호출 존재만 확인하도록 간소화했습니다.

### Testing

- 초기 `gradle test --tests com.cotor.integration.CheckpointResumeIntegrationTest` 실행은 테스트 코드 수정 전 컴파일 오류(`withArg`/mock 매처 관련)로 실패했습니다.
- 수정 후 `gradle test --tests com.cotor.integration.CheckpointResumeIntegrationTest`를 실행해 모든 테스트가 빌드 및 통과되어 `BUILD SUCCESSFUL`을 확인했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67e180f848333b1ac2298c2425753)