### PR TITLE
[ci] GitHub Actions 빌드/테스트/커버리지 배지 파이프라인

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-test-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build, test, and generate coverage
+        run: ./gradlew --no-daemon clean test jacocoTestReport
+
+      - name: Upload test and coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-and-coverage-reports
+          path: |
+            build/reports/tests/test
+            build/reports/jacoco/test/html
+            build/reports/jacoco/test/jacocoTestReport.xml
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,8 @@
 # Cotor - AI CLI 마스터-에이전트 시스템
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/yourusername/cotor)
+[![CI](https://github.com/heodongun/cotor/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/heodongun/cotor/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/heodongun/cotor/branch/master/graph/badge.svg)](https://codecov.io/gh/heodongun/cotor)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/heodongun/cotor)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.1.0-purple)](https://kotlinlang.org/)
 [![JVM](https://img.shields.io/badge/jvm-23-orange)](https://openjdk.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cotor - AI CLI Master-Agent System
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/yourusername/cotor)
+[![CI](https://github.com/heodongun/cotor/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/heodongun/cotor/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/heodongun/cotor/branch/master/graph/badge.svg)](https://codecov.io/gh/heodongun/cotor)
+[![Version](https://img.shields.io/badge/version-1.0.0-blue)](https://github.com/heodongun/cotor)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.1.0-purple)](https://kotlinlang.org/)
 [![JVM](https://img.shields.io/badge/jvm-23-orange)](https://openjdk.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)


### PR DESCRIPTION
## Summary\n- add GitHub Actions CI workflow for build/test/jacoco coverage on push/PR to master\n- upload test and JaCoCo reports as artifacts\n- upload JaCoCo XML to Codecov for coverage tracking badge\n- add CI and Coverage badges to README (EN/KO)\n\nFixes #43