### PR TITLE
Add `agent` CLI with `add`/`list` subcommands and tests

### DIFF
--- a/src/main/kotlin/com/cotor/Main.kt
+++ b/src/main/kotlin/com/cotor/Main.kt
@@ -30,7 +30,7 @@ fun main(args: Array<String>) {
         // Simple mode - just run pipeline directly
         if (!args[0].startsWith("-")) {
             when (args[0]) {
-                "init", "list", "status", "version", "run", "validate", "test", "dash", "interactive", "template", "resume", "checkpoint", "stats", "completion", "doctor", "web", "lint", "explain", "plugin" -> {
+                "init", "list", "status", "version", "run", "validate", "test", "dash", "interactive", "template", "resume", "checkpoint", "stats", "completion", "doctor", "web", "lint", "explain", "plugin", "agent" -> {
                     // Use full CLI for these commands
                 }
                 else -> {
@@ -61,6 +61,7 @@ fun main(args: Array<String>) {
                 LintCommand(),
                 ExplainCommand(),
                 PluginCommand(),
+                AgentCommand(),
                 VersionCommand(),
                 CompletionCommand()
             )

--- a/src/main/kotlin/com/cotor/presentation/cli/AgentCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/AgentCommand.kt
@@ -1,0 +1,204 @@
+package com.cotor.presentation.cli
+
+import com.cotor.data.config.FileConfigRepository
+import com.cotor.data.config.JsonParser
+import com.cotor.data.config.YamlParser
+import com.cotor.model.AgentConfig
+import com.cotor.model.CotorConfig
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.long
+import com.github.ajalt.clikt.parameters.types.path
+import com.github.ajalt.mordant.rendering.TextColors.green
+import com.github.ajalt.mordant.rendering.TextColors.yellow
+import com.github.ajalt.mordant.rendering.TextStyles.bold
+import com.github.ajalt.mordant.terminal.Terminal
+import kotlinx.coroutines.runBlocking
+import kotlin.io.path.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.io.path.writeText
+
+class AgentCommand : CliktCommand(
+    name = "agent",
+    help = "Manage agent presets and definitions"
+) {
+    init {
+        subcommands(AgentAddCommand(), AgentListCommand())
+    }
+
+    override fun run() = Unit
+}
+
+private data class AgentPreset(
+    val name: String,
+    val pluginClass: String,
+    val executable: String,
+    val defaultTimeout: Long,
+    val defaultModel: String,
+)
+
+private val builtinPresets = listOf(
+    AgentPreset("gemini", "com.cotor.data.plugin.GeminiPlugin", "gemini", 60000, "gemini-3.0-flash"),
+    AgentPreset("claude", "com.cotor.data.plugin.ClaudePlugin", "claude", 60000, "claude-3-7-sonnet-latest"),
+    AgentPreset("codex", "com.cotor.data.plugin.CodexPlugin", "codex", 60000, "gpt-5.3-codex-spark"),
+    AgentPreset("copilot", "com.cotor.data.plugin.CopilotPlugin", "copilot", 60000, "copilot"),
+    AgentPreset("opencode", "com.cotor.data.plugin.OpenCodePlugin", "opencode", 60000, "opencode-default"),
+    AgentPreset("qwen", "com.cotor.data.plugin.CommandPlugin", "qwen", 60000, "qwen3-coder")
+)
+
+class AgentAddCommand : CliktCommand(
+    name = "add",
+    help = "Add an agent from preset into .cotor/agents"
+) {
+    private val configRepository = FileConfigRepository(YamlParser(), JsonParser())
+    private val terminal = Terminal()
+
+    private val presetName by argument("preset")
+    private val configPath by option("--config", "-c", help = "Path to base configuration file")
+        .path(mustExist = false)
+        .default(Path("cotor.yaml"))
+    private val agentName by option("--name", help = "Override agent name")
+    private val model by option("--model", help = "Override default model parameter")
+    private val timeout by option("--timeout", help = "Override timeout (ms)").long()
+    private val force by option("--force", help = "Overwrite existing .cotor/agents/<name>.yaml file").flag(default = false)
+    private val dryRun by option("--dry-run", help = "Print planned YAML without writing").flag(default = false)
+    private val yes by option("--yes", help = "Skip confirmation prompt").flag(default = false)
+
+    override fun run() {
+        val preset = builtinPresets.firstOrNull { it.name == presetName.lowercase() }
+            ?: throw UsageError("Unknown preset '$presetName'. Available presets: ${builtinPresets.joinToString { it.name }}")
+
+        val resolvedName = (agentName ?: preset.name).trim()
+        require(resolvedName.isNotBlank()) { "Agent name must not be blank" }
+
+        val existingConfig = loadCurrentConfig(configPath)
+        if (existingConfig.agents.any { it.name == resolvedName } && !force) {
+            throw UsageError("Agent '$resolvedName' already exists. Use --force to overwrite.")
+        }
+
+        val resolvedModel = (model ?: preset.defaultModel).trim()
+        val resolvedTimeout = timeout ?: preset.defaultTimeout
+
+        val yaml = renderAgentYaml(
+            AgentConfig(
+                name = resolvedName,
+                pluginClass = preset.pluginClass,
+                timeout = resolvedTimeout,
+                parameters = presetParameters(preset.name, resolvedModel)
+            )
+        )
+
+        val projectDir = configPath.parent ?: Path(".")
+        val outPath = projectDir.resolve(Path(".cotor", "agents", "$resolvedName.yaml"))
+
+        terminal.println(bold("Planned agent definition"))
+        terminal.println(yaml)
+
+        if (dryRun) {
+            terminal.println(yellow("--dry-run enabled: no files were changed."))
+            return
+        }
+
+        if (!yes && !confirm("Write $outPath ?")) {
+            terminal.println(yellow("Cancelled."))
+            return
+        }
+
+        outPath.parent.createDirectories()
+        writeAtomically(outPath, yaml)
+
+        terminal.println(green("✅ Added agent '$resolvedName' at $outPath"))
+        terminal.println("Next step: cotor agent list -c $configPath")
+        terminal.println("Tip: ensure '${preset.executable}' is installed, then run 'cotor doctor'.")
+    }
+
+    private fun loadCurrentConfig(path: java.nio.file.Path): CotorConfig = runBlocking {
+        if (!path.exists()) {
+            CotorConfig()
+        } else {
+            configRepository.loadConfig(path)
+        }
+    }
+
+    private fun confirm(message: String): Boolean {
+        terminal.print("$message [y/N]: ")
+        val answer = readlnOrNull()?.trim()?.lowercase()
+        return answer == "y" || answer == "yes"
+    }
+
+    private fun writeAtomically(path: java.nio.file.Path, content: String) {
+        val tmpPath = path.resolveSibling("${path.name}.tmp")
+        tmpPath.writeText(content)
+        java.nio.file.Files.move(
+            tmpPath,
+            path,
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE
+        )
+    }
+
+    private fun presetParameters(preset: String, model: String): Map<String, String> {
+        return when (preset) {
+            "qwen" -> mapOf(
+                "model" to model,
+                "argvJson" to "[\"qwen\",\"--model\",\"$model\",\"{input}\"]"
+            )
+            else -> mapOf("model" to model)
+        }
+    }
+
+    private fun renderAgentYaml(agent: AgentConfig): String {
+        val parameterLines = agent.parameters.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { (key, value) -> "      $key: ${yamlScalar(value)}" }
+
+        return """
+agents:
+  - name: ${agent.name}
+    pluginClass: ${agent.pluginClass}
+    timeout: ${agent.timeout}
+    parameters:
+$parameterLines
+""".trimIndent() + "\n"
+    }
+
+    private fun yamlScalar(value: String): String {
+        val escaped = value.replace("\\", "\\\\").replace("\"", "\\\"")
+        return "\"$escaped\""
+    }
+}
+
+class AgentListCommand : CliktCommand(
+    name = "list",
+    help = "List merged agents from config + .cotor overrides"
+) {
+    private val configRepository = FileConfigRepository(YamlParser(), JsonParser())
+
+    private val configPath by option("--config", "-c", help = "Path to base configuration file")
+        .path(mustExist = false)
+        .default(Path("cotor.yaml"))
+
+    override fun run() {
+        val config = runBlocking {
+            if (!configPath.exists()) CotorConfig() else configRepository.loadConfig(configPath)
+        }
+
+        if (config.agents.isEmpty()) {
+            echo("No agents defined.")
+            return
+        }
+
+        echo("Agents (${config.agents.size}):")
+        config.agents.sortedBy { it.name }.forEach { agent ->
+            val model = agent.parameters["model"] ?: "-"
+            echo("- ${agent.name} | ${agent.pluginClass} | timeout=${agent.timeout} | model=$model")
+        }
+    }
+}

--- a/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
@@ -1,0 +1,106 @@
+package com.cotor.presentation.cli
+
+import com.github.ajalt.clikt.testing.test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.io.path.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class AgentCommandTest : FunSpec({
+    val createdRoots = CopyOnWriteArrayList<java.nio.file.Path>()
+
+    test("agent add writes preset yaml under .cotor/agents") {
+        val root = Path("build/tmp/agent-add-${System.currentTimeMillis()}")
+        createdRoots += root
+        root.createDirectories()
+        val config = root.resolve("cotor.yaml")
+        config.writeText("version: \"1.0\"\nagents: []\n")
+
+        val result = AgentCommand().test("add gemini --config $config --yes")
+
+        result.statusCode shouldBe 0
+        val added = root.resolve(".cotor/agents/gemini.yaml")
+        added.exists() shouldBe true
+        added.readText() shouldContain "pluginClass: com.cotor.data.plugin.GeminiPlugin"
+        added.readText() shouldContain "model: \"gemini-3.0-flash\""
+    }
+
+    test("agent list shows merged agents") {
+        val root = Path("build/tmp/agent-list-${System.currentTimeMillis()}")
+        createdRoots += root
+        root.createDirectories()
+        val config = root.resolve("cotor.yaml")
+        config.writeText(
+            """
+            version: "1.0"
+            agents:
+              - name: base-agent
+                pluginClass: com.cotor.data.plugin.EchoPlugin
+            """.trimIndent()
+        )
+        val overrideDir = root.resolve(".cotor/agents")
+        overrideDir.createDirectories()
+        overrideDir.resolve("gemini.yaml").writeText(
+            """
+            agents:
+              - name: gemini
+                pluginClass: com.cotor.data.plugin.GeminiPlugin
+                timeout: 60000
+            """.trimIndent()
+        )
+
+        val result = AgentCommand().test("list --config $config")
+
+        result.statusCode shouldBe 0
+        result.output shouldContain "base-agent"
+        result.output shouldContain "gemini"
+    }
+
+    test("agent add qwen writes command plugin parameters") {
+        val root = Path("build/tmp/agent-qwen-${System.currentTimeMillis()}")
+        createdRoots += root
+        root.createDirectories()
+        val config = root.resolve("cotor.yaml")
+        config.writeText("version: \"1.0\"\nagents: []\n")
+
+        val result = AgentCommand().test("add qwen --config $config --yes")
+
+        result.statusCode shouldBe 0
+        val added = root.resolve(".cotor/agents/qwen.yaml")
+        added.exists() shouldBe true
+        added.readText() shouldContain "pluginClass: com.cotor.data.plugin.CommandPlugin"
+        added.readText() shouldContain "model: \"qwen3-coder\""
+        added.readText() shouldContain "argvJson:"
+    }
+
+    test("agent add codex uses updated default model") {
+        val root = Path("build/tmp/agent-codex-${System.currentTimeMillis()}")
+        createdRoots += root
+        root.createDirectories()
+        val config = root.resolve("cotor.yaml")
+        config.writeText("version: \"1.0\"\nagents: []\n")
+
+        val result = AgentCommand().test("add codex --config $config --yes")
+
+        result.statusCode shouldBe 0
+        val added = root.resolve(".cotor/agents/codex.yaml")
+        added.exists() shouldBe true
+        added.readText() shouldContain "model: \"gpt-5.3-codex-spark\""
+    }
+
+    afterSpec {
+        createdRoots.forEach { root ->
+            if (Files.exists(root)) {
+                Files.walk(root)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach { Files.deleteIfExists(it) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
### Motivation

- Provide a built-in workflow to manage agent presets and per-project agent overrides stored under `.cotor/agents`.
- Make `agent` available as a first-class top-level command in both simple-mode dispatch and the full CLI so users can add/list agent definitions.

### Description

- Add `AgentCommand` with `add` and `list` subcommands implementing preset-based agent creation and merged listing in `src/main/kotlin/com/cotor/presentation/cli/AgentCommand.kt`.
- Register the `agent` command in the main CLI dispatch by recognizing `agent` in simple-mode checks and adding `AgentCommand()` to the `subcommands` list in `Main.kt`.
- Implement built-in presets, parameter customization (`--model`, `--timeout`, `--name`), `--dry-run`, `--force`, and `--yes` flags, atomic file writes, and YAML rendering for agent definitions.
- Add `AgentCommandTest` unit tests in `src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt` to verify writing presets under `.cotor/agents`, merged listing, special `qwen` parameters, and default model values, with test cleanup logic.

### Testing

- Ran the new unit tests under `AgentCommandTest` via the project test suite (e.g. `./gradlew test`).
- The `agent add` and `agent list` tests executed and passed, validating file creation, YAML contents, and merged listing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a779c6d6b4833384dacf16137b2a1c)