### PR TITLE
Persist/load session, memory flushing, and long-context compaction for interactive chat

### DIFF
--- a/src/main/kotlin/com/cotor/chat/ChatModels.kt
+++ b/src/main/kotlin/com/cotor/chat/ChatModels.kt
@@ -1,16 +1,19 @@
 package com.cotor.chat
 
+import kotlinx.serialization.Serializable
 import java.time.Instant
 
+@Serializable
 enum class ChatRole {
     USER,
     ASSISTANT
 }
 
+@Serializable
 data class ChatMessage(
     val role: ChatRole,
     val content: String,
-    val timestamp: Instant = Instant.now()
+    val timestamp: String = Instant.now().toString()
 )
 
 enum class ChatMode {
@@ -29,4 +32,3 @@ enum class ChatMode {
         }
     }
 }
-

--- a/src/main/kotlin/com/cotor/chat/ChatSession.kt
+++ b/src/main/kotlin/com/cotor/chat/ChatSession.kt
@@ -1,15 +1,19 @@
 package com.cotor.chat
 
 /**
- * Minimal chat session state. This is intentionally simple so it can be reused by both:
- * - TUI interactive mode (readLine loop)
- * - Non-interactive mode (--prompt / --prompt-file), which is easier to test
+ * Chat session state with simple long-context controls:
+ * - Head/Tail preservation with middle summarization
+ * - Prompt budget limiting
+ * - Cache-aware pruning for large assistant/tool-like outputs
  */
 class ChatSession(
     private val includeContext: Boolean,
-    private val maxHistoryMessages: Int
+    private val maxHistoryMessages: Int,
+    initialMessages: List<ChatMessage> = emptyList(),
+    private val maxPromptChars: Int = 20_000,
+    private val toolOutputPruneChars: Int = 1_200
 ) {
-    private val messages = mutableListOf<ChatMessage>()
+    private val messages = initialMessages.toMutableList()
 
     fun snapshot(): List<ChatMessage> = messages.toList()
 
@@ -25,28 +29,88 @@ class ChatSession(
         messages += ChatMessage(ChatRole.ASSISTANT, content)
     }
 
-    fun buildPrompt(currentUserInput: String): String {
+    /**
+     * Summarize middle messages while preserving head/tail messages.
+     */
+    fun compactHistory(keepHead: Int = 4, keepTail: Int = 16) {
+        if (messages.size <= keepHead + keepTail + 1) return
+
+        val head = messages.take(keepHead)
+        val middle = messages.drop(keepHead).dropLast(keepTail)
+        val tail = messages.takeLast(keepTail)
+
+        if (middle.isEmpty()) return
+
+        val summaryLines = middle
+            .chunked(2)
+            .mapIndexed { idx, chunk ->
+                val snippet = chunk.joinToString(" | ") {
+                    val role = if (it.role == ChatRole.USER) "U" else "A"
+                    "$role:${it.content.replace("\n", " ").take(80)}"
+                }
+                "${idx + 1}. $snippet"
+            }
+            .take(12)
+
+        val summaryMessage = ChatMessage(
+            role = ChatRole.ASSISTANT,
+            content = "[Summary of earlier conversation]\n" + summaryLines.joinToString("\n")
+        )
+
+        messages.clear()
+        messages.addAll(head)
+        messages += summaryMessage
+        messages.addAll(tail)
+    }
+
+    fun buildPrompt(
+        currentUserInput: String,
+        bootstrapContext: String = "",
+        memoryContext: List<String> = emptyList()
+    ): String {
         if (!includeContext) return currentUserInput
 
         val history = messages.takeLast(maxHistoryMessages)
         val sb = StringBuilder()
         sb.appendLine("You are Cotor, a master agent that can consult multiple CLI-based sub-agents.")
         sb.appendLine("Continue the conversation naturally. Prefer concrete, actionable answers.")
+        if (bootstrapContext.isNotBlank()) {
+            sb.appendLine()
+            sb.appendLine("Workspace bootstrap context:")
+            sb.appendLine(bootstrapContext.trim())
+        }
+        if (memoryContext.isNotEmpty()) {
+            sb.appendLine()
+            sb.appendLine("Relevant long-term memory:")
+            memoryContext.forEach { sb.appendLine("- $it") }
+        }
         sb.appendLine()
+
         if (history.isNotEmpty()) {
             sb.appendLine("Conversation so far:")
-            history.forEach { msg ->
+            history.forEachIndexed { idx, msg ->
                 val label = when (msg.role) {
                     ChatRole.USER -> "User"
                     ChatRole.ASSISTANT -> "Assistant"
                 }
-                sb.appendLine("$label: ${msg.content}")
+                val normalized = msg.content.replace("\r\n", "\n")
+                val pruned = if (msg.role == ChatRole.ASSISTANT && normalized.length > toolOutputPruneChars && idx < history.lastIndex - 1) {
+                    "[cache-aware-pruned assistant output, ${normalized.length} chars omitted]"
+                } else {
+                    normalized
+                }
+                sb.appendLine("$label: $pruned")
             }
             sb.appendLine()
         }
         sb.appendLine("User: $currentUserInput")
         sb.append("Assistant:")
+
+        if (sb.length > maxPromptChars) {
+            compactHistory()
+            return buildPrompt(currentUserInput, bootstrapContext, memoryContext)
+        }
+
         return sb.toString()
     }
 }
-

--- a/src/main/kotlin/com/cotor/chat/ChatTranscriptWriter.kt
+++ b/src/main/kotlin/com/cotor/chat/ChatTranscriptWriter.kt
@@ -1,17 +1,96 @@
 package com.cotor.chat
 
-import java.nio.file.Files
-import java.nio.file.Path
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import java.time.Instant
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readLines
 import kotlin.io.path.writeText
 
 class ChatTranscriptWriter(
-    private val saveDir: Path
+    private val saveDir: java.nio.file.Path
 ) {
-    fun ensureDir(): Path {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val jsonlFile = saveDir.resolve("session.jsonl")
+    private val memoryFile = saveDir.resolve("MEMORY.md")
+
+    fun ensureDir(): java.nio.file.Path {
         saveDir.createDirectories()
         return saveDir
+    }
+
+    fun loadSessionMessages(): List<ChatMessage> {
+        ensureDir()
+        if (!jsonlFile.exists()) return emptyList()
+        return jsonlFile.readLines()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                runCatching { json.decodeFromString<ChatMessage>(line) }.getOrNull()
+            }
+    }
+
+    fun writeJsonl(session: ChatSession) {
+        ensureDir()
+        val body = buildString {
+            session.snapshot().forEach { msg ->
+                appendLine(json.encodeToString(msg))
+            }
+        }
+        jsonlFile.writeText(body)
+    }
+
+    fun clearJsonl() {
+        ensureDir()
+        jsonlFile.writeText("")
+    }
+
+    fun flushMemoryIfNeeded(session: ChatSession, flushThreshold: Int = 80, keepTail: Int = 30) {
+        val snapshot = session.snapshot()
+        if (snapshot.size <= flushThreshold) return
+
+        val flushChunk = snapshot.dropLast(keepTail)
+        if (flushChunk.isEmpty()) return
+
+        val bullets = flushChunk
+            .chunked(2)
+            .map { pair ->
+                pair.joinToString(" | ") {
+                    val role = if (it.role == ChatRole.USER) "USER" else "ASSISTANT"
+                    "$role:${it.content.replace("\n", " ").take(100)}"
+                }
+            }
+            .take(20)
+
+        val entry = buildString {
+            appendLine("## Memory Flush ${Instant.now()}")
+            bullets.forEach { appendLine("- $it") }
+            appendLine()
+        }
+
+        val existing = if (memoryFile.exists()) memoryFile.readLines().joinToString("\n") else ""
+        memoryFile.writeText((existing + "\n" + entry).trimStart())
+
+        session.compactHistory(keepHead = 4, keepTail = keepTail)
+        writeJsonl(session)
+    }
+
+    fun searchMemory(query: String, limit: Int = 3): List<String> {
+        if (!memoryFile.exists() || query.isBlank()) return emptyList()
+        val tokens = query.lowercase().split(" ").filter { it.isNotBlank() }
+        if (tokens.isEmpty()) return emptyList()
+
+        return memoryFile.readLines()
+            .filter { it.startsWith("-") }
+            .map { it.removePrefix("-").trim() }
+            .map { line ->
+                val score = tokens.count { token -> line.lowercase().contains(token) }
+                line to score
+            }
+            .filter { it.second > 0 }
+            .sortedByDescending { it.second }
+            .take(limit)
+            .map { it.first }
     }
 
     fun writeMarkdown(
@@ -61,4 +140,3 @@ class ChatTranscriptWriter(
         saveDir.resolve("transcript.txt").writeText(txt)
     }
 }
-

--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
@@ -29,12 +29,11 @@ import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.File
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.readLines
+import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 /**
@@ -84,6 +83,17 @@ class InteractiveCommand : CliktCommand(
         .int()
         .default(20)
 
+
+    private val bootstrapMaxChars by option(
+        "--bootstrap-max-chars",
+        help = "Max chars loaded from workspace bootstrap docs (AGENTS/README)"
+    ).int().default(20_000)
+
+    private val memorySearchLimit by option(
+        "--memory-search-limit",
+        help = "How many MEMORY.md entries to inject per turn"
+    ).int().default(3)
+
     private val showAll by option(
         "--show-all",
         help = "In auto mode, show all agent outputs instead of only the selected best output"
@@ -126,9 +136,14 @@ class InteractiveCommand : CliktCommand(
         val selectedAgents = parseAgentsOption(agents, allAgents.values.toList())
         val activeAgent = resolveActiveAgent(chatMode, agent, selectedAgents, allAgents)
 
-        val session = ChatSession(includeContext = !noContext, maxHistoryMessages = maxHistory)
         val outputDir = (saveDir ?: defaultSaveDir()).also { it.createDirectories() }
         val transcript = ChatTranscriptWriter(outputDir)
+        val bootstrapContext = loadBootstrapContext(bootstrapMaxChars)
+        val session = ChatSession(
+            includeContext = !noContext,
+            maxHistoryMessages = maxHistory,
+            initialMessages = transcript.loadSessionMessages()
+        )
 
         val headerLines = buildList {
             add("Config: $configPath")
@@ -145,12 +160,16 @@ class InteractiveCommand : CliktCommand(
                     activeAgent = activeAgent,
                     selectedAgents = selectedAgents,
                     userInput = prompt!!,
-                    verbose = false
+                    verbose = false,
+                    bootstrapContext = bootstrapContext,
+                    memoryContext = transcript.searchMemory(prompt!!, memorySearchLimit)
                 )
                 session.addUser(prompt!!)
                 session.addAssistant(response)
                 transcript.writeMarkdown(session, headerLines)
                 transcript.writeRawText(session)
+                transcript.writeJsonl(session)
+                transcript.flushMemoryIfNeeded(session)
                 echo(response)
             }
 
@@ -167,7 +186,9 @@ class InteractiveCommand : CliktCommand(
                         activeAgent = activeAgent,
                         selectedAgents = selectedAgents,
                         userInput = line,
-                        verbose = false
+                        verbose = false,
+                        bootstrapContext = bootstrapContext,
+                        memoryContext = transcript.searchMemory(line, memorySearchLimit)
                     )
                     session.addUser(line)
                     session.addAssistant(response)
@@ -175,6 +196,8 @@ class InteractiveCommand : CliktCommand(
                 }
                 transcript.writeMarkdown(session, headerLines)
                 transcript.writeRawText(session)
+                transcript.writeJsonl(session)
+                transcript.flushMemoryIfNeeded(session)
                 echo(outputs.joinToString("\n\n"))
             }
 
@@ -186,7 +209,8 @@ class InteractiveCommand : CliktCommand(
                     selectedAgentsInitial = selectedAgents,
                     allAgents = allAgents,
                     transcript = transcript,
-                    headerLines = headerLines
+                    headerLines = headerLines,
+                    bootstrapContext = bootstrapContext
                 )
             }
         }
@@ -244,7 +268,9 @@ class InteractiveCommand : CliktCommand(
         activeAgent: AgentConfig?,
         selectedAgents: List<AgentConfig>,
         userInput: String,
-        verbose: Boolean
+        verbose: Boolean,
+        bootstrapContext: String,
+        memoryContext: List<String>
     ): String = coroutineScope {
         val spinner = launch {
             val frames = listOf("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
@@ -263,7 +289,9 @@ class InteractiveCommand : CliktCommand(
                 activeAgent = activeAgent,
                 selectedAgents = selectedAgents,
                 userInput = userInput,
-                verbose = verbose
+                verbose = verbose,
+                bootstrapContext = bootstrapContext,
+                memoryContext = memoryContext
             )
         } finally {
             spinner.cancel()
@@ -277,9 +305,15 @@ class InteractiveCommand : CliktCommand(
         activeAgent: AgentConfig?,
         selectedAgents: List<AgentConfig>,
         userInput: String,
-        verbose: Boolean
+        verbose: Boolean,
+        bootstrapContext: String,
+        memoryContext: List<String>
     ): String = coroutineScope {
-        val effectivePrompt = session.buildPrompt(userInput)
+        val effectivePrompt = session.buildPrompt(
+            currentUserInput = userInput,
+            bootstrapContext = bootstrapContext,
+            memoryContext = memoryContext
+        )
         when (chatMode) {
             ChatMode.SINGLE -> {
                 val target = activeAgent ?: selectedAgents.firstOrNull()
@@ -343,7 +377,8 @@ class InteractiveCommand : CliktCommand(
         selectedAgentsInitial: List<AgentConfig>,
         allAgents: Map<String, AgentConfig>,
         transcript: ChatTranscriptWriter,
-        headerLines: List<String>
+        headerLines: List<String>,
+        bootstrapContext: String
     ) {
         var chatMode = chatModeInitial
         var selectedAgents = selectedAgentsInitial
@@ -353,6 +388,9 @@ class InteractiveCommand : CliktCommand(
         terminal.println(bold("◎ Cotor Interactive"))
         terminal.println(dim("Type ':help' for commands, ':exit' to quit."))
         terminal.println(dim("Transcript: ${transcript.ensureDir()}"))
+        if (session.snapshot().isNotEmpty()) {
+            terminal.println(dim("Loaded ${session.snapshot().size} messages from session.jsonl"))
+        }
         terminal.println()
 
         var endedByEof = false
@@ -375,6 +413,7 @@ class InteractiveCommand : CliktCommand(
                     cmd.equals("agents", true) -> printAgents(allAgents)
                     cmd.equals("clear", true) -> {
                         session.clear()
+                        transcript.clearJsonl()
                         terminal.println(dim("Cleared session history."))
                     }
                     cmd.startsWith("mode ", true) -> {
@@ -409,6 +448,8 @@ class InteractiveCommand : CliktCommand(
                     cmd.equals("save", true) -> {
                         transcript.writeMarkdown(session, headerLines + "Mode: $chatMode")
                         transcript.writeRawText(session)
+                        transcript.writeJsonl(session)
+                        transcript.flushMemoryIfNeeded(session)
                         terminal.println(green("Saved transcript to ${transcript.ensureDir()}"))
                     }
                     else -> terminal.println(dim("Unknown command. Try ':help'"))
@@ -424,7 +465,9 @@ class InteractiveCommand : CliktCommand(
                     activeAgent = activeAgent,
                     selectedAgents = selectedAgents,
                     userInput = input,
-                    verbose = true
+                    verbose = true,
+                    bootstrapContext = bootstrapContext,
+                    memoryContext = transcript.searchMemory(input, memorySearchLimit)
                 )
                 session.addUser(input)
                 session.addAssistant(response)
@@ -436,6 +479,8 @@ class InteractiveCommand : CliktCommand(
                 // Persist after each successful turn.
                 transcript.writeMarkdown(session, headerLines + "Mode: $chatMode")
                 transcript.writeRawText(session)
+                transcript.writeJsonl(session)
+                transcript.flushMemoryIfNeeded(session)
             } catch (e: Exception) {
                 terminal.println(red("Error: ${e.message ?: "unknown error"}"))
                 terminal.println(dim("Hint: use ':agents' to list, ':mode auto|compare|single', ':model <name>'"))
@@ -444,6 +489,8 @@ class InteractiveCommand : CliktCommand(
 
         transcript.writeMarkdown(session, headerLines + "Mode: $chatMode")
         transcript.writeRawText(session)
+        transcript.writeJsonl(session)
+        transcript.flushMemoryIfNeeded(session)
         if (endedByEof) {
             terminal.println(dim("Input stream closed (EOF). Exiting interactive mode."))
         }
@@ -475,9 +522,29 @@ class InteractiveCommand : CliktCommand(
         terminal.println()
     }
 
+
+    private fun loadBootstrapContext(maxChars: Int): String {
+        val candidates = listOf(
+            Path("AGENTS.md"),
+            Path("README.md"),
+            Path("README.ko.md"),
+            Path("docs/README.md")
+        )
+
+        val merged = buildString {
+            candidates.filter { it.exists() }.forEach { file ->
+                appendLine("## ${file.toString()}")
+                appendLine(file.readText().trim())
+                appendLine()
+            }
+        }
+
+        if (merged.isBlank()) return ""
+        return merged.take(maxChars)
+    }
+
     private fun defaultSaveDir(): java.nio.file.Path {
-        val ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
-        return Path(".cotor").resolve("interactive").resolve(ts)
+        return Path(".cotor").resolve("interactive").resolve("default")
     }
 
     private data class StarterAgent(

--- a/src/test/kotlin/com/cotor/chat/ChatSessionTest.kt
+++ b/src/test/kotlin/com/cotor/chat/ChatSessionTest.kt
@@ -1,6 +1,7 @@
 package com.cotor.chat
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -32,5 +33,46 @@ class ChatSessionTest : FunSpec({
         prompt.shouldNotContain("User: u1")
         prompt.shouldNotContain("Assistant: a1")
     }
-})
 
+    test("buildPrompt includes bootstrap and memory contexts") {
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 5)
+        val prompt = session.buildPrompt(
+            currentUserInput = "status?",
+            bootstrapContext = "AGENTS: keep code clean",
+            memoryContext = listOf("지난번에는 retry를 켰다")
+        )
+
+        prompt.shouldContain("Workspace bootstrap context:")
+        prompt.shouldContain("AGENTS: keep code clean")
+        prompt.shouldContain("Relevant long-term memory:")
+        prompt.shouldContain("- 지난번에는 retry를 켰다")
+    }
+
+    test("compactHistory preserves head and tail with summary in middle") {
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 100)
+        repeat(20) { i ->
+            session.addUser("u$i")
+            session.addAssistant("a$i")
+        }
+
+        session.compactHistory(keepHead = 2, keepTail = 4)
+        val snapshot = session.snapshot()
+
+        snapshot.shouldHaveSize(7)
+        snapshot.first().content shouldBe "u0"
+        snapshot[1].content shouldBe "a0"
+        snapshot[2].content.shouldContain("[Summary of earlier conversation]")
+        snapshot.takeLast(4).map { it.content } shouldBe listOf("u18", "a18", "u19", "a19")
+    }
+
+    test("buildPrompt prunes oversized older assistant outputs") {
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 10, toolOutputPruneChars = 20)
+        session.addUser("show details")
+        session.addAssistant("x".repeat(100))
+        session.addUser("ok and now?")
+        session.addAssistant("short")
+
+        val prompt = session.buildPrompt("next")
+        prompt.shouldContain("cache-aware-pruned assistant output")
+    }
+})

--- a/src/test/kotlin/com/cotor/chat/ChatTranscriptWriterTest.kt
+++ b/src/test/kotlin/com/cotor/chat/ChatTranscriptWriterTest.kt
@@ -1,0 +1,73 @@
+package com.cotor.chat
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+class ChatTranscriptWriterTest : FunSpec({
+    test("writeJsonl and loadSessionMessages round-trip chat history") {
+        val dir = Files.createTempDirectory("cotor-chat-test")
+        val writer = ChatTranscriptWriter(dir)
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 10)
+
+        session.addUser("hello")
+        session.addAssistant("world")
+        writer.writeJsonl(session)
+
+        val loaded = writer.loadSessionMessages()
+        loaded.shouldHaveSize(2)
+        loaded[0].role shouldBe ChatRole.USER
+        loaded[0].content shouldBe "hello"
+        loaded[1].role shouldBe ChatRole.ASSISTANT
+        loaded[1].content shouldBe "world"
+    }
+
+    test("clearJsonl removes persisted history") {
+        val dir = Files.createTempDirectory("cotor-chat-test-clear")
+        val writer = ChatTranscriptWriter(dir)
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 10)
+        session.addUser("keep?")
+        writer.writeJsonl(session)
+
+        writer.clearJsonl()
+
+        writer.loadSessionMessages() shouldBe emptyList()
+    }
+
+    test("flushMemoryIfNeeded writes MEMORY and compacts session") {
+        val dir = Files.createTempDirectory("cotor-chat-memory")
+        val writer = ChatTranscriptWriter(dir)
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 200)
+
+        repeat(45) { i ->
+            session.addUser("u$i")
+            session.addAssistant("a$i")
+        }
+
+        writer.flushMemoryIfNeeded(session, flushThreshold = 50, keepTail = 10)
+
+        val memoryFile = dir.resolve("MEMORY.md")
+        memoryFile.exists() shouldBe true
+        memoryFile.readText().shouldContain("Memory Flush")
+        (session.snapshot().size < 90) shouldBe true
+    }
+
+    test("searchMemory returns relevant bullets") {
+        val dir = Files.createTempDirectory("cotor-chat-search")
+        val writer = ChatTranscriptWriter(dir)
+        val session = ChatSession(includeContext = true, maxHistoryMessages = 100)
+
+        repeat(30) { i ->
+            session.addUser("retry policy test $i")
+            session.addAssistant("consensus score was high")
+        }
+        writer.flushMemoryIfNeeded(session, flushThreshold = 40, keepTail = 10)
+
+        val found = writer.searchMemory("retry consensus", limit = 2)
+        found.shouldHaveSize(2)
+    }
+})


### PR DESCRIPTION
### Motivation
- Improve interactive chat resilience by persisting session history and restoring it across runs. 
- Prevent oversized prompts and extremely large assistant outputs from blowing the model context by summarizing/compacting history and pruning tool-like outputs. 
- Inject workspace bootstrap docs and lightweight long-term memory into prompts to give the agent useful context.

### Description
- Added serialization for chat models and changed `ChatMessage.timestamp` to a `String` for stable JSONL persistence via `kotlinx.serialization` and `ChatTranscriptWriter.writeJsonl`/`loadSessionMessages`/`clearJsonl`. 
- Extended `ChatSession` to accept `initialMessages`, added `compactHistory(keepHead, keepTail)` summarization, prompt building now accepts `bootstrapContext` and `memoryContext`, enforces `maxPromptChars`, and performs cache-aware pruning of large assistant outputs. 
- Implemented `ChatTranscriptWriter` JSONL persistence, `flushMemoryIfNeeded` that writes condensed bullets to `MEMORY.md` and compacts the live session, and `searchMemory` to retrieve relevant bullets for injection. 
- Wired up interactive CLI: new options `--bootstrap-max-chars` and `--memory-search-limit`, `loadBootstrapContext` reads workspace docs, session is restored from `session.jsonl`, and JSONL/memory flushes are performed after turns and on save/exit. 
- Added and updated tests covering the prompt building, history compaction, pruning, JSONL round-trip, memory flush, and memory search.

### Testing
- Ran unit tests with `./gradlew test`, including `ChatSessionTest` and `ChatTranscriptWriterTest`, and they passed. 
- Verified Kotest specs for `ChatSession` and `ChatTranscriptWriter` executed successfully (`build/test` completed without failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a779d2fe1c8333a0bd2d9540f1f80c)