### PR TITLE
feat(interactive): add Tab completion for TUI commands with JLine

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.clikt)
     implementation(libs.mordant)  // Terminal UI
     implementation(libs.progressbar)            // Progress bar
+    implementation(libs.jline)                  // Interactive line editing/completion
 
     // Serialization
     implementation(libs.kotlinx.serialization.json)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinLogging = "3.0.5"
 ktor = "3.0.3"
 kotest = "5.8.0"
 mockk = "1.13.8"
+jline = "3.26.3"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -38,6 +39,7 @@ kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+jline = { module = "org.jline:jline", version.ref = "jline" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
@@ -26,6 +26,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.jline.reader.EndOfFileException
+import org.jline.reader.LineReaderBuilder
+import org.jline.reader.UserInterruptException
+import org.jline.terminal.TerminalBuilder
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.File
@@ -357,9 +361,21 @@ class InteractiveCommand : CliktCommand(
 
         var endedByEof = false
 
+        val lineReader = buildLineReader(allAgents.keys.toList())
+
         while (true) {
-            terminal.print(bold(cyan("you> ")) )
-            val line = readLine()
+            val line = try {
+                lineReader?.readLine("you> ") ?: run {
+                    terminal.print(bold(cyan("you> ")) )
+                    readLine()
+                }
+            } catch (_: UserInterruptException) {
+                terminal.println()
+                continue
+            } catch (_: EndOfFileException) {
+                null
+            }
+
             if (line == null) {
                 endedByEof = true
                 break
@@ -449,6 +465,17 @@ class InteractiveCommand : CliktCommand(
         }
         terminal.println(dim("Bye. Saved transcript to ${transcript.ensureDir()}"))
     }
+
+
+    private fun buildLineReader(agentNames: List<String>) = runCatching {
+        val jlineTerminal = TerminalBuilder.builder()
+            .system(true)
+            .build()
+        LineReaderBuilder.builder()
+            .terminal(jlineTerminal)
+            .completer(InteractiveCommandCompleter { agentNames })
+            .build()
+    }.getOrNull()
 
     private fun printHelp() {
         terminal.println()

--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleter.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleter.kt
@@ -1,0 +1,63 @@
+package com.cotor.presentation.cli
+
+import org.jline.reader.Candidate
+import org.jline.reader.Completer
+import org.jline.reader.LineReader
+import org.jline.reader.ParsedLine
+
+class InteractiveCommandCompleter(
+    private val agentNamesProvider: () -> List<String>
+) : Completer {
+    private val commands = listOf("help", "agents", "clear", "save", "exit", "mode", "use", "model", "include")
+    private val modeValues = listOf("auto", "compare", "single")
+
+    override fun complete(reader: LineReader?, line: ParsedLine, candidates: MutableList<Candidate>) {
+        val suggestions = suggest(line.line(), line.cursor())
+        suggestions.forEach { candidates += Candidate(it) }
+    }
+
+    fun suggest(input: String, cursor: Int = input.length): List<String> {
+        val safeCursor = cursor.coerceIn(0, input.length)
+        val uptoCursor = input.substring(0, safeCursor)
+        if (!uptoCursor.startsWith(":")) return emptyList()
+
+        val raw = uptoCursor.removePrefix(":")
+        val normalizedAgents = agentNamesProvider().distinct().sorted()
+
+        if (!raw.contains(" ")) {
+            return commands
+                .map { ":$it" }
+                .filter { it.startsWith(":$raw", ignoreCase = true) }
+        }
+
+        val command = raw.substringBefore(" ").lowercase()
+        val arg = raw.substringAfter(" ", "")
+
+        return when (command) {
+            "mode" -> completeSimpleArg(command, arg, modeValues)
+            "use", "model" -> completeSimpleArg(command, arg, normalizedAgents)
+            "include" -> completeInclude(arg, normalizedAgents)
+            else -> emptyList()
+        }
+    }
+
+    private fun completeSimpleArg(command: String, arg: String, options: List<String>): List<String> {
+        val token = arg.trimStart()
+        return options
+            .filter { it.startsWith(token, ignoreCase = true) }
+            .map { ":$command $it" }
+    }
+
+    private fun completeInclude(arg: String, options: List<String>): List<String> {
+        val parts = arg.split(",")
+        val current = parts.lastOrNull()?.trimStart().orEmpty()
+        val selected = parts.dropLast(1).map { it.trim() }.filter { it.isNotBlank() }.toSet()
+        val prefix = parts.dropLast(1).joinToString(",")
+        val prefixWithComma = if (prefix.isBlank()) "" else "$prefix,"
+
+        return options
+            .filterNot { selected.contains(it) }
+            .filter { it.startsWith(current, ignoreCase = true) }
+            .map { ":include $prefixWithComma$it" }
+    }
+}

--- a/src/test/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleterTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleterTest.kt
@@ -1,0 +1,30 @@
+package com.cotor.presentation.cli
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+
+class InteractiveCommandCompleterTest : FunSpec({
+    val completer = InteractiveCommandCompleter { listOf("codex", "gemini", "claude") }
+
+    test("completes command prefixes") {
+        completer.suggest(":ag") shouldContain ":agents"
+        completer.suggest(":mo") shouldContain ":mode"
+    }
+
+    test("completes mode values") {
+        completer.suggest(":mode c") shouldContain ":mode compare"
+    }
+
+    test("completes agent name for :use") {
+        completer.suggest(":use co") shouldContain ":use codex"
+    }
+
+    test("completes include tokens by comma-separated segment") {
+        completer.suggest(":include co,ge") shouldContain ":include co,gemini"
+    }
+
+    test("lists all mode options when argument is empty") {
+        completer.suggest(":mode ") shouldContainAll listOf(":mode auto", ":mode compare", ":mode single")
+    }
+})


### PR DESCRIPTION
### Motivation
- Improve TUI UX by providing command and token-level Tab completion (e.g. `:ag` → `:agents`, `:mode c` → `:mode compare`, `:use co` → `:use codex`, `:include co,ge` → `:include co,gemini`).
- Replace the basic `readLine()`-only input loop with a pluggable input layer that can use a richer line editor when available while keeping a safe fallback.

### Description
- Added JLine as an optional dependency in the version catalog and build (`gradle/libs.versions.toml`, `build.gradle.kts`) so the project can use `LineReader` features when present.
- Implemented `InteractiveCommandCompleter` to provide completion rules for command prefixes, `:mode` values, `:use`/`:model` agent names, and comma-separated `:include` tokens (`src/main/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleter.kt`).
- Extended the interactive TUI input loop in `InteractiveCommand` to attempt building a JLine `LineReader` with the completer and fall back to `readLine()` if JLine is unavailable or fails, and to handle `Ctrl+C`/EOF gracefully (`src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt`).
- Added focused unit tests for completion mapping behavior (`InteractiveCommandCompleterTest`) to validate the mapping from partial inputs to expected completion strings (`src/test/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleterTest.kt`).

### Testing
- Attempted `./gradlew test` failed in this environment because the Gradle wrapper JAR was missing, so the system `gradle` binary was used instead. (wrapper error: `Could not find or load main class org.gradle.wrapper.GradleWrapperMain`).
- Ran `gradle test --tests com.cotor.presentation.cli.InteractiveCommandCompleterTest --tests com.cotor.presentation.cli.InteractiveCommandTest -x jacocoTestCoverageVerification -x jacocoTestReport`, and the requested tests completed successfully (build success with coverage checks skipped).
- Running full `spotlessApply` failed due to a pre-existing unrelated filename rule violation in `src/main/kotlin/com/cotor/presentation/web/stream/RealtimeEvents.kt`, which is not part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77e3ec1c88333a514f227da574176)