### PR TITLE
docs: align core docs with current CLI commands and workflow

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,535 +1,73 @@
-# Cotor 전체 기능 목록
+# Cotor 기능 요약 (코드 기준 최신)
 
 **버전**: 1.0.0
-**최종 업데이트**: 2025-11-27
 
----
+## 실행/오케스트레이션
 
-## 🚀 핵심 기능
+- 실행 모드: `SEQUENTIAL`, `PARALLEL`, `DAG`
+- 조건 분기/루프 스테이지 지원
+- 스테이지 의존성 해석 및 검증
+- 실행 중 이벤트 기반 타임라인 수집
 
-### 1. 파이프라인 실행 모드
+## 검증/품질
 
-- **Sequential (순차)**: 단계별 순차 실행
-- **Parallel (병렬)**: 동시 다발적 실행
-- **DAG (방향성 비순환 그래프)**: 의존성 기반 실행
+- `validate`: 파이프라인 구조/의존성/에이전트 정의 검증
+- `lint`: YAML/설정 정적 점검
+- 출력 검증기(`output` validation) 및 템플릿 검증
 
-### 2. 고급 실행 제어
+## 모니터링/복구
 
-- **조건부 실행**: 조건에 따른 분기
-- **루프**: 반복 실행
-- **의존성 관리**: 스테이지 간 의존성 처리
-- **타임아웃**: 각 에이전트별 시간 제한
+- `run --watch`: 진행 상황 모니터링
+- `run --dry-run`: 실행 없이 예상 흐름/시간 확인
+- 체크포인트 저장/복원(`resume`, `checkpoint gc`)
+- 최근/실행중 파이프라인 상태 조회(`status`)
+- 통계 누적 및 추세 표시(`stats`)
 
-### 3. 모니터링
+## 템플릿 시스템
 
-- **실시간 진행 상황**: 실행 중 진행률 표시
-- **타임라인**: 각 스테이지별 실행 이력
-- **스피너 애니메이션**: 시각적 피드백
-- **상세 로그**: Verbose 모드 지원
+`cotor template --list` 기준 내장 템플릿:
 
----
+1. `compare`
+2. `chain`
+3. `review`
+4. `consensus`
+5. `fanout`
+6. `selfheal`
+7. `verified`
+8. `custom`
 
-## 📊 관리 기능
+지원 기능:
+- 템플릿 미리보기(`--preview`)
+- 파일 출력
+- 플레이스홀더 치환(`--fill key=value`)
 
-### 1. 체크포인트
+## CLI 명령 (현재 Main 등록 기준)
 
-- 자동 체크포인트 생성
-- 중단된 파이프라인 재개
-- 체크포인트 관리 (목록, 삭제, 정리)
-- JSON 형식 저장 (`.cotor/checkpoints/`)
+- 기본: `init`, `list`, `run`, `validate`, `test`, `version`, `completion`
+- 운영/관측: `status`, `stats`, `doctor`, `dash`, `interactive`, `web`
+- 유지보수: `resume`, `checkpoint`
+- 생산성: `template`, `lint`, `explain`
+- 확장: `plugin`, `agent`
 
-### 2. 통계
+## 확장 기능
 
-- 자동 통계 수집
-- 실행 이력 추적
-- 성능 트렌드 분석 (개선/안정/저하)
-- 성공률 추적
-- 권장 사항 제공
+- Agent preset 추가/조회: `agent add`, `agent list`
+- Plugin 점검/스캐폴딩: `plugin list`, `plugin validate`, `plugin init`
 
-### 3. 에러 처리
+## 출력
 
-- 사용자 친화적 오류 메시지
-- 해결 방안 제안
-- 디버그 모드 (--debug)
-- 스택 트레이스 제공
+`run --output-format`:
+- `json` (기본)
+- `csv`
+- `text`
 
----
+## 보안
 
-## 🛠️ CLI 명령어
+- 실행파일/디렉토리 화이트리스트 기반 검증
+- 위험 명령 패턴 차단을 위한 보안 검증 계층
 
-### 기본 명령어
+## 인터페이스
 
-| 명령어 | 설명 | 옵션 |
-|--------|------|------|
-| `init` | 설정 파일 생성 | `--interactive` |
-| `list` | 에이전트 목록 | `-c <config>` |
-| `run` | 파이프라인 실행 | `--watch`, `--verbose`, `--dry-run`, `-o <format>` |
-| `validate` | 파이프라인 검증 | `-c <config>` |
-| `version` | 버전 정보 | - |
-| `--short` | 치트시트 | - |
-| `--help` | 도움말 | - |
-
-### 고급 명령어
-
-| 명령어 | 설명 | 기능 |
-|--------|------|------|
-| `doctor` | 환경 점검 | Java, JAR, 설정, 예제, AI CLI 확인 |
-| `stats` | 통계 조회 | 전체 또는 개별 파이프라인 통계 |
-| `template` | 템플릿 관리 | `--list`, `--preview`, `--fill` |
-| `checkpoint` | 체크포인트 관리 | 목록, 정리 |
-| `resume` | 파이프라인 재개 | 체크포인트에서 복원 |
-| `dash` | TUI 대시보드 | 실시간 모니터링 |
-| `web` | 웹 UI | 브라우저 기반 인터페이스 |
-| `completion` | 쉘 자동완성 | bash, zsh, fish |
-| `test` | 테스트 실행 | 파이프라인 테스트 |
-| `status` | 실행 상태 | 활성 파이프라인 추적 |
-
----
-
-## 📝 템플릿 시스템
-
-### 내장 템플릿 (5종)
-
-1. **compare** - 병렬 비교
-   - 여러 AI가 동일 문제 해결
-   - 결과 비교 및 최선 선택
-
-2. **chain** - 순차 처리
-   - 생성 → 검토 → 최적화
-   - 단계별 정제
-
-3. **review** - 코드 리뷰
-   - 보안, 성능, 모범 사례
-   - 다각도 분석
-
-4. **consensus** - 합의 도출
-   - 여러 의견 수렴
-   - 합의점 찾기
-
-5. **custom** - 커스터마이즈
-   - 일반 패턴 제공
-   - 프로젝트별 수정
-
-### 템플릿 기능
-
-- 템플릿 목록 조회
-- 미리보기
-- 변수 치환 (`--fill key=value`)
-- YAML 생성
-
----
-
-## 🔒 보안 기능
-
-### 1. 화이트리스트
-
-- 허용된 실행 파일만 사용
-- 허용된 디렉토리 제한
-- 악의적인 명령 차단
-
-### 2. 검증 시스템
-
-- YAML 구문 검증
-- 스키마 유효성 검사
-- 에이전트 존재 확인
-- 의존성 순환 검사
-- 타임아웃 설정 확인
-- 보안 정책 준수
-
-### 3. 샌드박스
-
-- 격리된 실행 환경
-- 리소스 제한
-- 권한 관리
-
----
-
-## 📤 출력 형식
-
-### 지원 형식
-
-1. **text** - 사람이 읽기 쉬운 텍스트
-   - 색상 및 포맷팅
-   - 아이콘 및 구분선
-   - 요약 정보
-
-2. **json** - 프로그래매틱 처리 (기본값)
-   - 구조화된 데이터
-   - API 통합 용이
-   - 파싱 최적화
-
-3. **csv** - 스프레드시트 호환
-   - 표 형식 데이터
-   - 엑셀/구글 시트 호환
-   - 대량 데이터 분석
-
----
-
-## 🎨 사용자 경험
-
-### 1. 터미널 UI
-
-- **색상 코딩**:
-  - 🟢 초록: 성공
-  - 🔴 빨강: 오류
-  - 🟡 노랑: 경고
-  - 🔵 파랑: 정보
-  - ⚪ 회색: 부가 정보
-
-- **아이콘**:
-  - ✅ 완료
-  - ❌ 실패
-  - ⚠️ 경고
-  - 🚀 실행
-  - 📦 결과
-  - ⏱️ 시간
-  - 📊 통계
-  - 🩺 진단
-  - 🔖 체크포인트
-
-### 2. 프로그레스 바
-
-- 실시간 진행률 (%)
-- 완료/전체 스테이지
-- 경과 시간
-- 예상 완료 시간
-
-### 3. 자동완성
-
-- **bash**: `_cotor_completions`
-- **zsh**: `_cotor_completions`
-- **fish**: 내장 자동완성
-
----
-
-## 🔌 통합 기능
-
-### 1. AI CLI 통합
-
-지원 AI:
-- Claude CLI (npm)
-- Gemini CLI
-- OpenAI CLI (pip)
-- Copilot CLI
-- 기타 커스텀 CLI
-
-### 2. Claude Code 통합
-
-설치:
-```bash
-./shell/install-claude-integration.sh
-```
-
-기능:
-- 슬래시 커맨드 (`/cotor-*`)
-- 지식 베이스 통합
-- Claude에서 직접 실행
-
-### 3. CI/CD 통합
-
-- GitHub Actions
-- GitLab CI
-- Jenkins
-- CircleCI
-- 기타 CI 시스템
-
----
-
-## 📊 결과 분석
-
-### 1. 합의 분석
-
-- 합의 점수 계산
-- 의견 불일치 탐지
-- 최선의 결과 선택
-- 권장 사항 제공
-
-### 2. 성능 분석
-
-- 실행 시간 측정
-- 병목 지점 식별
-- 트렌드 추적
-- 최적화 제안
-
-### 3. 품질 분석
-
-- 출력 품질 평가
-- 일관성 검증
-- 구문 검증
-- 형식 검증
-
----
-
-## 🧪 테스트 기능
-
-### 1. 단위 테스트
-
-Gradle 통합:
-```bash
-./gradlew test
-```
-
-커버리지:
-- AgentExecutor
-- PipelineOrchestrator
-- PipelineValidator
-- ConditionEvaluator
-- ResultAggregator
-- DefaultResultAnalyzer
-- TemplateEngine
-- RecoveryExecutor
-- DefaultOutputValidator
-
-### 2. 통합 테스트
-
-예제 실행:
-```bash
-./examples/run-examples.sh
-```
-
-테스트 스크립트:
-- `test-cotor-enhanced.sh`
-- `test-cotor-pipeline.sh`
-- `test-claude-integration.sh`
-
-### 3. Dry Run
-
-시뮬레이션 모드:
-- 실제 실행 없이 검증
-- 예상 시간 계산
-- 의존성 그래프 확인
-
----
-
-## ⚙️ 설정 관리
-
-### 1. YAML 설정
-
-구조:
-```yaml
-version: "1.0"
-
-agents:
-  - name: agent-name
-    pluginClass: com.example.Plugin
-    timeout: 30000
-    parameters:
-      key: value
-    tags:
-      - tag1
-
-pipelines:
-  - name: pipeline-name
-    description: "설명"
-    executionMode: SEQUENTIAL
-    stages:
-      - id: stage-1
-        agent:
-          name: agent-name
-        input: "입력"
-
-security:
-  useWhitelist: true
-  allowedExecutables:
-    - python3
-  allowedDirectories:
-    - /usr/local/bin
-
-logging:
-  level: INFO
-  file: cotor.log
-  format: json
-
-performance:
-  maxConcurrentAgents: 10
-  coroutinePoolSize: 8
-```
-
-### 2. 환경 변수
-
-- `COTOR_CONFIG` - 설정 파일 경로
-- `COTOR_LOG_LEVEL` - 로그 레벨
-- `COTOR_DEBUG` - 디버그 모드
-
-### 3. 설정 검증
-
-자동 검증:
-- 구문 오류 검출
-- 누락된 필수 필드
-- 잘못된 값 범위
-- 순환 의존성
-
----
-
-## 🌐 웹 인터페이스
-
-### 1. 웹 UI (cotor web)
-
-기능:
-- 파이프라인 시각적 편집
-- 드래그 앤 드롭
-- 실시간 모니터링
-- 결과 시각화
-
-포트: `http://localhost:8080`
-
-### 2. TUI 대시보드 (cotor dash)
-
-기능:
-- 터미널 기반 대시보드
-- 실시간 업데이트
-- 키보드 네비게이션
-- 로그 스트리밍
-
----
-
-## 📚 문서화
-
-### 1. 사용 가능한 문서
-
-- `README.md` - 프로젝트 개요 (영문)
-- `README.ko.md` - 프로젝트 개요 (한글)
-- `docs/QUICK_START.md` - 빠른 시작 가이드
-- `docs/CLAUDE_SETUP.md` - Claude 연동 설정
-- `docs/USAGE_TIPS.md` - 사용 팁
-- `docs/UPGRADE_GUIDE.md` - 업그레이드 가이드
-- `docs/release/CHANGELOG.md` - 변경 이력
-- `docs/reports/TEST_REPORT.md` - 테스트 리포트
-- `docs/reports/FEATURE_TEST_REPORT_v1.0.0.md` - 상세 기능 테스트
-
-### 2. 예제
-
-- `examples/single-agent.yaml` - 단일 에이전트
-- `examples/parallel-compare.yaml` - 병렬 비교
-- `examples/decision-loop.yaml` - 조건/루프
-- `examples/run-examples.sh` - 일괄 실행
-
-### 3. 템플릿
-
-- `docs/templates/` - 파이프라인 템플릿
-
----
-
-## 🔧 개발자 기능
-
-### 1. 플러그인 시스템
-
-커스텀 에이전트 개발:
-```kotlin
-class CustomPlugin : AgentPlugin {
-    override suspend fun execute(input: String): String {
-        // 구현
-    }
-}
-```
-
-### 2. 이벤트 시스템
-
-이벤트:
-- `PipelineStartedEvent`
-- `StageStartedEvent`
-- `StageCompletedEvent`
-- `StageFailedEvent`
-- `PipelineCompletedEvent`
-
-구독:
-```kotlin
-eventBus.subscribe(StageCompletedEvent::class) { event ->
-    // 처리
-}
-```
-
-### 3. Koin DI
-
-의존성 주입:
-```kotlin
-val orchestrator: PipelineOrchestrator by inject()
-val validator: PipelineValidator by inject()
-```
-
----
-
-## 📈 성능
-
-### 1. 최적화
-
-- 코루틴 기반 비동기 처리
-- 병렬 실행 최적화
-- 리소스 풀링
-- 캐싱
-
-### 2. 제한
-
-- 최대 동시 에이전트: 설정 가능 (기본 10)
-- 코루틴 풀 크기: 설정 가능 (기본 8)
-- 타임아웃: 에이전트별 설정
-
-### 3. 모니터링
-
-- 실행 시간 추적
-- 메모리 사용량
-- CPU 사용률
-- 스레드 풀 상태
-
----
-
-## 🎯 사용 사례
-
-### 1. 코드 리뷰
-
-여러 AI가 다양한 관점에서 코드 리뷰:
-- 보안 검토
-- 성능 분석
-- 모범 사례 확인
-
-### 2. 의사결정 지원
-
-복잡한 문제에 대한 다각도 분석:
-- 여러 AI의 의견 수렴
-- 장단점 비교
-- 최적 솔루션 선택
-
-### 3. 콘텐츠 생성
-
-단계별 정제 과정:
-- 초안 생성
-- 검토 및 개선
-- 최종 최적화
-
-### 4. 데이터 분석
-
-병렬 데이터 처리:
-- 여러 각도에서 분석
-- 결과 종합
-- 인사이트 도출
-
----
-
-## 🚀 향후 계획
-
-### v1.1.0 (예정)
-
-- [ ] Resume 기능 완성
-- [ ] 웹 UI 고급 기능
-- [ ] 추가 템플릿
-- [ ] 성능 최적화
-
-### v1.2.0 (예정)
-
-- [ ] 클라우드 실행 지원
-- [ ] 고급 조건부 로직
-- [ ] 동적 파이프라인 생성
-- [ ] 더 많은 AI CLI 통합
-
-### v2.0.0 (장기)
-
-- [ ] 분산 실행
-- [ ] 머신러닝 통합
-- [ ] 고급 시각화
-- [ ] 엔터프라이즈 기능
-
----
-
-**마지막 업데이트**: 2025-11-27
-**버전**: 1.0.0
-**문서 유지관리**: AI Assistant
+- 기본 실행: 인자 없이 `cotor` → interactive 모드
+- 별칭: `cotor tui` (interactive alias)
+- 단축 안내: `cotor --short`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,212 +1,49 @@
-# Cotor 문서 인덱스
+# Cotor Docs Index
 
-**버전**: 1.0.0
-**최종 업데이트**: 2025-11-28
+코드 기준으로 현재 유효한 문서를 빠르게 찾기 위한 인덱스입니다.
 
----
+## 시작
 
-## 📖 시작하기
+- `README.md` / `README.ko.md`: 전체 개요
+- `QUICK_START.md`: 5분 시작 가이드
+- `USAGE_TIPS.md`: 실전 사용 팁
+- `cookbook.md`: 시나리오 모음
 
-### 빠른 시작
-- [README (영문)](../README.md) - 프로젝트 개요
-- [README (한글)](../README.ko.md) - 프로젝트 개요 (한글)
-- [Quick Start](QUICK_START.md) - 빠른 시작 가이드
-- [Usage Tips](USAGE_TIPS.md) - 사용 팁
-- [Cookbook](cookbook.md) - 실전 시나리오 파이프라인 모음
+## 기능/구조
 
-### 상세 가이드
-- [English Guide](README.md) - 영문 상세 가이드
-- [한글 가이드](README.ko.md) - 한글 상세 가이드
-- [Architecture](ARCHITECTURE.md) - 시스템 아키텍처 다이어그램
+- `FEATURES.md`: 최신 기능 요약
+- `ARCHITECTURE.md`: 구성/흐름
+- `CONDITION_DSL.md`: 조건식 DSL
+- `WEB_EDITOR.md`: 웹 편집기 사용법
 
----
+## 운영/업그레이드
 
-## 🎯 기능 및 사용법
+- `release/CHANGELOG.md`: 변경 이력
+- `UPGRADE_GUIDE.md`: 업그레이드 절차
+- `UPGRADE_RECOMMENDATIONS.md`: 권장안
 
-### 전체 기능
-- [**Features**](FEATURES.md) - 전체 기능 상세 목록 (550줄)
-  - 핵심 기능
-  - CLI 명령어 전체
-  - 템플릿 시스템
-  - 보안 기능
-  - 통합 방법
-  - 사용 사례
+## Claude 통합
 
-### Claude 통합
-- [Claude Setup](CLAUDE_SETUP.md) - Claude Code 통합 설정
+- `CLAUDE_SETUP.md`
+- `claude/cotor-knowledge.md`
+- `claude/commands/*.md`
 
----
+## 리포트
 
-## 🧪 테스트 및 검증
+- `reports/TEST_REPORT.md`
+- `reports/IMPLEMENTATION_SUMMARY.md`
+- `reports/IMPROVEMENTS.md`
 
-### 테스트 리포트
-- [**Live Test Results**](../test-results/LIVE_TEST_RESULTS.md) - 실제 실행 테스트 (14KB, 신규)
-  - 전역 설치 테스트
-  - 13개 명령어 실행 결과
-  - 실제 출력 캡처
-  - 성능 측정
+## 템플릿
 
-- [**Test Results Summary**](../test-results/README.md) - 테스트 요약 (3.4KB)
+- `templates/temp-cotor-template.md`
 
-- [**Feature Test Report v1.0.0**](reports/FEATURE_TEST_REPORT_v1.0.0.md) - 상세 기능 테스트 (400줄)
-  - 빌드 및 설치
-  - 모든 기능 검증
-  - 통합 테스트
-  - 프로덕션 준비도
+## 빠른 명령 참조
 
-- [Test Report](reports/TEST_REPORT.md) - 기존 테스트 리포트
-
----
-
-## 📋 릴리스 및 변경사항
-
-### 릴리스 노트
-- [Changelog](release/CHANGELOG.md) - 변경 이력
-- [Features v1.1](release/FEATURES_v1.1.md) - 향후 버전 계획
-
-### 업그레이드
-- [Upgrade Guide](UPGRADE_GUIDE.md) - 업그레이드 가이드
-- [Upgrade Recommendations](UPGRADE_RECOMMENDATIONS.md) - 업그레이드 권장사항
-
----
-
-## 📊 리포트 및 분석
-
-### 구현 리포트
-- [Implementation Summary](reports/IMPLEMENTATION_SUMMARY.md) - 구현 요약
-- [Implementation Complete](reports/IMPLEMENTATION_COMPLETE.md) - 구현 완료 상세
-- [Summary](reports/SUMMARY.md) - 전체 요약
-- [Improvements](reports/IMPROVEMENTS.md) - 개선 사항
-
-### 문서 리포트
-- [**Documentation Summary**](reports/DOCUMENTATION_SUMMARY.md) - 문서화 요약 (신규)
-  - 전체 문서 구조
-  - 신규 문서 목록
-  - 문서 통계
-  - 향후 계획
-
----
-
-## 📦 예제
-
-### 준비된 예제
-- [examples/single-agent.yaml](../examples/single-agent.yaml) - 단일 에이전트
-- [examples/parallel-compare.yaml](../examples/parallel-compare.yaml) - 병렬 비교
-- [examples/decision-loop.yaml](../examples/decision-loop.yaml) - 조건/루프
-- [examples/run-examples.sh](../examples/run-examples.sh) - 일괄 실행
-
----
-
-## 🛠️ 설치 및 스크립트
-
-### Shell 스크립트
-- [shell/install-global.sh](../shell/install-global.sh) - 전역 설치
-- [shell/install.sh](../shell/install.sh) - 로컬 설치
-- [shell/cotor](../shell/cotor) - CLI 실행 파일
-- [shell/install-claude-integration.sh](../shell/install-claude-integration.sh) - Claude 통합
-
-### 테스트 스크립트
-- [shell/test-cotor-enhanced.sh](../shell/test-cotor-enhanced.sh) - 향상된 테스트
-- [shell/test-cotor-pipeline.sh](../shell/test-cotor-pipeline.sh) - 파이프라인 테스트
-- [shell/test-claude-integration.sh](../shell/test-claude-integration.sh) - Claude 통합 테스트
-
----
-
-## 📚 문서 카테고리
-
-### 난이도별
-- **초급**: README, Quick Start, Usage Tips
-- **중급**: Features, Claude Setup, Examples
-- **고급**: Test Reports, Implementation Summary, Upgrade Guide
-
-### 목적별
-- **설치**: README, Quick Start, shell 스크립트
-- **사용**: Features, Usage Tips, Examples
-- **개발**: Test Reports, Implementation Summary
-- **통합**: Claude Setup, install-claude-integration.sh
-- **유지보수**: Upgrade Guide, Changelog
-
-### 언어별
-- **영문**: 15+ 문서
-- **한글**: README.ko.md, 한글 가이드, 주요 문서 한글 번역
-
----
-
-## 🔍 빠른 검색
-
-### "설치하고 싶어요"
-→ [README](../README.md) → [Quick Start](QUICK_START.md)
-
-### "기능이 궁금해요"
-→ [Features](FEATURES.md) → [Test Results](../test-results/LIVE_TEST_RESULTS.md)
-
-### "실제로 작동하나요?"
-→ [**Live Test Results**](../test-results/LIVE_TEST_RESULTS.md) - 실제 실행 결과!
-
-### "어떻게 사용하나요?"
-→ [Usage Tips](USAGE_TIPS.md) → [Examples](../examples/)
-
-### "Claude와 연동하려면?"
-→ [Claude Setup](CLAUDE_SETUP.md)
-
-### "업그레이드하고 싶어요"
-→ [Upgrade Guide](UPGRADE_GUIDE.md) → [Changelog](release/CHANGELOG.md)
-
----
-
-## 📊 문서 통계
-
-- **총 문서 수**: 25+
-- **신규 작성**: 6 (Features, Test Reports, Documentation Summary 등)
-- **업데이트**: 2 (README.md, README.ko.md)
-- **언어**: 영문 + 한글
-- **총 라인 수**: 약 3,000줄
-
----
-
-## 🎯 추천 읽기 순서
-
-### 처음 사용자
-1. [README](../README.md)
-2. [Quick Start](QUICK_START.md)
-3. [Live Test Results](../test-results/LIVE_TEST_RESULTS.md) ← **실제 동작 확인!**
-4. [Examples](../examples/)
-
-### 고급 사용자
-1. [Features](FEATURES.md)
-2. [Feature Test Report](reports/FEATURE_TEST_REPORT_v1.0.0.md)
-3. [Usage Tips](USAGE_TIPS.md)
-4. [Claude Setup](CLAUDE_SETUP.md)
-
-### 개발자
-1. [Implementation Summary](reports/IMPLEMENTATION_SUMMARY.md)
-2. [Test Reports](reports/)
-3. [Documentation Summary](reports/DOCUMENTATION_SUMMARY.md)
-4. [Upgrade Guide](UPGRADE_GUIDE.md)
-
----
-
-## 🆕 최신 추가 문서
-
-**2025-11-28 추가**:
-- ✨ [Live Test Results](../test-results/LIVE_TEST_RESULTS.md) - 실제 실행 테스트 (14KB)
-- ✨ [Test Results Summary](../test-results/README.md) - 빠른 확인용
-- ✨ [Features](FEATURES.md) - 전체 기능 상세 (550줄)
-- ✨ [Feature Test Report](reports/FEATURE_TEST_REPORT_v1.0.0.md) - 체계적 테스트 (400줄)
-- ✨ [Documentation Summary](reports/DOCUMENTATION_SUMMARY.md) - 문서화 현황
-- ✨ [INDEX](INDEX.md) - 본 문서
-
----
-
-## 📞 도움이 필요하신가요?
-
-- 📧 Email: support@cotor.io
-- 💬 Discord: [커뮤니티](https://discord.gg/cotor)
-- 🐛 Issues: [GitHub](https://github.com/yourusername/cotor/issues)
-- 📖 Wiki: [문서](https://github.com/yourusername/cotor/wiki)
-
----
-
-**마지막 업데이트**: 2025-11-28
-**문서 버전**: 1.0.0
-**상태**: ✅ 완료
+```bash
+cotor --short
+cotor --help
+cotor template --list
+cotor doctor
+cotor stats
+```

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,358 +1,92 @@
-# Cotor Quick Start Guide
+# Cotor Quick Start
 
-Get up and running with Cotor in 5 minutes!
+5분 안에 Cotor 파이프라인을 실행하는 최소 경로입니다.
 
 ## 10줄 요약
+
 1. `./shell/install-global.sh` 또는 `./gradlew shadowJar && ./shell/cotor version`
-2. `cotor init` (또는 `cotor init --interactive`)
-3. `cotor list` 로 에이전트 확인
-4. `cotor template` 으로 YAML 예제 만들기
-5. `cotor plugin init my-plugin` 으로 Kotlin 플러그인 스캐폴딩 생성
-6. `cotor validate <pipeline> -c <yaml>`
-7. `cotor run <pipeline> -c <yaml> --output-format text`
-8. `cotor dash -c <yaml>` TUI, `cotor web` 웹 UI
-9. 예제: `examples/run-examples.sh`
-10. 점검: `cotor doctor`, 문제시 `--debug` 또는 docs/README*, Claude 연동: `./shell/install-claude-integration.sh`
+2. `cotor init --interactive`
+3. `cotor template --list`
+4. `cotor template compare my-pipeline.yaml --fill prompt="Write tests"`
+5. `cotor validate compare-solutions -c my-pipeline.yaml`
+6. `cotor run compare-solutions -c my-pipeline.yaml --dry-run`
+7. `cotor run compare-solutions -c my-pipeline.yaml --output-format text`
+8. `cotor stats`
+9. `cotor doctor`
+10. `cotor dash -c my-pipeline.yaml` 또는 `cotor web`
 
 ## Prerequisites
 
-- Java 17 or higher
-- At least one AI CLI tool installed (Claude, Gemini, Copilot, etc.)
+- Java 17+
+- 사용하려는 AI CLI(claude, gemini, codex, copilot 등)
 
-## Installation
-
-### Option 1: Quick Install (Recommended)
+## 설치
 
 ```bash
 git clone https://github.com/yourorg/cotor.git
 cd cotor
 ./gradlew shadowJar
 chmod +x shell/cotor
+./shell/cotor version
 ```
 
-### Option 2: Global Install
+## 첫 파이프라인 만들기
+
+### 1) 템플릿 생성
 
 ```bash
-./shell/install-global.sh
+cotor template compare my-pipeline.yaml --fill prompt="Summarize Kotlin coroutines"
 ```
 
-This makes `cotor` available system-wide.
-
-## Your First Pipeline
-
-### Step 1: Create a Configuration File
+### 2) 유효성 검사
 
 ```bash
-cat > my-pipeline.yaml << 'EOF'
-version: "1.0"
-
-agents:
-  - name: claude
-    pluginClass: com.cotor.data.plugin.ClaudePlugin
-    timeout: 60000
-
-pipelines:
-  - name: hello-world
-    description: "My first cotor pipeline"
-    executionMode: SEQUENTIAL
-    stages:
-      - id: greeting
-        agent:
-          name: claude
-        input: "Say hello and introduce yourself"
-
-security:
-  useWhitelist: true
-  allowedExecutables:
-    - claude
-  allowedDirectories:
-    - /usr/local/bin
-    - /opt/homebrew/bin
-EOF
+cotor validate compare-solutions -c my-pipeline.yaml
 ```
 
-### Step 2: Validate the Pipeline
+### 3) 드라이런 (예상 시간/흐름 확인)
 
 ```bash
-java -jar build/libs/cotor-1.0.0-all.jar validate hello-world -c my-pipeline.yaml
+cotor run compare-solutions -c my-pipeline.yaml --dry-run
 ```
 
-**Expected output:**
-```
-✅ Pipeline structure: valid
-✅ All agents defined: valid
-✅ Stage dependencies: valid
-
-🎉 No warnings found!
-```
-
-### Step 3: Dry-Run (Optional)
-
-Test without actually running:
+### 4) 실제 실행
 
 ```bash
-java -jar build/libs/cotor-1.0.0-all.jar run hello-world --dry-run -c my-pipeline.yaml
+cotor run compare-solutions -c my-pipeline.yaml --watch --output-format text
 ```
 
-**Expected output:**
-```
-📋 Pipeline Estimate: hello-world
-   Execution Mode: SEQUENTIAL
-
-Stages:
-  ├─ greeting (claude)
-  │  └─ ~30s
-
-⏱️  Total Estimated Duration: ~30s
-```
-
-### Step 4: Run the Pipeline
+## 자주 쓰는 명령
 
 ```bash
-java -jar build/libs/cotor-1.0.0-all.jar run hello-world -c my-pipeline.yaml --verbose
+cotor list -c my-pipeline.yaml
+cotor status
+cotor stats
+cotor stats compare-solutions
+cotor checkpoint gc --dry-run
+cotor resume <checkpoint-id> -c my-pipeline.yaml
+cotor lint my-pipeline.yaml
+cotor explain my-pipeline.yaml compare-solutions
 ```
 
-**What you'll see:**
-
-```
-🚀 Running: hello-world (1 stages)
-┌──────────────────────────────────────────────┐
-│ 🔄 Stage 1: greeting                         │
-└──────────────────────────────────────────────┘
-⏱️  Elapsed: 00:00:15 | Progress: 0% (0/1 stages completed)
-
-... (pipeline executes) ...
-
-📊 Pipeline Execution Summary
-──────────────────────────────────────────────
-Pipeline: hello-world
-Execution Mode: SEQUENTIAL
-
-Results:
-  ✅ Completed: 1/1
-  ⏱️  Total Duration: 15.2s
-──────────────────────────────────────────────
-
-📄 Results:
-{
-  "summary": {
-    "totalAgents": 1,
-    "successCount": 1,
-    "failureCount": 0
-  },
-  "results": [
-    {
-      "agentName": "claude",
-      "isSuccess": true,
-      "output": "Hello! I'm Claude..."
-    }
-  ]
-}
-```
-
-## Next Steps
-
-### Try Multi-Agent Pipelines
-
-Create a pipeline with multiple AI agents:
-
-```yaml
-version: "1.0"
-
-agents:
-  - name: claude
-    pluginClass: com.cotor.data.plugin.ClaudePlugin
-    timeout: 60000
-  - name: gemini
-    pluginClass: com.cotor.data.plugin.GeminiPlugin
-    timeout: 60000
-
-pipelines:
-  - name: compare-solutions
-    description: "Get multiple perspectives"
-    executionMode: PARALLEL  # Run simultaneously!
-    stages:
-      - id: claude-solution
-        agent:
-          name: claude
-        input: "Write a Python function to reverse a string"
-
-      - id: gemini-solution
-        agent:
-          name: gemini
-        input: "Write a Python function to reverse a string"
-
-security:
-  useWhitelist: true
-  allowedExecutables:
-    - claude
-    - gemini
-  allowedDirectories:
-    - /usr/local/bin
-    - /opt/homebrew/bin
-```
-
-Run it:
+## 에이전트/플러그인 관리
 
 ```bash
-java -jar build/libs/cotor-1.0.0-all.jar run compare-solutions -c my-pipeline.yaml
+cotor agent add claude --yes
+cotor agent list
+cotor plugin list
+cotor plugin validate
+cotor plugin init my-plugin
 ```
 
-You'll get 2 different implementations simultaneously!
+## 문제 해결
 
-### Try Sequential Pipelines
+- 환경 점검: `cotor doctor`
+- 상세 에러 확인: 명령 뒤에 `--debug`
+- 빠른 도움말: `cotor --short`, `cotor --help`
 
-Create a pipeline where output flows through stages:
+## 다음 단계
 
-```yaml
-pipelines:
-  - name: code-review-chain
-    description: "Generate → Review → Optimize"
-    executionMode: SEQUENTIAL  # Output feeds to next stage
-    stages:
-      - id: generate
-        agent:
-          name: claude
-        input: "Create a simple REST API endpoint"
-
-      - id: review
-        agent:
-          name: gemini
-        # Input will be Claude's output
-
-      - id: optimize
-        agent:
-          name: claude
-        # Input will be Gemini's reviewed code
-```
-
-### Test with the Board Example
-
-Try the complete board implementation example:
-
-```bash
-cd test/board-feature
-java -jar ../../build/libs/cotor-1.0.0-all.jar validate board-implementation -c board-pipeline.yaml
-java -jar ../../build/libs/cotor-1.0.0-all.jar run board-implementation --dry-run -c board-pipeline.yaml
-```
-
-## Troubleshooting
-
-### Error: "Configuration file not found"
-
-Make sure you're in the correct directory:
-
-```bash
-ls -la my-pipeline.yaml  # Should exist
-pwd  # Check current directory
-```
-
-### Error: "Agent not found"
-
-Make sure the AI CLI is installed:
-
-```bash
-which claude  # Should show path
-claude --version  # Should work
-```
-
-Add the path to your security whitelist in the YAML file.
-
-### Error: "Pipeline validation failed"
-
-Run validation to see specific errors:
-
-```bash
-java -jar build/libs/cotor-1.0.0-all.jar validate <pipeline-name> -c <config-file>
-```
-
-Fix the reported errors and try again.
-
-## Common Patterns
-
-### Pattern 1: Compare Multiple Solutions
-
-```yaml
-executionMode: PARALLEL
-stages:
-  - id: solution-1
-    agent: { name: claude }
-    input: "<same problem>"
-  - id: solution-2
-    agent: { name: gemini }
-    input: "<same problem>"
-```
-
-### Pattern 2: Sequential Processing
-
-```yaml
-executionMode: SEQUENTIAL
-stages:
-  - id: step-1
-    agent: { name: claude }
-    input: "<initial input>"
-  - id: step-2
-    agent: { name: gemini }
-    # Automatically uses step-1 output
-```
-
-### Pattern 3: Multi-Perspective Review
-
-```yaml
-executionMode: PARALLEL
-stages:
-  - id: security-review
-    agent: { name: claude }
-    input: "Review for security: <code>"
-  - id: performance-review
-    agent: { name: gemini }
-    input: "Review for performance: <code>"
-```
-
-## Best Practices
-
-1. **Always Validate First**
-   ```bash
-   cotor validate <pipeline> -c <config>
-   ```
-
-2. **Use Dry-Run for Estimates**
-   ```bash
-   cotor run <pipeline> --dry-run -c <config>
-   ```
-
-3. **Enable Verbose Mode for Debugging**
-   ```bash
-   cotor run <pipeline> --verbose -c <config>
-   ```
-
-4. **Set Appropriate Timeouts**
-   - Simple tasks: 30-60 seconds
-   - Complex tasks: 120-240 seconds
-   - Long-running: 300+ seconds
-
-5. **Use PARALLEL for Independence**
-   - When tasks don't depend on each other
-   - When you want multiple perspectives
-   - When speed matters
-
-6. **Use SEQUENTIAL for Dependencies**
-   - When output feeds to next stage
-   - When order matters
-   - When building on previous results
-
-## Need Help?
-
-- **Documentation**: [docs/](../docs/)
-- **Examples**: [examples/](../examples/)
-- **Upgrade Guide**: [docs/UPGRADE_GUIDE.md](./UPGRADE_GUIDE.md)
-- **Issues**: [GitHub Issues](https://github.com/yourorg/cotor/issues)
-
-## What's Next?
-
-1. Read the [Upgrade Guide](./UPGRADE_GUIDE.md) for advanced features
-2. Check out [example pipelines](../examples/)
-3. Create your own custom plugins
-4. Integrate with CI/CD pipelines
-
-Happy orchestrating! 🎉
+- 다양한 템플릿: `docs/FEATURES.md`
+- 실전 예제: `examples/`
+- 아키텍처: `docs/ARCHITECTURE.md`

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -3,7 +3,7 @@
 [![English](https://img.shields.io/badge/Language-English-blue)](README.md)
 [![한국어](https://img.shields.io/badge/Language-한국어-red)](README.ko.md)
 
-여러 AI 에이전트를 하나의 CLI로 오케스트레이션하는 Kotlin 기반 도구입니다. 실시간 모니터링, 검증, 웹/TUI 대시보드를 제공합니다.
+Cotor는 Kotlin 기반 CLI/TUI 오케스트레이터로, 여러 AI 에이전트 파이프라인의 검증·실행·모니터링·복구를 한 도구에서 제공합니다.
 
 ## 빠른 설치
 
@@ -13,92 +13,58 @@ cd cotor
 ./shell/install-global.sh
 ```
 
-로컬 전용(심볼릭 링크 없이):
+로컬 전용 실행:
 ```bash
 ./gradlew shadowJar
 chmod +x shell/cotor
 ./shell/cotor version
 ```
 
-Claude Code 통합:
-```bash
-./shell/install-claude-integration.sh
-```
-
-## 바로 사용하기
+## 바로 쓰는 명령
 
 ```bash
-cotor                              # 기본 interactive TUI 실행
-cotor init                         # cotor.yaml 생성
-cotor list                         # 등록된 에이전트 확인
+cotor                            # 기본 interactive 모드 실행
+cotor --short                    # 10줄 치트시트
+cotor init --interactive         # 대화형 초기 설정
+cotor list -c cotor.yaml         # 등록 에이전트 확인
 cotor validate <pipeline> -c <yaml>
+cotor run <pipeline> -c <yaml> --dry-run
 cotor run <pipeline> -c <yaml> --output-format text
-cotor template                     # 내장 템플릿 목록
-cotor dash -c <yaml>               # TUI 대시보드
-cotor tui                          # `cotor interactive` 별칭
-cotor web                          # 웹 파이프라인 스튜디오 실행
-cotor completion zsh|bash|fish     # 쉘 자동완성
-alias co="cotor"                   # 짧은 별칭
+cotor template --list            # 내장 템플릿 목록
+cotor agent add claude --yes     # .cotor/agents 프리셋 추가
+cotor plugin list                # 플러그인 메타데이터 확인
+cotor stats                      # 실행 통계
+cotor doctor                     # 환경 점검
+cotor dash -c <yaml>             # Codex 스타일 대시보드
+cotor web                        # 웹 파이프라인 스튜디오
 ```
 
-### 바로 실행 가능한 예제
-- `examples/single-agent.yaml` – 단일 에이전트 Hello
-- `examples/parallel-compare.yaml` – 병렬 비교
-- `examples/decision-loop.yaml` – 조건/루프
-- `examples/run-examples.sh` – 예제 일괄 실행
+## 현재 CLI 명령 체계
 
-## 핵심 포인트
+기본 서브커맨드:
+`init`, `list`, `run`, `validate`, `test`, `template`, `resume`, `checkpoint`, `stats`, `doctor`, `status`, `dash`, `interactive`, `web`, `lint`, `explain`, `plugin`, `agent`, `version`, `completion`
 
-- 순차/병렬/DAG를 아우르는 코루틴 기반 비동기 실행
-- 의사결정/루프 스테이지, 체크포인트, 복구 전략 지원
-- 타임라인 모니터와 요약, 결과 집계
-- YAML 친화적 설정 + 검증/구문 체크
-- 웹 대시보드와 CLI/TUI 실행 환경
+## 핵심 기능
 
-## 문서 맵
+- 순차/병렬/DAG 실행 및 스테이지 의존성 처리
+- 조건(분기)·루프 스테이지 지원
+- 실행 타임라인 수집 + watch 모니터링
+- 체크포인트 저장/재개 및 체크포인트 정리
+- 결과 출력 포맷(`json`, `csv`, `text`)
+- 템플릿 생성 (`compare`, `chain`, `review`, `consensus`, `fanout`, `selfheal`, `verified`, `custom`)
+- 에이전트 프리셋 관리, 플러그인 점검
 
-- 개요: `README.md` · `README.ko.md`
-- 업그레이드: `UPGRADE_GUIDE.md` · `UPGRADE_RECOMMENDATIONS.md`
-- 릴리스: `release/CHANGELOG.md` · `release/FEATURES_v1.1.md`
-- 리포트: `reports/TEST_REPORT.md` · `reports/IMPLEMENTATION_SUMMARY.md`
+## 문서 안내
+
 - 빠른 시작: `QUICK_START.md`
 - 아키텍처: `ARCHITECTURE.md`
-- Claude 설정: `CLAUDE_SETUP.md`
-- Claude Code 통합: `shell/install-claude-integration.sh`
+- 기능 목록: `FEATURES.md`
 - 사용 팁: `USAGE_TIPS.md`
-- 템플릿: `templates/`
-- 기여 규칙 + 한/영 동기화 체크리스트: `../CONTRIBUTING.md`
+- 변경 이력: `release/CHANGELOG.md`
+- 리포트: `reports/`
+- Claude 연동: `CLAUDE_SETUP.md`, `claude/`
 
-## 점검하기
+## 참고
 
-```bash
-./gradlew test
-./shell/cotor version
-```
-
-선택적 스모크 테스트(레포 루트에서 실행):
-```bash
-./shell/test-cotor-enhanced.sh
-./shell/test-cotor-pipeline.sh
-./shell/test-claude-integration.sh
-```
-
-10줄 치트시트가 필요하면 `cotor --short` 를 실행하세요.
-
-## 실행 스크립트
-
-- `./shell/cotor` – CLI 엔트리포인트(그레이들 빌드 자동 트리거)
-- `./shell/install-global.sh` – 빌드 후 전역 설치(심볼릭 링크)
-- `./shell/install.sh` – 로컬 설치 + alias 안내
-- `./shell/install-claude-integration.sh` – Claude Code 명령/지식 베이스 설치
-- `./shell/test-*` – 스모크/통합 테스트 스크립트
-
-## 필요한 AI CLI 설치
-
-필요한 제공자별로 설치하세요:
-```bash
-# Claude CLI (npm)
-# Copilot CLI
-# Gemini / OpenAI / 기타
-pip install openai
-```
+- `--config`를 생략하면 대부분 `cotor.yaml`을 기본으로 사용합니다.
+- 인자 없이 `cotor`를 실행하면 interactive 모드가 시작됩니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 [![English](https://img.shields.io/badge/Language-English-blue)](README.md)
 [![한국어](https://img.shields.io/badge/Language-한국어-red)](README.ko.md)
 
-Kotlin-based CLI for orchestrating multi-agent AI pipelines with realtime monitoring, validation, and dashboards.
+Cotor is a Kotlin-based CLI/TUI tool for orchestrating AI-agent pipelines with validation, timeline monitoring, checkpoints, and recovery.
 
 ## Quick Install
 
@@ -13,92 +13,58 @@ cd cotor
 ./shell/install-global.sh
 ```
 
-Local-only (no symlink):
+Local-only setup:
 ```bash
 ./gradlew shadowJar
 chmod +x shell/cotor
 ./shell/cotor version
 ```
 
-Claude Code integration (slash commands + knowledge base):
-```bash
-./shell/install-claude-integration.sh
-```
-
 ## Use It Fast
 
 ```bash
-cotor                              # launch interactive TUI (default)
-cotor init                         # create cotor.yaml
-cotor list                         # view registered agents
+cotor                            # launch interactive mode (default)
+cotor --short                    # 10-line cheat sheet
+cotor init --interactive         # interactive bootstrap
+cotor list -c cotor.yaml         # list registered agents
 cotor validate <pipeline> -c <yaml>
+cotor run <pipeline> -c <yaml> --dry-run
 cotor run <pipeline> -c <yaml> --output-format text
-cotor template                     # list built-in templates
-cotor dash -c <yaml>               # TUI dashboard
-cotor tui                          # alias of `cotor interactive`
-cotor web                          # launch web pipeline studio
-cotor completion zsh|bash|fish     # shell autocompletion
-alias co="cotor"                   # faster typing
+cotor template --list            # list built-in templates
+cotor agent add claude --yes     # create .cotor/agents preset
+cotor plugin list                # inspect plugin metadata
+cotor stats                      # pipeline statistics
+cotor doctor                     # environment diagnostics
+cotor dash -c <yaml>             # codex-style dashboard
+cotor web                        # web pipeline studio
 ```
 
-### Ready-to-run examples
-- `examples/single-agent.yaml` – 단일 에이전트 Hello
-- `examples/parallel-compare.yaml` – 병렬 비교
-- `examples/decision-loop.yaml` – 조건/루프
-- `examples/run-examples.sh` – 위 3개를 한 번에 실행
+## Command Surface (current)
+
+Primary subcommands: `init`, `list`, `run`, `validate`, `test`, `template`, `resume`, `checkpoint`, `stats`, `doctor`, `status`, `dash`, `interactive`, `web`, `lint`, `explain`, `plugin`, `agent`, `version`, `completion`.
 
 ## Core Highlights
 
-- Coroutine-based async execution across sequential, parallel, and DAG flows
-- Decision/loop stages, checkpoints, and recovery strategies
-- Timeline monitor with summaries and aggregated outputs
-- YAML-friendly configs with validation and syntax checks
-- Web dashboard + CLI/TUI for discovery and execution
+- Sequential / Parallel / DAG orchestration with stage dependencies
+- Decision and loop stage execution support
+- Real-time timeline collection + watch mode monitoring
+- Checkpoint save/resume and checkpoint garbage collection
+- Output formatting in `json`, `csv`, `text`
+- Template generation (`compare`, `chain`, `review`, `consensus`, `fanout`, `selfheal`, `verified`, `custom`)
+- Agent preset management and plugin metadata inspection
 
 ## Docs Map
 
-- Overview: `README.md` (this file) · `README.ko.md`
-- Upgrades: `UPGRADE_GUIDE.md` · `UPGRADE_RECOMMENDATIONS.md`
-- Releases: `release/CHANGELOG.md` · `release/FEATURES_v1.1.md`
-- Reports: `reports/TEST_REPORT.md` · `reports/IMPLEMENTATION_SUMMARY.md`
+- Korean guide: `README.ko.md`
 - Quick start: `QUICK_START.md`
 - Architecture: `ARCHITECTURE.md`
-- Claude setup: `CLAUDE_SETUP.md`
-- Claude Code integration: `shell/install-claude-integration.sh`
+- Features: `FEATURES.md`
 - Usage tips: `USAGE_TIPS.md`
-- Templates: `templates/`
-- Contribution rule + EN/KR sync checklist: `../CONTRIBUTING.md`
+- Changelog: `release/CHANGELOG.md`
+- Reports: `reports/`
+- Claude integration docs: `CLAUDE_SETUP.md`, `claude/`
 
-## Run Checks
+## Notes
 
-```bash
-./gradlew test
-./shell/cotor version
-```
-
-Optional smoke scripts (from repo root):
-```bash
-./shell/test-cotor-enhanced.sh
-./shell/test-cotor-pipeline.sh
-./shell/test-claude-integration.sh
-```
-
-Need a 10-line cheat sheet? Run `cotor --short`.
-
-## Shell Scripts
-
-- `./shell/cotor` – CLI entrypoint (builds the shaded JAR if missing)
-- `./shell/install-global.sh` – build + global install (symlink)
-- `./shell/install.sh` – local install with alias instructions
-- `./shell/install-claude-integration.sh` – Claude Code commands/knowledge base
-- `./shell/test-*` – smoke and integration checks
-
-## Need AI CLIs?
-
-Install per provider as needed:
-```bash
-# Claude CLI (npm)
-# Copilot CLI
-# Gemini / OpenAI / others
-pip install openai
-```
+- If config is omitted, most commands use `cotor.yaml` by default.
+- Running `cotor` with no args starts interactive mode; passing an unknown first argument runs simple direct pipeline execution.


### PR DESCRIPTION
### Motivation

- The repository documentation had grown out-of-sync with the current CLI implementation and examples, causing confusion for users following Quick Start flows. 
- The CLI now exposes additional operational commands and flags (e.g. `--dry-run`, `--watch`, `--output-format`, `template --fill`, `agent`, `plugin`, `doctor`, `stats`, `dash`, `web`) which should be reflected in the docs. 

### Description

- Rewrote `docs/README.md` (EN) and `docs/README.ko.md` (KR) to reflect the current command surface and recommended workflows including interactive bootstrapping and new operational commands. 
- Rewrote `docs/QUICK_START.md` to provide a minimal, up-to-date 4-step flow that uses `cotor template --fill`, `cotor validate`, `cotor run --dry-run`, and `cotor run --watch --output-format text`. 
- Slimmed and modernized `docs/FEATURES.md` to be a concise, code-aligned feature summary (execution modes, validation, monitoring/checkpoints, templates, security, output formats). 
- Simplified `docs/INDEX.md` to list the current, relevant docs and make navigation consistent with the implemented code. 
- Adjusted examples and command samples across the updated docs to reference the CLI flags and subcommands implemented in `Main.kt` and the command classes. 

### Testing

- Performed a whitespace/conflict marker check with `git diff --check`, which passed. 
- Performed a static scan of the codebase to ensure referenced subcommands and flags exist in the CLI classes under `src/main/kotlin/com/cotor/presentation/cli`. 
- Attempted to run the wrapper smoke command `./shell/cotor --help`, but runtime execution could not be completed in this environment due to a missing Gradle wrapper runtime class (`org.gradle.wrapper.GradleWrapperMain`). 
- No unit tests were modified as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7838c14048333bfa54eef7b040f58)