### PR TITLE
docs: add `cotor lint` guidance and CI/lint guardrails to Claude docs

### DIFF
--- a/docs/CLAUDE_SETUP.md
+++ b/docs/CLAUDE_SETUP.md
@@ -384,3 +384,20 @@ rm -rf ~/.claude/settings/cotor-settings.json
 1. [GitHub Issues](https://github.com/yourusername/cotor/issues)에 문제 보고
 2. 테스트 스크립트 결과 첨부: `./test-claude-integration.sh > test-results.txt`
 3. 파일 구조 첨부: `ls -laR ~/.claude/ > file-structure.txt`
+
+## CI/린트 가드레일
+
+새로운 CI 기준으로 아래 두 명령이 기본 게이트입니다.
+
+```bash
+gradle formatCheck
+gradle test
+```
+
+파이프라인 YAML을 생성/수정하는 슬래시 명령(`/cotor-generate`, `/cotor-template`)을 썼다면 실행 전에 아래를 권장합니다.
+
+```bash
+cotor validate <pipeline.yaml>
+cotor lint <pipeline.yaml>
+```
+

--- a/docs/claude/commands/cotor-execute.md
+++ b/docs/claude/commands/cotor-execute.md
@@ -17,9 +17,11 @@ category: cotor
 ## 동작
 
 1. 파이프라인 파일 경로 확인
-2. `cotor execute [파일] --monitor` 실행
-3. 실행 출력 실시간 스트리밍
-4. 완료 시 최종 상태 및 결과 표시
+2. `cotor validate [파일]`로 사전 검증
+3. `cotor lint [파일]`로 정적 린트 확인
+4. `cotor execute [파일] --monitor` 실행
+5. 실행 출력 실시간 스트리밍
+6. 완료 시 최종 상태 및 결과 표시
 
 ## 예시
 

--- a/docs/claude/commands/cotor-generate.md
+++ b/docs/claude/commands/cotor-generate.md
@@ -112,3 +112,19 @@ security:
 
 - `/cotor-execute`: 파이프라인 실행
 
+
+## 생성 후 권장 체크
+
+생성 직후에는 아래 순서로 검증합니다.
+
+```bash
+cotor validate [생성된 파일]
+cotor lint [생성된 파일]
+```
+
+코드까지 수정했다면 CI 규칙에 맞춰 아래도 실행합니다.
+
+```bash
+gradle formatCheck
+gradle test
+```

--- a/docs/claude/commands/cotor-validate.md
+++ b/docs/claude/commands/cotor-validate.md
@@ -18,7 +18,8 @@ category: cotor
 
 1. 파이프라인 파일 경로 확인
 2. `cotor validate [파일]` 실행
-3. 검증 결과 표시
+3. `cotor lint [파일]` 실행
+4. 검증/린트 결과 표시
 
 ## 예시
 
@@ -31,3 +32,4 @@ category: cotor
 - `/cotor-generate`: 파이프라인 생성
 - `/cotor-execute`: 검증 후 실행
 - `/cotor-template`: 검증된 템플릿 사용
+- `cotor lint`: 정적 린트 점검

--- a/docs/claude/cotor-knowledge.md
+++ b/docs/claude/cotor-knowledge.md
@@ -74,6 +74,19 @@ cotor validate <pipeline-file>
 cotor validate pipeline.yaml
 ```
 
+### cotor lint
+파이프라인 YAML 파일에 대한 정적 린트를 수행합니다.
+
+**구문:**
+```bash
+cotor lint <pipeline-file>
+```
+
+**예시:**
+```bash
+cotor lint pipeline.yaml
+```
+
 ### cotor run
 파이프라인을 실행합니다 (전통적인 방식).
 
@@ -106,6 +119,24 @@ cotor list [--config <config-file>]
 ```bash
 cotor init
 ```
+
+## CI/린트 규칙 (중요)
+
+새로운 CI에서는 아래 순서가 기본 게이트입니다.
+
+1. `gradle formatCheck`
+2. `gradle test`
+
+AI가 코드 변경을 제안하거나 생성할 때는 아래 체크리스트를 우선 적용합니다.
+
+- Kotlin/Gradle 변경 시:
+  - `gradle format`으로 포맷 적용 후 `gradle formatCheck` 재검증
+  - `gradle test` 실행
+- 파이프라인 YAML 변경 시:
+  - `cotor validate <file>`
+  - `cotor lint <file>`
+
+CI 실패를 줄이기 위해 포맷/테스트/린트 명령을 먼저 제안하고, 실패 시 해당 명령의 출력에 근거해 수정합니다.
 
 ## 파이프라인 생성 규칙
 


### PR DESCRIPTION
### Motivation
- Align AI-facing documentation with the repository's CI and lint rules so generated or suggested changes follow the same preflight checks. 
- Encourage slash-commands and UI flows to perform validation and static linting before execution to reduce CI breakage. 
- Provide clear, repeatable guardrails for users installing Claude command/knowledge files so they run the same `format`/`test` checks used by CI. 

### Description
- Added `cotor lint` usage and examples to `docs/claude/cotor-knowledge.md` to document the new static lint command. 
- Updated `docs/claude/commands/cotor-validate.md` to include a `cotor lint` step so validation flows run both `validate` and `lint`. 
- Updated `docs/claude/commands/cotor-execute.md` to recommend pre-run `cotor validate` and `cotor lint` before `cotor execute`. 
- Added a "post-generation" verification section to `docs/claude/commands/cotor-generate.md` recommending `cotor validate`, `cotor lint`, and CI commands (`gradle formatCheck` / `gradle test`). 
- Added a CI/lint guardrail section to `docs/CLAUDE_SETUP.md` describing the CI gate order (`gradle formatCheck` then `gradle test`) and recommended checks for YAML/code changes. 

### Testing
- Ran `gradle formatCheck` with the system Gradle and it completed successfully (BUILD SUCCESSFUL). 
- Attempted `./gradlew formatCheck` with the project wrapper which failed due to a missing `org.gradle.wrapper.GradleWrapperMain` class. 
- Ran `gradle test` which executed the test suite but failed due to an existing test failure: `TemplateEngineTest > should interpolate environment variables()` (105 tests, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7927ecd7c8333b0ad4d087f321db6)