### PR TITLE
Handle null parent when resolving .cotor directory and guard isDirectory check

### DIFF
--- a/src/main/kotlin/com/cotor/data/config/ConfigRepository.kt
+++ b/src/main/kotlin/com/cotor/data/config/ConfigRepository.kt
@@ -34,9 +34,10 @@ class FileConfigRepository(
 
     override suspend fun loadConfig(path: Path): CotorConfig = withContext(Dispatchers.IO) {
         val baseConfig = parseConfig(path)
-        val cotorDir = path.parent?.resolve(".cotor")
+        val configDir = path.toAbsolutePath().parent ?: java.nio.file.Paths.get(".").toAbsolutePath()
+        val cotorDir = configDir.resolve(".cotor")
 
-        if (cotorDir == null || !cotorDir.isDirectory()) {
+        if (!cotorDir.isDirectory()) {
             return@withContext baseConfig.config
         }
 


### PR DESCRIPTION
### Motivation

- Prevent a null-parent crash and reliably locate the repository `.cotor` overrides directory when the provided config `Path` has no parent or is relative. 

### Description

- Compute `configDir` from `path.toAbsolutePath().parent ?: java.nio.file.Paths.get(".").toAbsolutePath()` and resolve `.cotor` against that directory. 
- Replace the previous `path.parent?.resolve(".cotor")` approach and remove the nullable `cotorDir` branch to simplify the existence check. 
- Keep the existing override-loading behavior which walks and merges YAML override files from the resolved `.cotor` directory. 
- Change is limited to `src/main/kotlin/com/cotor/data/config/ConfigRepository.kt` and does not alter parsing or merge logic. 

### Testing

- Ran unit tests with `./gradlew test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8efd893408333add3e5aa35edb7f5)