### PR TITLE
Fix interactive :model tab completion replacement behavior

### DIFF
--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleter.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleter.kt
@@ -12,11 +12,28 @@ class InteractiveCommandCompleter(
     private val modeValues = listOf("auto", "compare", "single")
 
     override fun complete(reader: LineReader?, line: ParsedLine, candidates: MutableList<Candidate>) {
-        val suggestions = suggest(line.line(), line.cursor())
-        suggestions.forEach { candidates += Candidate(it) }
+        val values = completionValues(line.line(), line.cursor())
+        values.forEach { candidates += Candidate(it) }
     }
 
     fun suggest(input: String, cursor: Int = input.length): List<String> {
+        val values = completionValues(input, cursor)
+        val safeCursor = cursor.coerceIn(0, input.length)
+        val uptoCursor = input.substring(0, safeCursor)
+        if (!uptoCursor.startsWith(":")) return emptyList()
+
+        val raw = uptoCursor.removePrefix(":")
+        if (!raw.contains(" ")) return values
+
+        val command = raw.substringBefore(" ").lowercase()
+        return when (command) {
+            "mode", "use", "model" -> values.map { ":$command $it" }
+            "include" -> values.map { ":include $it" }
+            else -> emptyList()
+        }
+    }
+
+    private fun completionValues(input: String, cursor: Int): List<String> {
         val safeCursor = cursor.coerceIn(0, input.length)
         val uptoCursor = input.substring(0, safeCursor)
         if (!uptoCursor.startsWith(":")) return emptyList()
@@ -34,21 +51,19 @@ class InteractiveCommandCompleter(
         val arg = raw.substringAfter(" ", "")
 
         return when (command) {
-            "mode" -> completeSimpleArg(command, arg, modeValues)
-            "use", "model" -> completeSimpleArg(command, arg, normalizedAgents)
-            "include" -> completeInclude(arg, normalizedAgents)
+            "mode" -> completeSimpleArgValue(arg, modeValues)
+            "use", "model" -> completeSimpleArgValue(arg, normalizedAgents)
+            "include" -> completeIncludeValue(arg, normalizedAgents)
             else -> emptyList()
         }
     }
 
-    private fun completeSimpleArg(command: String, arg: String, options: List<String>): List<String> {
+    private fun completeSimpleArgValue(arg: String, options: List<String>): List<String> {
         val token = arg.trimStart()
-        return options
-            .filter { it.startsWith(token, ignoreCase = true) }
-            .map { ":$command $it" }
+        return options.filter { it.startsWith(token, ignoreCase = true) }
     }
 
-    private fun completeInclude(arg: String, options: List<String>): List<String> {
+    private fun completeIncludeValue(arg: String, options: List<String>): List<String> {
         val parts = arg.split(",")
         val current = parts.lastOrNull()?.trimStart().orEmpty()
         val selected = parts.dropLast(1).map { it.trim() }.filter { it.isNotBlank() }.toSet()
@@ -58,6 +73,6 @@ class InteractiveCommandCompleter(
         return options
             .filterNot { selected.contains(it) }
             .filter { it.startsWith(current, ignoreCase = true) }
-            .map { ":include $prefixWithComma$it" }
+            .map { "$prefixWithComma$it" }
     }
 }

--- a/src/test/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleterTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/InteractiveCommandCompleterTest.kt
@@ -3,6 +3,9 @@ package com.cotor.presentation.cli
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import org.jline.reader.Candidate
+import org.jline.reader.ParsedLine
 
 class InteractiveCommandCompleterTest : FunSpec({
     val completer = InteractiveCommandCompleter { listOf("codex", "gemini", "claude") }
@@ -26,5 +29,21 @@ class InteractiveCommandCompleterTest : FunSpec({
 
     test("lists all mode options when argument is empty") {
         completer.suggest(":mode ") shouldContainAll listOf(":mode auto", ":mode compare", ":mode single")
+    }
+
+    test("jline completion returns only argument token for :model") {
+        val parsedLine = object : ParsedLine {
+            override fun word(): String = "co"
+            override fun wordCursor(): Int = 2
+            override fun wordIndex(): Int = 1
+            override fun words(): MutableList<String> = mutableListOf(":model", "co")
+            override fun line(): String = ":model co"
+            override fun cursor(): Int = 9
+        }
+        val candidates = mutableListOf<Candidate>()
+
+        completer.complete(reader = null, line = parsedLine, candidates = candidates)
+
+        candidates.map { it.value() } shouldBe listOf("codex")
     }
 })


### PR DESCRIPTION
### Motivation
- Tab completion in the interactive REPL produced duplicated/incorrect strings (e.g. `:model :model\ codex`) because JLine candidates returned full command lines instead of the raw argument token. 

### Description
- Split completer logic so JLine `complete()` returns raw argument tokens via a new `completionValues` helper and keeps `suggest()` for the CLI/test API that returns `:<command> <arg>` display strings. 
- Replaced and renamed helpers to clarify token-only completion: `completeSimpleArgValue`, `completeIncludeValue`, and `completionValues` handle the token list while `suggest()` maps tokens back to display form. 
- Added a regression unit test that simulates a JLine `ParsedLine` for `:model co` and asserts the candidate value is `codex` to ensure JLine integration returns argument-only candidates. 

### Testing
- Ran targeted unit tests with Gradle: `gradle test --tests com.cotor.presentation.cli.InteractiveCommandCompleterTest -x jacocoTestCoverageVerification -x jacocoTestReport`, which completed successfully. 
- Re-ran the same test with `--rerun-tasks` and it also succeeded. 
- Running the full `gradle test` in this environment fails due to JaCoCo coverage threshold verification unrelated to this change, so the focused tests were used to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f8be86e88333887676bfd5a2e198)