### PR TITLE
docs: add Cotor guide website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Cotor is a Kotlin-based AI CLI for orchestrating multi-agent workflows with a si
 ### Quick Links
 - [📖 English Guide](docs/README.md)
 - [📖 한글 가이드](docs/README.ko.md)
+- [🌐 Cotor 소개 페이지](https://cotor-guide.pages.dev/)
 - [🚀 Quick Start](docs/QUICK_START.md)
 - [⚡ Features](docs/FEATURES.md)
 - [📑 Documentation Index](docs/INDEX.md)


### PR DESCRIPTION
### Motivation
- Make the project README point to the new Cotor introduction/guide site so visitors can find the hosted documentation quickly.

### Description
- Added a new Quick Links entry in `README.md` linking to `https://cotor-guide.pages.dev/`.

### Testing
- Verified the change with `git diff -- README.md` and `git status --short`, and committed the update successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8fee083088333b786c8597632421f)