### PR TITLE
feat: show Cotor ASCII logo on interactive TUI startup

### DIFF
--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
@@ -108,6 +108,15 @@ class InteractiveCommand :
         help = "Enable agent-level retries using each agent's configured retryPolicy"
     ).flag(default = false)
 
+    private val startupLogo = listOf(
+        " ██████╗ ██████╗ ████████╗ ██████╗ ██████╗",
+        "██╔════╝██╔═══██╗╚══██╔══╝██╔═══██╗██╔══██╗",
+        "██║     ██║   ██║   ██║   ██║   ██║██████╔╝",
+        "██║     ██║   ██║   ██║   ██║   ██║██╔══██╗",
+        "╚██████╗╚██████╔╝   ██║   ╚██████╔╝██║  ██║",
+        " ╚═════╝ ╚═════╝    ╚═╝    ╚═════╝ ╚═╝  ╚═╝"
+    )
+
     override fun run() = runBlocking {
         if (!configPath.exists()) {
             terminal.println(yellow("⚠ cotor.yaml not found at: $configPath"))
@@ -388,6 +397,8 @@ class InteractiveCommand :
         var selectedAgents = selectedAgentsInitial
         var activeAgent: AgentConfig? = activeAgentInitial
 
+        terminal.println()
+        startupLogo.forEach { terminal.println(cyan(bold(it))) }
         terminal.println()
         terminal.println(bold("◎ Cotor Interactive"))
         terminal.println(dim("Type ':help' for commands, ':exit' to quit."))


### PR DESCRIPTION
### Motivation
- Show a clear Cotor-branded ASCII banner when users enter the interactive TUI to improve first-impression and usability.

### Description
- Added a `startupLogo` ASCII art `List<String>` to `InteractiveCommand` and print each line with `terminal.println(cyan(bold(...)))` at the start of `runInteractiveLoop` in `src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt`.

### Testing
- Tried to run `./gradlew test`, but it failed due to a missing Gradle wrapper class (`org.gradle.wrapper.GradleWrapperMain`), so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9d93af1883339b3d6175397125b4)