### PR TITLE
[HEO-85] Fix Docker image Gradle build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM gradle:8.10.2-jdk17 AS build
 WORKDIR /workspace
 
 COPY build.gradle.kts settings.gradle.kts gradle.properties ./
+COPY gradle gradle
 COPY src src
 
 RUN gradle --no-daemon shadowJar


### PR DESCRIPTION
## Summary\n- copy the Gradle version catalog into the Docker build stage\n- unblock the PR-only Docker Image workflow that fails on  resolution\n\n## Validation\n- replayed the failing GitHub Actions job log to confirm the pre-fix  failure during \n- verified the current diff adds  and that  exists in the build context\n\nCloses HEO-85