### PR TITLE
[HEO-103] docs: add team ops onboarding package

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -27,6 +27,7 @@ Cotor는 여러 AI 에이전트를 하나의 CLI로 오케스트레이션하는 
 - [📖 한글 가이드](docs/README.ko.md)
 - [🚀 빠른 시작](docs/QUICK_START.md)
 - [🖥️ 데스크톱 앱](docs/DESKTOP_APP.md)
+- [🧭 팀 운영 / 온보딩](docs/team-ops/README.ko.md)
 - [⚡ 기능 목록](docs/FEATURES.md)
 - [📑 문서 인덱스](docs/INDEX.md)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Cotor is a Kotlin-based AI CLI for orchestrating multi-agent workflows with a si
 - [🌐 Cotor 소개 페이지](https://cotor-guide.pages.dev/)
 - [🚀 Quick Start](docs/QUICK_START.md)
 - [🖥️ Desktop App](docs/DESKTOP_APP.md)
+- [🧭 Team Ops Onboarding](docs/team-ops/README.md)
 - [⚡ Features](docs/FEATURES.md)
 - [📑 Documentation Index](docs/INDEX.md)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,6 +19,7 @@
 
 ## 운영/업그레이드
 
+- `team-ops/README.md` / `team-ops/README.ko.md`: 팀 운영 / 온보딩 패키지
 - `release/CHANGELOG.md`: 변경 이력
 - `UPGRADE_GUIDE.md`: 업그레이드 절차
 - `UPGRADE_RECOMMENDATIONS.md`: 권장안

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -72,6 +72,7 @@ cotor web                        # 웹 파이프라인 스튜디오
 
 ## 문서 안내
 
+- 팀 운영 / 온보딩: `team-ops/README.ko.md`
 - 빠른 시작: `QUICK_START.md`
 - 데스크톱 앱: `DESKTOP_APP.md`
 - 아키텍처: `ARCHITECTURE.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ Primary subcommands: `init`, `list`, `run`, `validate`, `test`, `template`, `res
 - Korean guide: `README.ko.md`
 - Quick start: `QUICK_START.md`
 - Desktop app: `DESKTOP_APP.md`
+- Team ops onboarding: `team-ops/README.md`
 - Architecture: `ARCHITECTURE.md`
 - Features: `FEATURES.md`
 - Usage tips: `USAGE_TIPS.md`

--- a/docs/team-ops/README.ko.md
+++ b/docs/team-ops/README.ko.md
@@ -1,0 +1,78 @@
+# 팀 운영 / 온보딩 패키지
+
+이 문서는 Cotor 저장소에서 신규 기여자와 유지보수자가 같은 방식으로 일하도록 맞추기 위한 DX 운영 핸드북입니다. 새 팀원 온보딩, 변경 작업 시작, 릴리스/문서 점검 때 기준 문서로 사용합니다.
+
+## 이 패키지에 포함된 내용
+
+- 첫 접근에 필요한 30분 온보딩 체크리스트
+- 공통 소유권 확보를 위한 첫 주 체크리스트
+- 저장소의 실제 검증 루틴에 맞춘 운영 리듬
+- 진행 공유, 변경 계획, 릴리스 점검용 복사용 템플릿
+
+## 30분 온보딩 체크리스트
+
+- [ ] 저장소를 클론하고 기본 브랜치가 최신 상태인지 확인합니다.
+- [ ] `./gradlew test`를 1회 실행해 로컬 Kotlin/Gradle 도구 체인을 검증합니다.
+- [ ] `./gradlew formatCheck`로 CI와 같은 포맷 규칙을 통과하는지 확인합니다.
+- [ ] `./shell/install-git-hooks.sh`로 로컬 Git hook을 설치합니다.
+- [ ] `./shell/cotor version`으로 CLI 진입점이 동작하는지 확인합니다.
+- [ ] [docs/README.md](../README.md), [docs/INDEX.md](../INDEX.md), [CONTRIBUTING.md](../../CONTRIBUTING.md)를 읽습니다.
+- [ ] [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)의 CI 계약을 확인합니다.
+- [ ] 파일을 수정하기 전에 담당 이슈 1개를 고르고 검증 경로를 먼저 적어 둡니다.
+
+## 첫 주 소유권 체크리스트
+
+- [ ] 동작 변경이 있으면 영문/국문 문서를 함께 갱신하는 작은 변경을 직접 완료합니다.
+- [ ] 사용자 체감 워크플로가 바뀌면 [`docs/release/CHANGELOG.md`](../release/CHANGELOG.md)를 함께 업데이트합니다.
+- [ ] `macos/` 또는 `shell/install-desktop-app.sh`를 건드릴 때는 데스크톱/macOS 문서도 같이 재검토합니다.
+- [ ] 리뷰 요청 전 [CONTRIBUTING.md](../../CONTRIBUTING.md)의 PR 체크리스트를 다시 확인합니다.
+
+## 팀 운영 리듬
+
+- 일일 트리아지
+  - 구현 전에 이슈 신호, 목표 검증, 문서 영향 범위를 먼저 확정합니다.
+- 브랜치 푸시 전
+  - `./gradlew formatCheck`와 변경을 직접 증명하는 최소 검증을 실행합니다.
+- 리뷰 요청 전
+  - 한/영 문서 동기화, changelog 반영 여부, CI 민감 파일 변경 여부를 다시 확인합니다.
+- 릴리스 위생
+  - `docs/release/CHANGELOG.md`, 상단 문서 링크, 영향받는 설치/설정 가이드가 현재 워크플로를 가리키는지 확인합니다.
+
+## 재사용 템플릿
+
+### 비동기 진행 공유 템플릿
+
+```md
+## Async Update
+
+- Yesterday:
+- Today:
+- Risks / blockers:
+- Validation evidence:
+- Docs or release impact:
+```
+
+### 변경 계획 템플릿
+
+```md
+## Change Plan
+
+- Problem / signal:
+- Scope:
+- Validation:
+- Docs to update:
+- Risks:
+```
+
+### 릴리스 준비 체크리스트
+
+```md
+## Release Readiness
+
+- [ ] `./gradlew formatCheck`
+- [ ] `./gradlew test`
+- [ ] 사용자 영향 변경이면 `docs/release/CHANGELOG.md` 반영
+- [ ] 영문/국문 문서 동시 업데이트
+- [ ] 패키징/실행 흐름 변경 시 desktop/macOS 문서 재검토
+- [ ] 수동 스모크 경로를 이슈 또는 PR에 기록
+```

--- a/docs/team-ops/README.md
+++ b/docs/team-ops/README.md
@@ -1,0 +1,78 @@
+# Team Operations & Onboarding Package
+
+This package is the repo-specific DX handbook for contributors and maintainers. Use it when onboarding a new teammate, preparing a change, or running release and documentation hygiene for Cotor.
+
+## What This Package Covers
+
+- A 30-minute setup checklist for first access
+- A first-week checklist for shared ownership
+- A lightweight operating rhythm tied to the repository's actual checks
+- Copy/paste templates for updates, change plans, and release readiness
+
+## 30-Minute Onboarding Checklist
+
+- [ ] Clone the repository and confirm the default branch is up to date.
+- [ ] Run `./gradlew test` once to verify the local Kotlin/Gradle toolchain.
+- [ ] Run `./gradlew formatCheck` to confirm formatting matches CI expectations.
+- [ ] Install local hooks with `./shell/install-git-hooks.sh`.
+- [ ] Verify the local CLI entrypoint with `./shell/cotor version`.
+- [ ] Read [docs/README.md](../README.md), [docs/INDEX.md](../INDEX.md), and [CONTRIBUTING.md](../../CONTRIBUTING.md).
+- [ ] Review the CI contract in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml).
+- [ ] Pick one issue and write down the exact validation path before editing files.
+
+## First-Week Ownership Checklist
+
+- [ ] Land one small change with matching English and Korean documentation when behavior changes.
+- [ ] Update [`docs/release/CHANGELOG.md`](../release/CHANGELOG.md) whenever a user-facing workflow changes.
+- [ ] Confirm whether desktop or macOS packaging docs need review when touching `macos/` or `shell/install-desktop-app.sh`.
+- [ ] Reuse the PR checklist in [CONTRIBUTING.md](../../CONTRIBUTING.md) before opening review.
+
+## Team Operating Rhythm
+
+- Daily triage
+  - Confirm the issue signal, target validation, and any doc impact before implementation starts.
+- Before pushing a branch
+  - Run `./gradlew formatCheck` and the narrowest proof that demonstrates the change.
+- Before requesting review
+  - Recheck EN/KR documentation sync, changelog impact, and CI-sensitive files.
+- Release hygiene
+  - Ensure `docs/release/CHANGELOG.md`, top-level docs links, and affected setup guides still point to the current workflow.
+
+## Reusable Templates
+
+### Async Update Template
+
+```md
+## Async Update
+
+- Yesterday:
+- Today:
+- Risks / blockers:
+- Validation evidence:
+- Docs or release impact:
+```
+
+### Change Plan Template
+
+```md
+## Change Plan
+
+- Problem / signal:
+- Scope:
+- Validation:
+- Docs to update:
+- Risks:
+```
+
+### Release Readiness Checklist
+
+```md
+## Release Readiness
+
+- [ ] `./gradlew formatCheck`
+- [ ] `./gradlew test`
+- [ ] `docs/release/CHANGELOG.md` updated for user-facing changes
+- [ ] English and Korean docs updated together
+- [ ] Desktop/macOS docs reviewed if packaging or launch flow changed
+- [ ] Manual smoke path recorded in the issue or PR
+```


### PR DESCRIPTION
## Summary
- add a bilingual team operations / onboarding package for contributors and maintainers
- cover repo-specific onboarding, operating rhythm, and reusable update/release templates
- link the package from the top-level and docs landing pages

## Validation
- find docs/team-ops -maxdepth 1 -type f | sort
- grep -niE "team ops|운영|온보딩" README.md README.ko.md docs/README.md docs/README.ko.md docs/INDEX.md docs/team-ops/README.md docs/team-ops/README.ko.md
- git diff --check

Supersedes the wrongly linked HEO-73 PR path for this migrated ticket.