### PR TITLE
fix(runtime): stage app-server jars before launch

### DIFF
--- a/macos/Packaging/CotorDesktopLauncher.sh.template
+++ b/macos/Packaging/CotorDesktopLauncher.sh.template
@@ -19,6 +19,7 @@ TOKEN_FILE="$RUNTIME_DIR/app-server.token"
 APP_HOME="$HOME/Library/Application Support/CotorDesktop"
 BACKEND_RUNTIME_DIR="$APP_HOME/runtime/backend"
 INSTANCE_METADATA_FILE="$BACKEND_RUNTIME_DIR/app-server.instance.json"
+BACKEND_RUNTIME_JAR=""
 SERVER_URL="${COTOR_APP_SERVER_URL:-}"
 SERVER_PORT=""
 SERVER_TOKEN="${COTOR_APP_TOKEN:-}"
@@ -133,6 +134,15 @@ log_launcher() {
 
 clear_backend_runtime_files() {
     rm -f "$PID_FILE" "$PORT_FILE" "$TOKEN_FILE"
+    if [[ -n "$BACKEND_RUNTIME_JAR" ]]; then
+        rm -f "$BACKEND_RUNTIME_JAR" >/dev/null 2>&1 || true
+    fi
+}
+
+stage_backend_runtime_jar() {
+    BACKEND_RUNTIME_JAR="$BACKEND_RUNTIME_DIR/cotor-backend-runtime-$$.jar"
+    mkdir -p "$BACKEND_RUNTIME_DIR"
+    cp "$BACKEND_JAR" "$BACKEND_RUNTIME_JAR"
 }
 
 read_existing_instance_pid() {
@@ -181,7 +191,7 @@ terminate_conflicting_app_home_backend() {
 list_bundled_backend_pids() {
     ps -axo pid=,args= | while read -r pid args; do
         [[ -n "$pid" ]] || continue
-        [[ "$args" == *"$BACKEND_JAR"* ]] || continue
+        [[ "$args" == *"$BACKEND_JAR"* || "$args" == *"$BACKEND_RUNTIME_DIR/cotor-backend-runtime-"* ]] || continue
         [[ "$args" == *" app-server "* || "$args" == *" app-server" ]] || continue
         printf '%s\n' "$pid"
     done
@@ -233,6 +243,10 @@ start_managed_backend() {
         show_alert "The bundled Cotor backend could not be found inside the app."
         return 1
     fi
+    if ! stage_backend_runtime_jar; then
+        show_alert "Cotor Desktop could not stage its bundled backend for execution."
+        return 1
+    fi
 
     SERVER_PORT="$(find_free_port)"
     SERVER_TOKEN="$(/usr/bin/uuidgen | /usr/bin/tr '[:upper:]' '[:lower:]')"
@@ -242,7 +256,7 @@ start_managed_backend() {
     env \
         COTOR_DESKTOP_APP_HOME="$APP_HOME" \
         COTOR_APP_HOME="$APP_HOME" \
-        "$java_bin" -jar "$BACKEND_JAR" app-server --port "$SERVER_PORT" --token "$SERVER_TOKEN" >>"$LOG_FILE" 2>&1 &
+        "$java_bin" -jar "$BACKEND_RUNTIME_JAR" app-server --port "$SERVER_PORT" --token "$SERVER_TOKEN" >>"$LOG_FILE" 2>&1 &
     local backend_pid=$!
     MANAGED_BACKEND_PID="$backend_pid"
     MANAGED_BACKEND_STARTED=1

--- a/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
+++ b/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
@@ -22,7 +22,7 @@ actor EmbeddedBackendLauncher {
         if shutdownRequested {
             return
         }
-        terminateStaleBundledBackendProcesses()
+        await terminateStaleBundledBackendProcesses()
         if await healthCheck() {
             return
         }
@@ -40,6 +40,10 @@ actor EmbeddedBackendLauncher {
             AppLogger.error("Embedded backend launch failed: missing java or bundled jar.")
             return
         }
+        guard let runtimeJarPath = stageRuntimeBackendJar(sourcePath: jarPath) else {
+            AppLogger.error("Embedded backend launch failed: could not stage backend jar.")
+            return
+        }
 
         let runtimeDir = defaultDesktopAppHome()
             .appendingPathComponent("runtime", isDirectory: true)
@@ -54,7 +58,7 @@ actor EmbeddedBackendLauncher {
         process.executableURL = URL(fileURLWithPath: javaPath)
         process.arguments = [
             "-jar",
-            jarPath,
+            runtimeJarPath,
             "app-server",
             "--port",
             "\(port)",
@@ -70,7 +74,7 @@ actor EmbeddedBackendLauncher {
                 AppLogger.info("Skipping embedded backend launch because shutdown is in progress.")
                 return
             }
-            AppLogger.info("Launching embedded backend on port \(port) with jar \(jarPath).")
+            AppLogger.info("Launching embedded backend on port \(port) with runtime jar \(runtimeJarPath).")
             try process.run()
             self.process = process
             let started = await waitForHealth(timeoutSeconds: 10)
@@ -126,7 +130,7 @@ actor EmbeddedBackendLauncher {
         return shutdownConfirmed
     }
 
-    private func terminateStaleBundledBackendProcesses() {
+    private func terminateStaleBundledBackendProcesses() async {
         guard let jarPath = resolveBundledBackendJarPath() else {
             return
         }
@@ -138,7 +142,7 @@ actor EmbeddedBackendLauncher {
             stalePids.forEach { pid in
                 _ = kill(pid, SIGTERM)
             }
-            Thread.sleep(forTimeInterval: 0.8)
+            try? await Task.sleep(for: .milliseconds(800))
             let survivors = try staleBundledBackendPids(for: jarPath).filter { stalePids.contains($0) }
             survivors.forEach { pid in
                 _ = kill(pid, SIGKILL)
@@ -158,6 +162,10 @@ actor EmbeddedBackendLauncher {
     }
 
     private func staleBundledBackendPids(for jarPath: String) throws -> [Int32] {
+        let runtimeDir = defaultDesktopAppHome()
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("backend", isDirectory: true)
+            .path
         let inspector = Process()
         inspector.executableURL = URL(fileURLWithPath: "/bin/ps")
         inspector.arguments = ["-axo", "pid=,args="]
@@ -172,7 +180,9 @@ actor EmbeddedBackendLauncher {
                 .split(separator: "\n")
                 .compactMap { line -> Int32? in
                     let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty, trimmed.contains(jarPath), trimmed.contains("app-server") else {
+                    let matchesBundledJar = trimmed.contains(jarPath)
+                    let matchesRuntimeJar = trimmed.contains("\(runtimeDir)/cotor-backend-runtime-")
+                    guard !trimmed.isEmpty, (matchesBundledJar || matchesRuntimeJar), trimmed.contains("app-server") else {
                         return nil
                     }
                     guard !trimmed.contains("--port \(port)") else {
@@ -186,6 +196,24 @@ actor EmbeddedBackendLauncher {
                 }
         } catch {
             throw error
+        }
+    }
+
+    private func stageRuntimeBackendJar(sourcePath: String) -> String? {
+        let runtimeDir = defaultDesktopAppHome()
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("backend", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: runtimeDir, withIntermediateDirectories: true)
+            let runtimeJar = runtimeDir.appendingPathComponent("cotor-backend-runtime-\(ProcessInfo.processInfo.processIdentifier).jar")
+            if FileManager.default.fileExists(atPath: runtimeJar.path) {
+                try FileManager.default.removeItem(at: runtimeJar)
+            }
+            try FileManager.default.copyItem(atPath: sourcePath, toPath: runtimeJar.path)
+            return runtimeJar.path
+        } catch {
+            AppLogger.error("Failed to stage embedded backend jar: \(error.localizedDescription)")
+            return nil
         }
     }
 

--- a/shell/cotor
+++ b/shell/cotor
@@ -69,6 +69,19 @@ if [ ! -f "$JAR_PATH" ]; then
     fi
 fi
 
+if [ "${1:-}" = "app-server" ]; then
+    APP_HOME="${COTOR_APP_HOME:-${HOME}/Library/Application Support/CotorDesktop}"
+    RUNTIME_BACKEND_DIR="$APP_HOME/runtime/backend"
+    RUNTIME_JAR="$RUNTIME_BACKEND_DIR/cotor-app-server-$$.jar"
+    /bin/mkdir -p "$RUNTIME_BACKEND_DIR" || exit 1
+    /bin/cp "$JAR_PATH" "$RUNTIME_JAR" || exit 1
+    cleanup_runtime_jar() {
+        /bin/rm -f "$RUNTIME_JAR" >/dev/null 2>&1 || true
+    }
+    trap cleanup_runtime_jar EXIT
+    JAR_PATH="$RUNTIME_JAR"
+fi
+
 # Run the JAR with all arguments passed to this script
 export COTOR_PROJECT_ROOT="$PROJECT_ROOT"
 "$JAVA_CMD" -jar "$JAR_PATH" "$@"


### PR DESCRIPTION
## Summary
- Stage app-server jars into per-process runtime copies before launching long-running CLI and desktop-managed backends.
- Prevent rebuilds of build/libs/cotor-*-all.jar from invalidating a running app-server classpath.
- Extend desktop stale-backend detection to recognize staged runtime jar processes.

## Validation
- ./gradlew --no-daemon check --stacktrace -Pkotlin.incremental=false --rerun-tasks
- ./gradlew --no-daemon shadowJar
- jar tf build/libs/cotor-1.0.6-all.jar | grep com/cotor/MainKt.class
- ./shell/cotor version
- cd macos && swift test && swift build
- /bin/bash shell/build-desktop-app-bundle.sh
- Browser Use smoke: /health and /api/app/companies on a temp app-server
- Desktop launcher smoke: managed backend health/API using a temp HOME

## Notes
- Does not include existing local runtime/generated dirty files.
- Computer Use native click automation remained blocked by pending macOS Accessibility/Screen Recording permission in the local Codex Computer Use window.