### PR TITLE
Release prep security hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD ["curl", "--fail", "--silent", "http://127.0.0.1:8787/health"]
 
 ENTRYPOINT ["java", "-jar", "/app/cotor.jar"]
-CMD ["app-server", "--host", "0.0.0.0", "--port", "8787"]
+CMD ["app-server", "--host", "127.0.0.1", "--port", "8787"]

--- a/Formula/cotor.rb
+++ b/Formula/cotor.rb
@@ -1,7 +1,6 @@
 class Cotor < Formula
   desc "AI company orchestration platform - CLI and desktop app"
   homepage "https://github.com/bssm-oss/cotor"
-  version "1.0.6"
   url "https://github.com/bssm-oss/cotor/releases/download/v1.0.6/cotor-1.0.6-all.jar"
   sha256 "d23e0424175eb704d40fd4db8f9012932653abf77e06b7d1288a744b2908d1aa"
   license "MIT"
@@ -78,8 +77,8 @@ class Cotor < Formula
     ENV.delete("GOOGLE_API_KEY")
     output = shell_output("#{bin}/cotor interactive --no-context --prompt hello")
     assert_match "hello", output
-    assert_predicate testpath/"home/.cotor/interactive/default/cotor.yaml", :exist?
-    assert_predicate testpath/"home/.cotor/interactive/default/interactive.log", :exist?
+    assert_path_exists testpath/"home/.cotor/interactive/default/cotor.yaml"
+    assert_path_exists testpath/"home/.cotor/interactive/default/interactive.log"
 
     if OS.mac?
       assert_predicate pkgshare/"desktop/Cotor Desktop.app", :directory?

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -4413,6 +4413,22 @@ private struct CenterPaneView: View {
             .sorted { $0.updatedAt > $1.updatedAt }
     }
 
+    private var meetingRoomProjection: MeetingRoomProjection {
+        let companyId = store.selectedCompanyID ?? store.selectedCompany?.id
+        return MeetingRoomProjection.build(
+            companyId: companyId,
+            agents: store.dashboard.companyAgentDefinitions,
+            goals: store.dashboard.goals,
+            orgProfiles: store.dashboard.orgProfiles,
+            issues: store.dashboard.issues,
+            runningSessions: store.dashboard.runningAgentSessions,
+            reviewQueue: store.dashboard.reviewQueue,
+            runtime: MeetingRoomProjection.runtime(for: companyId, in: store.dashboard.companyRuntimes),
+            activity: store.dashboard.activity,
+            messages: store.dashboard.agentMessages
+        )
+    }
+
     private var meetingRoomMessages: [AgentMessageRecord] {
         store.dashboard.agentMessages
             .filter { store.selectedCompanyID == nil || $0.companyId == store.selectedCompanyID }
@@ -4637,8 +4653,6 @@ private struct CenterPaneView: View {
                 subtitle: l("Watch the live company floor map with wall events, active seats, and review load in one place.", "이벤트 월, 실행 좌석, 리뷰 부담을 한 곳에서 보는 실시간 회사 플로어 맵입니다.")
             )
             companyMeetingRoomPanel
-            companyRunningAgentsPanel
-            companyActivityFeed
         }
     }
 
@@ -4757,8 +4771,6 @@ private struct CenterPaneView: View {
 
             if companyOverviewSurface == .meetingRoom {
                 companyMeetingRoomPanel
-                companyRunningAgentsPanel
-                companyActivityFeed
             } else {
                 operationsBanner
                 if store.companyStreamStatusMessage != nil || store.backendStatusMessage != nil {
@@ -5358,69 +5370,14 @@ private struct CenterPaneView: View {
 
     private var companyMeetingRoomPanel: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(l("Meeting Room", "미팅룸"))
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(ShellPalette.text)
-                    Text(
-                        l(
-                            "Read-only floor map of live company activity. The wall mirrors events, the table mirrors active agents, and the desk mirrors review load.",
-                            "현재 회사 활동을 읽기 전용으로 보는 플로어 맵입니다. 벽은 이벤트, 테이블은 실행 중인 에이전트, 데스크는 리뷰 부담을 보여줍니다."
-                        )
-                    )
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(ShellPalette.muted)
-                    .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 0)
-
-                StatusSummaryPill(text: l("READ ONLY", "읽기 전용"), tint: ShellPalette.accent)
-            }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ShellTag(text: "\(l("Table", "테이블")) \(runningSessions.count)", tint: ShellPalette.accentWarm)
-                    ShellTag(text: "\(l("Desk", "데스크")) \(meetingRoomReviewItems.count)", tint: ShellPalette.warning)
-                    ShellTag(text: "\(l("Wall", "이벤트")) \(meetingRoomWallItems.count)", tint: ShellPalette.accent)
-                    ShellTag(text: "\(l("Messages", "메시지")) \(meetingRoomMessages.count)", tint: ShellPalette.accent)
-                    ShellTag(text: "\(l("Context", "컨텍스트")) \(meetingRoomContextEntries.count)", tint: ShellPalette.accentWarm)
-                }
-                .padding(.vertical, 2)
-            }
-
-            MeetingRoomZoneCard(
-                title: l("Current Agenda", "현재 안건"),
-                subtitle: l("The room’s active focus before you scan the live wall and desks.", "이벤트 월과 데스크를 보기 전에 방이 지금 집중하는 안건입니다."),
-                tint: ShellPalette.accentWarm
-            ) {
-                VStack(alignment: .leading, spacing: 8) {
-                    agendaSummaryRow(label: l("Focus", "집중 대상"), value: meetingRoomCurrentAgendaTitle, tint: ShellPalette.accent)
-                    agendaSummaryRow(label: l("State", "상태"), value: meetingRoomCurrentAgendaDetail, tint: ShellPalette.warning)
-                    agendaSummaryRow(label: l("Next action", "다음 액션"), value: meetingRoomNextActionLabel, tint: ShellPalette.success)
-                    agendaSummaryRow(label: l("Lead AI", "리더 AI"), value: workflowLeader, tint: ShellPalette.accentWarm)
-                }
-            }
-
-            if layoutMode == .compact {
-                VStack(alignment: .leading, spacing: 10) {
-                    meetingRoomEventWallZone
-                    meetingRoomCenterTableZone
-                    meetingRoomReviewDeskZone
-                }
-            } else {
-                HStack(alignment: .top, spacing: 10) {
-                    meetingRoomEventWallZone
-                        .frame(width: layoutMode == .stacked ? 220 : 236, alignment: .top)
-                    meetingRoomCenterTableZone
-                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .top)
-                    meetingRoomReviewDeskZone
-                        .frame(width: layoutMode == .stacked ? 220 : 236, alignment: .top)
-                }
-            }
+            MeetingRoomView(
+                projection: meetingRoomProjection,
+                language: store.language,
+                inboxCount: meetingRoomReviewItems.count + meetingRoomMessages.count,
+                isCompact: layoutMode == .compact
+            )
         }
-        .padding(14)
+        .padding(12)
         .shellInset()
     }
 
@@ -7675,6 +7632,38 @@ private struct IssueExecutionDetailCard: View {
     }
 }
 
+struct OrgProfileBatchEditPayloadDraft: Equatable {
+    let agentCli: String?
+    let model: String?
+    let specialties: [String]?
+    let enabled: Bool?
+
+    static func build(
+        batchAgent: String,
+        batchModel: String,
+        batchCapabilities: String,
+        batchEnabled: Bool?
+    ) -> OrgProfileBatchEditPayloadDraft {
+        let trimmedAgent = batchAgent.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedModel = batchModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsedSpecialties = batchCapabilities
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return OrgProfileBatchEditPayloadDraft(
+            agentCli: trimmedAgent.isEmpty ? nil : trimmedAgent,
+            model: trimmedModel.isEmpty ? nil : trimmedModel,
+            specialties: batchCapabilities.isEmpty ? nil : parsedSpecialties,
+            enabled: batchEnabled
+        )
+    }
+
+    static func modelAfterAgentSelection() -> String {
+        ""
+    }
+}
+
 private struct OrgProfileBatchEditSheet: View {
     @EnvironmentObject private var store: DesktopStore
     @Environment(\.dismiss) private var dismiss
@@ -7683,6 +7672,20 @@ private struct OrgProfileBatchEditSheet: View {
     @State private var batchCapabilities: String = ""
     @State private var batchEnabled: Bool? = nil
     private var l: AppLanguage { store.language }
+    private var batchModelAgentCli: String {
+        if !batchAgent.isEmpty {
+            return batchAgent
+        }
+        let selectedAgents = store.selectedBatchEditableAgents
+            .map { $0.agentCli.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let normalizedAgents = Set(selectedAgents.map { $0.lowercased() })
+        return normalizedAgents.count == 1 ? selectedAgents.first ?? "" : ""
+    }
+
+    private var batchModelOptions: [String] {
+        store.modelOptions(for: batchModelAgentCli)
+    }
 
     var body: some View {
         NavigationStack {
@@ -7770,8 +7773,21 @@ private struct OrgProfileBatchEditSheet: View {
                                 .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(ShellPalette.muted)
 
-                            TextField(l("No change", "변경 없음"), text: $batchModel)
+                            if !batchModelOptions.isEmpty {
+                                Picker(l("Model Override", "모델 오버라이드"), selection: $batchModel) {
+                                    Text(l("No change", "변경 없음")).tag("")
+                                    ForEach(batchModelOptions, id: \.self) { model in
+                                        Text(model).tag(model)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                            } else {
+                                TextField(
+                                    store.defaultModel(for: batchModelAgentCli) ?? l("No change", "변경 없음"),
+                                    text: $batchModel
+                                )
                                 .textFieldStyle(.roundedBorder)
+                            }
                         }
 
                         // Capabilities
@@ -7822,24 +7838,24 @@ private struct OrgProfileBatchEditSheet: View {
             batchCapabilities = ""
             batchEnabled = nil
         }
+        .onChange(of: batchAgent) { _, _ in
+            batchModel = OrgProfileBatchEditPayloadDraft.modelAfterAgentSelection()
+        }
     }
 
     private func applyBatchChanges() {
-        let agentCli = batchAgent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : batchAgent.trimmingCharacters(in: .whitespacesAndNewlines)
-        let model = batchModel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : batchModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let specialties: [String]? = {
-            let parsed = batchCapabilities
-                .split(separator: ",")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-            return batchCapabilities.isEmpty ? nil : parsed
-        }()
+        let payload = OrgProfileBatchEditPayloadDraft.build(
+            batchAgent: batchAgent,
+            batchModel: batchModel,
+            batchCapabilities: batchCapabilities,
+            batchEnabled: batchEnabled
+        )
         Task {
             let didApply = await store.batchUpdateSelectedCompanyAgents(
-                agentCli: agentCli,
-                model: model,
-                specialties: specialties,
-                enabled: batchEnabled
+                agentCli: payload.agentCli,
+                model: payload.model,
+                specialties: payload.specialties,
+                enabled: payload.enabled
             )
             if didApply {
                 dismiss()

--- a/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
@@ -116,6 +116,14 @@ struct MeetingRoomProjection: Hashable {
     let activityCount: Int
     let pullRequestStates: [String]
 
+    static func runtime(
+        for companyId: String?,
+        in runtimes: [CompanyRuntimeSnapshotRecord]
+    ) -> CompanyRuntimeSnapshotRecord? {
+        guard let companyId else { return nil }
+        return runtimes.first { $0.companyId == companyId }
+    }
+
     static func build(
         companyId: String?,
         agents allAgents: [CompanyAgentDefinitionRecord],

--- a/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
@@ -27,6 +27,7 @@ struct MeetingRoomRenderPlan: Hashable {
     let hiddenAgentCount: Int
     let visibleFlows: [MeetingRoomFlowItem]
     let shouldAnimate: Bool
+    let frameInterval: TimeInterval
 
     var animationKey: String {
         [
@@ -75,21 +76,90 @@ struct MeetingRoomRenderPlan: Hashable {
         }
         let visibleAgents = Array(prioritizedAgents.prefix(maxAgents))
         let visibleFlows = Array(projection.flows.prefix(maxFlows))
-        let hasActiveWork = visibleAgents.contains { $0.visualState == .running || $0.visualState == .review }
+        let hasLiveMotion = visibleAgents.contains { agent in
+            switch agent.visualState {
+            case .running, .review:
+                return true
+            case .idle, .blocked, .failed, .done, .costBlocked:
+                return false
+            }
+        }
+        let hasActiveFlow = visibleFlows.contains { flow in
+            switch flow.kind {
+            case .issueToAgent, .agentWorking, .a2aMessage, .agentToReview:
+                return true
+            case .goalToIssue, .reviewToMerge, .blocked, .costBlocked:
+                return false
+            }
+        }
+        let hasActiveMotion = hasLiveMotion || hasActiveFlow
         let shouldAnimate = isSceneActive &&
             !reduceMotion &&
             !lowResourceMode &&
             mode == .full &&
             agentCount <= 24 &&
-            (!visibleFlows.isEmpty || hasActiveWork || !visibleAgents.isEmpty)
+            hasActiveMotion
 
         return MeetingRoomRenderPlan(
             mode: mode,
             visibleAgents: visibleAgents,
             hiddenAgentCount: max(0, agentCount - visibleAgents.count),
             visibleFlows: visibleFlows,
-            shouldAnimate: shouldAnimate
+            shouldAnimate: shouldAnimate,
+            frameInterval: shouldAnimate ? (1.0 / 15.0) : 1.0
         )
+    }
+}
+
+private enum MeetingRoomDecorStyle: String, CaseIterable, Identifiable {
+    case studio
+    case glass
+    case lounge
+
+    var id: String { rawValue }
+
+    func label(_ language: AppLanguage) -> String {
+        switch self {
+        case .studio:
+            return language("Studio", "스튜디오")
+        case .glass:
+            return language("Glass", "글래스")
+        case .lounge:
+            return language("Lounge", "라운지")
+        }
+    }
+
+    var floorBase: Color {
+        switch self {
+        case .studio:
+            return Color(red: 0.62, green: 0.40, blue: 0.18)
+        case .glass:
+            return Color(red: 0.43, green: 0.47, blue: 0.45)
+        case .lounge:
+            return Color(red: 0.55, green: 0.34, blue: 0.19)
+        }
+    }
+
+    var wall: Color {
+        switch self {
+        case .studio:
+            return Color(red: 0.20, green: 0.13, blue: 0.18)
+        case .glass:
+            return Color(red: 0.10, green: 0.18, blue: 0.22)
+        case .lounge:
+            return Color(red: 0.23, green: 0.11, blue: 0.23)
+        }
+    }
+
+    var accent: Color {
+        switch self {
+        case .studio:
+            return Color(red: 0.77, green: 0.47, blue: 0.22)
+        case .glass:
+            return Color(red: 0.41, green: 0.78, blue: 0.82)
+        case .lounge:
+            return Color(red: 0.57, green: 0.25, blue: 0.62)
+        }
     }
 }
 
@@ -102,9 +172,16 @@ struct MeetingRoomView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("meetingRoomLowResourceMode") private var lowResourceMode = false
+    @AppStorage("meetingRoomDecorStyle") private var decorStyleRaw = MeetingRoomDecorStyle.studio.rawValue
+    @AppStorage("meetingRoomShowPlacementGrid") private var showPlacementGrid = true
+    @AppStorage("meetingRoomShowDecor") private var showDecor = true
     @State private var selectedAgent: MeetingRoomProjectionAgent?
     @State private var selectedFlow: MeetingRoomFlowItem?
     @State private var selectedZone: MeetingRoomOfficeZone?
+
+    private var decorStyle: MeetingRoomDecorStyle {
+        MeetingRoomDecorStyle(rawValue: decorStyleRaw) ?? .studio
+    }
 
     private var renderPlan: MeetingRoomRenderPlan {
         MeetingRoomRenderPlan.build(
@@ -122,13 +199,7 @@ struct MeetingRoomView: View {
             header(plan: plan)
 
             GeometryReader { geometry in
-                if plan.shouldAnimate {
-                    TimelineView(.periodic(from: .now, by: 1.1)) { timeline in
-                        officeStage(size: geometry.size, plan: plan, phase: timeline.date.timeIntervalSinceReferenceDate)
-                    }
-                } else {
-                    officeStage(size: geometry.size, plan: plan, phase: 0)
-                }
+                officeStage(size: geometry.size, plan: plan)
             }
             .frame(height: isCompact ? 360 : 500)
         }
@@ -151,22 +222,26 @@ struct MeetingRoomView: View {
         }
     }
 
-    private func officeStage(size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval) -> some View {
+    private func officeStage(size: CGSize, plan: MeetingRoomRenderPlan) -> some View {
         ZStack {
             officeBackdrop(size: size)
-            handoffLines(size: size, plan: plan, phase: phase)
+
+            if plan.shouldAnimate {
+                TimelineView(.periodic(from: .now, by: plan.frameInterval)) { timeline in
+                    animatedOfficeLayer(
+                        size: size,
+                        plan: plan,
+                        phase: timeline.date.timeIntervalSinceReferenceDate
+                    )
+                }
+            } else {
+                animatedOfficeLayer(size: size, plan: plan, phase: 0)
+            }
 
             ForEach(zoneButtons(size: size), id: \.zone) { item in
                 zoneButton(item)
                     .position(item.point)
-            }
-
-            ForEach(plan.visibleFlows) { flow in
-                workCard(flow, size: size, phase: phase, animated: plan.shouldAnimate)
-            }
-
-            ForEach(Array(plan.visibleAgents.enumerated()), id: \.element.id) { index, agent in
-                agentButton(agent, index: index, size: size, plan: plan, phase: phase)
+                    .zIndex(4)
             }
 
             hiddenAgentsBadge(size: size, plan: plan)
@@ -175,35 +250,89 @@ struct MeetingRoomView: View {
         .animation(plan.shouldAnimate ? .easeInOut(duration: 0.35) : nil, value: plan.animationKey)
     }
 
+    private func animatedOfficeLayer(size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval) -> some View {
+        ZStack {
+            handoffLines(size: size, plan: plan, phase: phase)
+
+            ForEach(plan.visibleFlows) { flow in
+                workCard(flow, size: size, phase: phase, animated: plan.shouldAnimate)
+            }
+
+            ForEach(Array(plan.visibleAgents.enumerated()), id: \.element.id) { index, agent in
+                agentButton(agent, index: index, size: size, plan: plan, phase: phase)
+            }
+        }
+    }
+
     private func header(plan: MeetingRoomRenderPlan) -> some View {
-        HStack(spacing: 8) {
-            ShellTag(text: "\(language("Agents", "에이전트")) \(projection.agents.count)", tint: ShellPalette.accent)
-            ShellTag(text: "\(language("Running", "작업 중")) \(projection.agents.filter { $0.visualState == .running }.count)", tint: ShellPalette.success)
-            ShellTag(text: "\(language("Review", "리뷰")) \(projection.reviewCount)", tint: ShellPalette.warning)
-            ShellTag(text: "\(language("Signals", "신호")) \(projection.activityCount)", tint: ShellPalette.panelRaised)
-            if plan.mode != .full {
-                ShellTag(text: plan.mode.label, tint: ShellPalette.warning)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 8) {
+                ShellTag(text: "\(language("Agents", "에이전트")) \(projection.agents.count)", tint: ShellPalette.accent)
+                ShellTag(text: "\(language("Running", "작업 중")) \(projection.agents.filter { $0.visualState == .running }.count)", tint: ShellPalette.success)
+                ShellTag(text: "\(language("Review", "리뷰")) \(projection.reviewCount)", tint: ShellPalette.warning)
+                ShellTag(text: "\(language("Signals", "신호")) \(projection.activityCount)", tint: ShellPalette.panelRaised)
+                if plan.mode != .full {
+                    ShellTag(text: plan.mode.label, tint: ShellPalette.warning)
+                }
+                Spacer(minLength: 0)
+                Text(runtimeLabel)
+                    .font(.system(size: 10, weight: .heavy, design: .monospaced))
+                    .foregroundStyle(ShellPalette.muted)
+                    .lineLimit(1)
             }
-            Spacer(minLength: 0)
-            Button {
-                lowResourceMode.toggle()
-            } label: {
-                Text(lowResourceMode ? language("Low on", "저전력 켬") : language("Low off", "저전력 끔"))
-                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
-                    .foregroundStyle(lowResourceMode ? ShellPalette.warning : ShellPalette.muted)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 4)
-                    .background(ShellPalette.panelAlt)
-                    .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+
+            HStack(spacing: 8) {
+                meetingControlButton(
+                    text: "\(language("Style", "스타일")) \(decorStyle.label(language))",
+                    tint: decorStyle.accent,
+                    accessibilityLabel: language("Change Meeting Room style", "미팅룸 스타일 변경"),
+                    action: cycleDecorStyle
+                )
+                meetingControlButton(
+                    text: showPlacementGrid ? language("Grid on", "그리드 켬") : language("Grid off", "그리드 끔"),
+                    tint: showPlacementGrid ? ShellPalette.accentWarm : ShellPalette.muted,
+                    accessibilityLabel: language("Toggle Meeting Room placement grid", "미팅룸 배치 그리드 전환"),
+                    action: { showPlacementGrid.toggle() }
+                )
+                meetingControlButton(
+                    text: showDecor ? language("Props on", "소품 켬") : language("Props off", "소품 끔"),
+                    tint: showDecor ? ShellPalette.warning : ShellPalette.muted,
+                    accessibilityLabel: language("Toggle Meeting Room props", "미팅룸 소품 전환"),
+                    action: { showDecor.toggle() }
+                )
+                meetingControlButton(
+                    text: lowResourceMode ? language("Low on", "저전력 켬") : language("Low off", "저전력 끔"),
+                    tint: lowResourceMode ? ShellPalette.warning : ShellPalette.muted,
+                    accessibilityLabel: language("Toggle Meeting Room low resource mode", "미팅룸 저자원 모드 전환"),
+                    action: { lowResourceMode.toggle() }
+                )
+                Spacer(minLength: 0)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(language("Toggle Meeting Room low resource mode", "미팅룸 저자원 모드 전환"))
-            Text(runtimeLabel)
-                .font(.system(size: 10, weight: .heavy, design: .monospaced))
-                .foregroundStyle(ShellPalette.muted)
-                .lineLimit(1)
         }
         .accessibilityElement(children: .combine)
+    }
+
+    private func meetingControlButton(text: String, tint: Color, accessibilityLabel: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(text)
+                .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                .foregroundStyle(tint)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(ShellPalette.panelAlt)
+                .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func cycleDecorStyle() {
+        let styles = MeetingRoomDecorStyle.allCases
+        guard let currentIndex = styles.firstIndex(of: decorStyle) else {
+            decorStyleRaw = MeetingRoomDecorStyle.studio.rawValue
+            return
+        }
+        decorStyleRaw = styles[(currentIndex + 1) % styles.count].rawValue
     }
 
     private var runtimeLabel: String {
@@ -213,45 +342,47 @@ struct MeetingRoomView: View {
     private func officeBackdrop(size: CGSize) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color(red: 0.10, green: 0.09, blue: 0.12))
+                .fill(decorStyle.wall)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .stroke(ShellPalette.line, lineWidth: 1)
                 )
 
-            HStack(spacing: 0) {
-                Rectangle().fill(Color(red: 0.22, green: 0.15, blue: 0.09).opacity(0.74))
-                Rectangle().fill(Color(red: 0.10, green: 0.20, blue: 0.25).opacity(0.70))
-            }
+            roomFloor(size: size)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
 
-            Rectangle()
-                .fill(Color(red: 0.50, green: 0.42, blue: 0.32).opacity(0.30))
-                .frame(height: size.height * 0.22)
-                .position(x: size.width / 2, y: size.height * 0.11)
+            wallFrame(size: size)
 
-            floorGrid(size: size)
+            if showPlacementGrid {
+                floorGrid(size: size)
+                placementFootprints(size: size)
+            }
 
-            pixelShelf(size: size, x: 0.18, y: 0.14)
-            pixelShelf(size: size, x: 0.70, y: 0.14)
-            pixelDesk(size: size, x: 0.21, y: 0.72, tint: Color(red: 0.54, green: 0.33, blue: 0.16))
-            pixelDesk(size: size, x: 0.78, y: 0.72, tint: Color(red: 0.54, green: 0.33, blue: 0.16))
-            pixelDesk(size: size, x: 0.76, y: 0.34, tint: Color(red: 0.54, green: 0.33, blue: 0.16))
-            pixelDesk(size: size, x: 0.46, y: 0.52, tint: Color(red: 0.54, green: 0.33, blue: 0.16))
-            pixelPlant(size: size, x: 0.07, y: 0.84)
-            pixelPlant(size: size, x: 0.92, y: 0.84)
-            pixelPlant(size: size, x: 0.54, y: 0.24)
+            meetingTable(size: size)
+            glassRoom(size: size)
+            workstationCluster(size: size)
+            loungeCluster(size: size)
+            utilityCorner(size: size)
+            entranceDoor(size: size)
 
-            Text("✦ COTOR AGENT OFFICE ✦")
+            if showDecor {
+                pixelShelf(size: size, x: 0.18, y: 0.14)
+                pixelShelf(size: size, x: 0.70, y: 0.14)
+                pixelPlant(size: size, x: 0.07, y: 0.84)
+                pixelPlant(size: size, x: 0.92, y: 0.84)
+                pixelPlant(size: size, x: 0.54, y: 0.24)
+            }
+
+            Text(language("✦ COTOR MEETING ROOM ✦", "✦ COTOR 회의실 ✦"))
                 .font(.system(size: 12, weight: .heavy, design: .monospaced))
                 .tracking(1)
                 .foregroundStyle(ShellPalette.text)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 7)
-                .background(Color(red: 0.15, green: 0.12, blue: 0.10).opacity(0.92))
+                .background(decorStyle.wall.opacity(0.92))
                 .overlay(
                     RoundedRectangle(cornerRadius: 3, style: .continuous)
-                        .stroke(Color(red: 0.75, green: 0.54, blue: 0.30).opacity(0.34), lineWidth: 1)
+                        .stroke(decorStyle.accent.opacity(0.46), lineWidth: 1)
                 )
                 .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
                 .position(x: size.width * 0.50, y: size.height * 0.06)
@@ -287,6 +418,232 @@ struct MeetingRoomView: View {
             }
         }
         .accessibilityHidden(true)
+    }
+
+    private func roomFloor(size: CGSize) -> some View {
+        ZStack {
+            Rectangle()
+                .fill(decorStyle.floorBase)
+
+            ForEach(0..<14, id: \.self) { index in
+                Rectangle()
+                    .fill(index.isMultiple(of: 2) ? Color.white.opacity(0.045) : Color.black.opacity(0.045))
+                    .frame(height: max(16, size.height / 22))
+                    .position(x: size.width / 2, y: size.height * (0.10 + CGFloat(index) * 0.055))
+            }
+
+            ForEach(1..<8, id: \.self) { index in
+                Rectangle()
+                    .fill(Color.black.opacity(0.12))
+                    .frame(width: 1, height: size.height * 0.78)
+                    .position(x: size.width * CGFloat(index) / 8, y: size.height * 0.52)
+            }
+
+            Rectangle()
+                .fill(Color(red: 0.78, green: 0.90, blue: 0.84).opacity(0.94))
+                .frame(width: size.width * 0.27, height: size.height * 0.28)
+                .overlay(tilePattern(size: CGSize(width: size.width * 0.27, height: size.height * 0.28)))
+                .position(x: size.width * 0.82, y: size.height * 0.18)
+
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(decorStyle == .lounge ? Color(red: 0.79, green: 0.66, blue: 0.44).opacity(0.92) : Color(red: 0.72, green: 0.55, blue: 0.34).opacity(0.72))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .stroke(decorStyle.accent.opacity(0.30), lineWidth: 2)
+                )
+                .frame(width: size.width * 0.28, height: size.height * 0.26)
+                .position(x: size.width * 0.79, y: size.height * 0.73)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func tilePattern(size: CGSize) -> some View {
+        ZStack {
+            ForEach(1..<4, id: \.self) { index in
+                Rectangle()
+                    .fill(Color.white.opacity(0.34))
+                    .frame(width: 1, height: size.height)
+                    .position(x: size.width * CGFloat(index) / 4, y: size.height / 2)
+                Rectangle()
+                    .fill(Color.white.opacity(0.34))
+                    .frame(width: size.width, height: 1)
+                    .position(x: size.width / 2, y: size.height * CGFloat(index) / 4)
+            }
+        }
+    }
+
+    private func wallFrame(size: CGSize) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(decorStyle.wall.opacity(0.92), lineWidth: 18)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(decorStyle.accent.opacity(0.32), lineWidth: 3)
+                .padding(13)
+            HStack(spacing: 8) {
+                ForEach(0..<3, id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(Color(red: 0.62, green: 0.82, blue: 0.89).opacity(0.64))
+                        .frame(width: 38, height: 18)
+                        .overlay(Rectangle().stroke(Color.white.opacity(0.25), lineWidth: 1))
+                }
+            }
+            .position(x: size.width * 0.20, y: size.height * 0.055)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func placementFootprints(size: CGSize) -> some View {
+        ZStack {
+            footprint(size: size, x: 0.23, y: 0.63, width: 0.18, height: 0.16, tint: ShellPalette.accentWarm)
+            footprint(size: size, x: 0.47, y: 0.63, width: 0.18, height: 0.16, tint: ShellPalette.accentWarm)
+            footprint(size: size, x: 0.79, y: 0.72, width: 0.24, height: 0.20, tint: decorStyle.accent)
+            footprint(size: size, x: 0.47, y: 0.29, width: 0.28, height: 0.20, tint: ShellPalette.accent)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func footprint(size: CGSize, x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat, tint: Color) -> some View {
+        RoundedRectangle(cornerRadius: 3, style: .continuous)
+            .fill(tint.opacity(0.10))
+            .overlay(
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .stroke(tint.opacity(0.32), style: StrokeStyle(lineWidth: 1, dash: [5, 5]))
+            )
+            .frame(width: size.width * width, height: size.height * height)
+            .position(x: size.width * x, y: size.height * y)
+    }
+
+    private func meetingTable(size: CGSize) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color(red: 0.47, green: 0.24, blue: 0.12))
+                .frame(width: size.width * 0.21, height: size.height * 0.075)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .stroke(Color.black.opacity(0.28), lineWidth: 2)
+                )
+                .position(x: size.width * 0.21, y: size.height * 0.31)
+            ForEach(0..<4, id: \.self) { index in
+                pixelChair
+                    .position(
+                        x: size.width * (0.13 + CGFloat(index) * 0.052),
+                        y: size.height * 0.255
+                    )
+                pixelChair
+                    .position(
+                        x: size.width * (0.13 + CGFloat(index) * 0.052),
+                        y: size.height * 0.365
+                    )
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .accessibilityHidden(true)
+    }
+
+    private func glassRoom(size: CGSize) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
+                .fill(Color(red: 0.66, green: 0.84, blue: 0.90).opacity(decorStyle == .glass ? 0.34 : 0.22))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .stroke(Color.white.opacity(0.42), lineWidth: 2)
+                )
+                .frame(width: size.width * 0.27, height: size.height * 0.22)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(Color(red: 0.45, green: 0.29, blue: 0.16).opacity(0.78))
+                .frame(width: size.width * 0.18, height: size.height * 0.045)
+            Rectangle()
+                .fill(Color.white.opacity(0.32))
+                .frame(width: 2, height: size.height * 0.20)
+                .offset(x: -size.width * 0.055)
+            Rectangle()
+                .fill(Color.white.opacity(0.32))
+                .frame(width: 2, height: size.height * 0.20)
+                .offset(x: size.width * 0.055)
+        }
+        .position(x: size.width * 0.49, y: size.height * 0.29)
+        .accessibilityHidden(true)
+    }
+
+    private func workstationCluster(size: CGSize) -> some View {
+        ZStack {
+            pixelDesk(size: size, x: 0.26, y: 0.61, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
+            pixelDesk(size: size, x: 0.42, y: 0.61, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
+            pixelDesk(size: size, x: 0.26, y: 0.78, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
+            pixelDesk(size: size, x: 0.42, y: 0.78, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
+        }
+        .frame(width: size.width, height: size.height)
+        .accessibilityHidden(true)
+    }
+
+    private func loungeCluster(size: CGSize) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color(red: 0.47, green: 0.22, blue: 0.58))
+                .frame(width: size.width * 0.16, height: size.height * 0.055)
+                .position(x: size.width * 0.78, y: size.height * 0.64)
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color(red: 0.40, green: 0.18, blue: 0.52))
+                .frame(width: size.width * 0.055, height: size.height * 0.15)
+                .position(x: size.width * 0.68, y: size.height * 0.73)
+            Circle()
+                .fill(Color(red: 0.88, green: 0.86, blue: 0.78))
+                .frame(width: 42, height: 42)
+                .overlay(Circle().stroke(Color.black.opacity(0.15), lineWidth: 2))
+                .position(x: size.width * 0.80, y: size.height * 0.74)
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color(red: 0.47, green: 0.22, blue: 0.58))
+                .frame(width: size.width * 0.11, height: size.height * 0.055)
+                .position(x: size.width * 0.87, y: size.height * 0.82)
+        }
+        .frame(width: size.width, height: size.height)
+        .accessibilityHidden(true)
+    }
+
+    private func utilityCorner(size: CGSize) -> some View {
+        ZStack {
+            pixelShelf(size: size, x: 0.79, y: 0.10)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(ShellPalette.panelDeeper)
+                .frame(width: 54, height: 34)
+                .overlay(Text("TV").font(.system(size: 9, weight: .black, design: .monospaced)).foregroundStyle(ShellPalette.faint))
+                .position(x: size.width * 0.91, y: size.height * 0.20)
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(Color(red: 0.82, green: 0.86, blue: 0.82))
+                .frame(width: 26, height: 44)
+                .overlay(Rectangle().fill(ShellPalette.accentWarm.opacity(0.7)).frame(width: 12, height: 10).offset(y: -10))
+                .position(x: size.width * 0.72, y: size.height * 0.22)
+        }
+        .frame(width: size.width, height: size.height)
+        .accessibilityHidden(true)
+    }
+
+    private func entranceDoor(size: CGSize) -> some View {
+        HStack(spacing: 3) {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(Color(red: 0.15, green: 0.76, blue: 0.89).opacity(0.86))
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(Color(red: 0.13, green: 0.68, blue: 0.82).opacity(0.86))
+        }
+        .frame(width: size.width * 0.12, height: size.height * 0.07)
+        .overlay(
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .stroke(decorStyle.wall.opacity(0.92), lineWidth: 4)
+        )
+        .position(x: size.width * 0.50, y: size.height * 0.965)
+        .accessibilityHidden(true)
+    }
+
+    private var pixelChair: some View {
+        VStack(spacing: 1) {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(Color(red: 0.12, green: 0.16, blue: 0.25))
+                .frame(width: 18, height: 13)
+            Rectangle()
+                .fill(Color.black.opacity(0.38))
+                .frame(width: 13, height: 4)
+        }
+        .frame(width: 22, height: 20)
     }
 
     private func zoneButtons(size: CGSize) -> [MeetingRoomZoneButton] {
@@ -332,10 +689,7 @@ struct MeetingRoomView: View {
                         path.move(to: from)
                         path.addLine(to: to)
                     }
-                    .stroke(
-                        stateTint(agent.visualState).opacity(0.24),
-                        style: StrokeStyle(lineWidth: 2, lineCap: .round, dash: [5, 8], dashPhase: CGFloat(phase * 8))
-                    )
+                    .stroke(stateTint(agent.visualState).opacity(0.2), lineWidth: 1.5)
 
                     Circle()
                         .fill(stateTint(agent.visualState))
@@ -527,7 +881,7 @@ struct MeetingRoomView: View {
 
     private func inboxBoard(size: CGSize) -> some View {
         VStack(spacing: 3) {
-            Text(language("YOUR INBOX", "YOUR INBOX"))
+            Text(language("YOUR INBOX", "받은 요청"))
             Text("\(inboxCount)")
                 .font(.system(size: 14, weight: .heavy, design: .monospaced))
         }
@@ -737,77 +1091,90 @@ private struct PixelAgentSprite: View {
     }
 
     private var spriteBody: some View {
-        let bob = isAnimated ? CGFloat(sin(phase * 1.3 + Double(abs(agent.id.hashValue % 7)))) * bobAmount : 0
-        let step = isAnimated ? CGFloat(sin(phase * 2.2 + Double(abs(agent.id.hashValue % 5)))) : 0
+        let seed = Double(abs(agent.id.hashValue % 11))
+        let bob = isAnimated ? CGFloat(sin(phase * 3.2 + seed)) * bobAmount : 0
+        let step = isAnimated ? CGFloat(sin(phase * 5.8 + seed)) : 0
+        let lean = agent.visualState == .running && isAnimated ? Double(step * 1.5) : 0
 
         return ZStack(alignment: .bottom) {
             if agent.visualState == .idle || agent.visualState == .running || agent.visualState == .done {
                 miniDesk
-                    .offset(y: 19)
+                    .offset(y: 21)
             }
 
             VStack(spacing: 0) {
                 compactHead
 
-                HStack(spacing: 0) {
-                    Rectangle()
-                        .fill(skinTint.opacity(0.96))
-                        .frame(width: 5, height: 15)
-                        .offset(x: -1, y: 3)
-                        .rotationEffect(.degrees(Double(step * 8)))
-
-                    Rectangle()
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
                         .fill(outfitTint)
-                        .frame(width: 23, height: 27)
+                        .frame(width: 24, height: 25)
                         .overlay(
-                            Image(systemName: roleIcon)
-                                .font(.system(size: 8, weight: .black))
-                                .foregroundStyle(ShellPalette.text.opacity(0.86))
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .stroke(Color.black.opacity(0.18), lineWidth: 1)
                         )
-
-                    Rectangle()
-                        .fill(skinTint.opacity(0.96))
-                        .frame(width: 5, height: 15)
-                        .offset(x: 1, y: 3)
-                        .rotationEffect(.degrees(Double(step * -8)))
+                    Image(systemName: roleIcon)
+                        .font(.system(size: 8, weight: .black))
+                        .foregroundStyle(ShellPalette.text.opacity(0.86))
+                        .offset(y: 1)
+                    HStack(spacing: 21) {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(skinTint.opacity(0.96))
+                            .frame(width: 5, height: 14)
+                            .rotationEffect(.degrees(Double(step * 10)))
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(skinTint.opacity(0.96))
+                            .frame(width: 5, height: 14)
+                            .rotationEffect(.degrees(Double(step * -10)))
+                    }
+                    .offset(y: 3)
                 }
 
-                HStack(spacing: 4) {
-                    Rectangle()
+                HStack(spacing: 5) {
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
                         .fill(ShellPalette.panelDeeper)
-                        .frame(width: 8, height: 8)
+                        .frame(width: 7, height: 8)
                         .offset(y: isAnimated ? max(0, step) * 2 : 0)
-                    Rectangle()
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
                         .fill(ShellPalette.panelDeeper)
-                        .frame(width: 8, height: 8)
+                        .frame(width: 7, height: 8)
                         .offset(y: isAnimated ? max(0, -step) * 2 : 0)
                 }
             }
             .offset(y: bob)
-            .rotationEffect(.degrees(agent.visualState == .running && isAnimated ? Double(step * 1.2) : 0))
+            .rotationEffect(.degrees(lean))
 
             if agent.visualState == .running {
                 deskKeyboard
-                    .offset(y: 14)
+                    .offset(y: 16)
             }
         }
-        .frame(width: 58, height: 66)
+        .frame(width: 58, height: 68)
     }
 
     private var compactHead: some View {
-        ZStack(alignment: .top) {
-            Rectangle()
+        ZStack {
+            RoundedRectangle(cornerRadius: 5, style: .continuous)
                 .fill(skinTint)
-                .frame(width: 25, height: 20)
+                .frame(width: 25, height: 22)
                 .overlay(
-                    Rectangle()
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
                         .stroke(Color.black.opacity(0.18), lineWidth: 1)
                 )
 
-            Rectangle()
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
                 .fill(hairTint)
-                .frame(width: 27, height: 7)
-                .offset(y: -3)
+                .frame(width: 27, height: 8)
+                .offset(y: -8)
+            HStack(spacing: 15) {
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(hairTint.opacity(0.92))
+                    .frame(width: 5, height: 10)
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(hairTint.opacity(0.92))
+                    .frame(width: 5, height: 10)
+            }
+            .offset(y: -2)
 
             HStack(spacing: 7) {
                 eye(left: true)
@@ -816,11 +1183,17 @@ private struct PixelAgentSprite: View {
                     .frame(width: 4, height: 4)
             }
             .scaleEffect(0.62)
-            .offset(y: 6)
+            .offset(y: 1)
 
             mouth
                 .scaleEffect(0.48)
-                .offset(y: 13)
+                .offset(y: 9)
+
+            HStack(spacing: 14) {
+                Rectangle().fill(Color.white.opacity(0.24)).frame(width: 3, height: 2)
+                Rectangle().fill(Color.white.opacity(0.24)).frame(width: 3, height: 2)
+            }
+            .offset(y: 7)
 
             compactHeadwear
         }

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -187,6 +187,36 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func batchEditAgentSelectionDoesNotImplyModelOverride() {
+        let payload = OrgProfileBatchEditPayloadDraft.build(
+            batchAgent: " codex ",
+            batchModel: OrgProfileBatchEditPayloadDraft.modelAfterAgentSelection(),
+            batchCapabilities: "",
+            batchEnabled: nil
+        )
+
+        #expect(payload.agentCli == "codex")
+        #expect(payload.model == nil)
+        #expect(payload.specialties == nil)
+        #expect(payload.enabled == nil)
+    }
+
+    @Test
+    func batchEditPayloadKeepsExplicitModelAndCapabilities() {
+        let payload = OrgProfileBatchEditPayloadDraft.build(
+            batchAgent: "opencode",
+            batchModel: " opencode/nemotron-3-super-free ",
+            batchCapabilities: "qa, review, , deploy",
+            batchEnabled: false
+        )
+
+        #expect(payload.agentCli == "opencode")
+        #expect(payload.model == "opencode/nemotron-3-super-free")
+        #expect(payload.specialties == ["qa", "review", "deploy"])
+        #expect(payload.enabled == false)
+    }
+
+    @Test
     func shellModeDefaultsToCompanyAndCanSwitchToTui() {
         let store = DesktopStore()
 

--- a/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
@@ -247,6 +247,43 @@ struct MeetingRoomProjectionTests {
     }
 
     @Test
+    func nilCompanyRuntimeSelectionDoesNotBorrowFirstCompanyRuntime() {
+        let selectedRuntime = MeetingRoomProjection.runtime(
+            for: nil,
+            in: [runtime(companyId: "company-a", status: "RUNNING", budgetPausedAt: 100)]
+        )
+        let projection = MeetingRoomProjection.build(
+            companyId: nil,
+            agents: [],
+            issues: [],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: selectedRuntime,
+            activity: [],
+            messages: []
+        )
+
+        #expect(selectedRuntime == nil)
+        #expect(projection.runtimeStatus == "STOPPED")
+        #expect(projection.todaySpentCents == 0)
+        #expect(!projection.isCostBlocked)
+    }
+
+    @Test
+    func runtimeSelectionScopesToSelectedCompany() throws {
+        let selectedRuntime = try #require(MeetingRoomProjection.runtime(
+            for: "company-b",
+            in: [
+                runtime(companyId: "company-a", status: "STOPPED"),
+                runtime(companyId: "company-b", status: "RUNNING"),
+            ]
+        ))
+
+        #expect(selectedRuntime.companyId == "company-b")
+        #expect(selectedRuntime.status == "RUNNING")
+    }
+
+    @Test
     func projectionCapsLargeIssueAndReviewDetailsForMeetingRoomSnapshotBudget() {
         let issues = (0..<250).map { index in
             issue(
@@ -315,6 +352,69 @@ struct MeetingRoomProjectionTests {
         #expect(!grouped.shouldAnimate)
         #expect(reduced.mode == .grouped)
         #expect(!reduced.shouldAnimate)
+    }
+
+    @Test
+    func renderPlanAnimatesOnlyActualRuntimeMotion() {
+        let idleProjection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "idle-builder", title: "Builder")],
+            issues: [],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(),
+            activity: [],
+            messages: []
+        )
+        let idlePlan = MeetingRoomRenderPlan.build(
+            projection: idleProjection,
+            isCompact: false,
+            reduceMotion: false,
+            lowResourceMode: false,
+            isSceneActive: true
+        )
+        let blockedProjection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "blocked-builder", title: "Builder")],
+            issues: [issue(id: "issue-blocked", title: "Blocked work", status: "BLOCKED", assigneeProfileId: "Builder")],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: []
+        )
+        let blockedPlan = MeetingRoomRenderPlan.build(
+            projection: blockedProjection,
+            isCompact: false,
+            reduceMotion: false,
+            lowResourceMode: false,
+            isSceneActive: true
+        )
+
+        let activeProjection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "active-builder", title: "Builder")],
+            issues: [issue(id: "issue-active", title: "Active work", status: "IN_PROGRESS", assigneeProfileId: "Builder")],
+            runningSessions: [session(agentId: "active-builder", agentName: "opencode", issueId: "issue-active", status: "RUNNING")],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: []
+        )
+        let activePlan = MeetingRoomRenderPlan.build(
+            projection: activeProjection,
+            isCompact: false,
+            reduceMotion: false,
+            lowResourceMode: false,
+            isSceneActive: true
+        )
+
+        #expect(!idlePlan.shouldAnimate)
+        #expect(idlePlan.frameInterval == 1.0)
+        #expect(!blockedPlan.shouldAnimate)
+        #expect(blockedPlan.frameInterval == 1.0)
+        #expect(activePlan.shouldAnimate)
+        #expect(activePlan.frameInterval == 1.0 / 15.0)
     }
 }
 
@@ -493,9 +593,9 @@ private func message(id: String, from: String, to: String?, issueId: String?, bo
     )
 }
 
-private func runtime(status: String = "RUNNING", budgetPausedAt: Int64? = nil) -> CompanyRuntimeSnapshotRecord {
+private func runtime(companyId: String? = "company", status: String = "RUNNING", budgetPausedAt: Int64? = nil) -> CompanyRuntimeSnapshotRecord {
     CompanyRuntimeSnapshotRecord(
-        companyId: "company",
+        companyId: companyId,
         status: status,
         tickIntervalSeconds: 60,
         activeGoalCount: 1,

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -4899,6 +4899,7 @@ class DesktopAppService(
             val activeGoals = current.goals.filter {
                 it.companyId == companyId && it.status == GoalStatus.ACTIVE
             }
+            val activeGoalIds = activeGoals.map { it.id }.toSet()
             val autonomousGoals = activeGoals.filter { it.autonomyEnabled }
             val autonomousGoalIds = autonomousGoals.map { it.id }.toSet()
 
@@ -4918,8 +4919,6 @@ class DesktopAppService(
                         is RuntimeCommand.StartIssue -> Unit
                     }
                 }
-            } else {
-                actions += "idle-no-autonomous-goals"
             }
 
             val executionSnapshot = stateStore.load()
@@ -4966,7 +4965,7 @@ class DesktopAppService(
             val now = System.currentTimeMillis()
             val runnableIssues = boundExecution.issues
                 .filter { issue ->
-                    issue.goalId in autonomousGoalIds
+                    issue.goalId in activeGoalIds
                 }
                 .filter { issue -> issue.runtimeDisposition == "RUNNABLE" }
                 .filter { issue -> issue.status in setOf(IssueStatus.PLANNED, IssueStatus.BACKLOG, IssueStatus.DELEGATED) }
@@ -4994,6 +4993,13 @@ class DesktopAppService(
                     )
                     val latestTask = tasksByIssueId[issue.id].orEmpty()
                         .maxByOrNull { it.updatedAt }
+                    val hasFailedExecutionHistory = tasksByIssueId[issue.id].orEmpty().any { task ->
+                        task.status == DesktopTaskStatus.FAILED
+                    }
+                    val recoveredNonAutonomousDuringThisTick =
+                        issue.updatedAt >= tickStartedAt &&
+                            hasFailedExecutionHistory &&
+                            issue.goalId !in autonomousGoalIds
                     val reopenedLegacyMergeConflict = issue.transitionReason?.contains(
                         "legacy CEO merge-conflict blocker",
                         ignoreCase = true
@@ -5002,8 +5008,15 @@ class DesktopAppService(
                     val waitingForRetryCooldown =
                         issue.status in setOf(IssueStatus.PLANNED, IssueStatus.BACKLOG, IssueStatus.DELEGATED) &&
                             retryDecision.mode == RecoverableRetryMode.WAITING
-                    dependenciesSatisfied && !alreadyStarted && !waitingForRetryCooldown && !reopenedDuringThisTick
+                    dependenciesSatisfied &&
+                        !alreadyStarted &&
+                        !waitingForRetryCooldown &&
+                        !recoveredNonAutonomousDuringThisTick &&
+                        !reopenedDuringThisTick
                 }
+            if (autonomousGoals.isEmpty() && runnableIssues.isEmpty()) {
+                actions += "idle-no-autonomous-goals"
+            }
             val delegatedRunnableIssues = runnableIssues.map { candidate ->
                 val delegated = if (candidate.assigneeProfileId == null || candidate.status != IssueStatus.DELEGATED) {
                     delegateIssue(candidate.id)

--- a/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
@@ -510,6 +510,7 @@ class DesktopStateStore(
  */
 fun defaultDesktopAppHome(): Path {
     val overriddenHome = sequenceOf(
+        System.getProperty("cotor.desktop.app.home"),
         System.getenv("COTOR_DESKTOP_APP_HOME"),
         System.getenv("COTOR_APP_HOME")
     )

--- a/src/main/kotlin/com/cotor/app/ExecutionBackends.kt
+++ b/src/main/kotlin/com/cotor/app/ExecutionBackends.kt
@@ -8,6 +8,7 @@ package com.cotor.app
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
+import com.cotor.data.http.CotorHttpClients
 import com.cotor.domain.executor.AgentExecutor
 import com.cotor.model.AgentConfig
 import com.cotor.model.AgentExecutionMetadata
@@ -18,7 +19,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.net.URI
-import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
@@ -81,7 +81,7 @@ class CodexAppServerBackend(
         canPublishPullRequests = true
     )
 
-    private val client = HttpClient.newBuilder().build()
+    private val client = CotorHttpClients.newClient()
 
     override suspend fun health(config: BackendConnectionConfig): ExecutionBackendStatus = withContext(Dispatchers.IO) {
         if (!config.enabled) {

--- a/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
+++ b/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
@@ -8,6 +8,7 @@ package com.cotor.app
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
+import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.process.ProcessManager
 import com.cotor.model.ProcessExecutionException
 import com.cotor.model.ProcessResult
@@ -110,7 +111,7 @@ class GitWorkspaceService(
     private val durableRuntimeService: DurableRuntimeService = DurableRuntimeService(),
     private val actionExecutionService: ActionExecutionService =
         ActionExecutionService(durableRuntimeService = durableRuntimeService, logger = logger),
-    private val httpClient: HttpClient = HttpClient.newBuilder().build(),
+    private val httpClient: HttpClient = CotorHttpClients.newClient(),
     private val githubHttpEnabledProvider: () -> Boolean = {
         val flag = System.getenv("COTOR_GITHUB_HTTP")?.trim()?.lowercase()
         flag == "1" || flag == "true"

--- a/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
+++ b/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
@@ -175,6 +175,7 @@ class CheckpointManager(
 
 private fun defaultCheckpointDir(): String {
     val overriddenHome = sequenceOf(
+        System.getProperty("cotor.desktop.app.home"),
         System.getenv("COTOR_DESKTOP_APP_HOME"),
         System.getenv("COTOR_APP_HOME")
     )

--- a/src/main/kotlin/com/cotor/data/plugin/CommandPlugin.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/CommandPlugin.kt
@@ -63,7 +63,13 @@ class CommandPlugin : AgentPlugin {
 
         // Resolve `{input}` substitutions before deciding whether stdin should also be used.
         // This keeps the command template deterministic from the config alone.
-        val argv = parseArgvJson(argvJson).map { token ->
+        val argvTemplate = parseArgvJson(argvJson)
+        if (argvTemplate.isEmpty()) {
+            throw IllegalArgumentException("argvJson must contain at least one element (the executable)")
+        }
+        context.validateCommand?.invoke(argvTemplate)
+
+        val argv = argvTemplate.map { token ->
             if (token.contains("{input}")) {
                 token.replace("{input}", context.input.orEmpty())
             } else {
@@ -73,10 +79,6 @@ class CommandPlugin : AgentPlugin {
 
         val useStdin = context.parameters["stdin"]?.lowercase() == "true"
         val stdin = if (useStdin) context.input else null
-
-        if (argv.isEmpty()) {
-            throw IllegalArgumentException("argvJson must contain at least one element (the executable)")
-        }
 
         var result = processManager.executeProcess(
             command = argv,

--- a/src/main/kotlin/com/cotor/data/plugin/OpenAIPlugin.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/OpenAIPlugin.kt
@@ -8,6 +8,7 @@ package com.cotor.data.plugin
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
+import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.process.ProcessManager
 import com.cotor.model.*
 import kotlinx.coroutines.Dispatchers
@@ -21,7 +22,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.net.URI
-import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
@@ -89,7 +89,7 @@ class OpenAIPlugin : AgentPlugin {
     )
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val http = HttpClient.newBuilder()
+    private val http = CotorHttpClients.newBuilder()
         .connectTimeout(Duration.ofSeconds(20))
         .build()
 

--- a/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
+++ b/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
@@ -179,7 +179,8 @@ class DefaultAgentExecutor(
                     workingDirectory = metadata.workingDirectory,
                     pipelineContext = metadata.pipelineContext,
                     currentStageId = metadata.stageId,
-                    onProcessStarted = metadata.onProcessStarted
+                    onProcessStarted = metadata.onProcessStarted,
+                    validateCommand = securityValidator::validateCommand
                 )
 
                 // Time only the plugin body itself so reported duration reflects the

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -204,7 +204,10 @@ class DefaultPipelineOrchestrator(
                             output = null,
                             error = e.message,
                             duration = 0,
-                            metadata = mapOf("failureCategory" to FailureCategory.CONFIG_ERROR.name)
+                            metadata = mapOf(
+                                "stageId" to "pipeline-config",
+                                "failureCategory" to FailureCategory.CONFIG_ERROR.name
+                            )
                         )
                         pipelineContext.addStageResult("pipeline-config", configErrorResult)
                         throw e
@@ -239,12 +242,12 @@ class DefaultPipelineOrchestrator(
                 observability.completePipeline(pipelineObservation, finalResult)
 
                 // Record execution statistics
-                val stageExecutions = pipelineContext.stageResults.values.map {
+                val stageExecutions = finalResult.results.map {
                     com.cotor.stats.StageExecution(
-                        name = it.agentName,
+                        name = it.metadata["stageId"] ?: it.agentName,
                         duration = it.duration,
                         status = if (it.isSuccess) com.cotor.stats.ExecutionStatus.SUCCESS else com.cotor.stats.ExecutionStatus.FAILURE,
-                        retries = it.metadata["retries"] as? Int ?: 0
+                        retries = it.metadata["retries"]?.toIntOrNull() ?: 0
                     )
                 }
                 statsManager.recordExecution(pipeline.name, finalResult, stageExecutions)
@@ -383,6 +386,7 @@ class DefaultPipelineOrchestrator(
             throw PipelineException("Stage ${it.id} uses ${it.type} which is not supported in DAG mode")
         }
         val results = mutableMapOf<String, AgentResult>()
+        validateDagDependencies(pipeline.stages)
         val sortedStages = topologicalSort(pipeline.stages)
 
         for (stage in sortedStages) {
@@ -423,6 +427,34 @@ class DefaultPipelineOrchestrator(
 
         stages.forEach { visit(it) }
         return sorted
+    }
+
+    private fun validateDagDependencies(stages: List<PipelineStage>) {
+        val stageIds = stages.map { it.id }.toSet()
+        stages.forEach { stage ->
+            stage.dependencies.forEach { depId ->
+                if (depId !in stageIds) {
+                    throw PipelineException("Stage '${stage.id}': Dependency '$depId' not found")
+                }
+            }
+        }
+
+        val visited = mutableSetOf<String>()
+        val visiting = mutableSetOf<String>()
+        val stageMap = stages.associateBy { it.id }
+
+        fun visit(stageId: String) {
+            if (stageId in visiting) {
+                throw PipelineException("Stage '$stageId': Circular dependency detected")
+            }
+            if (stageId in visited) return
+            visiting.add(stageId)
+            stageMap.getValue(stageId).dependencies.forEach(::visit)
+            visiting.remove(stageId)
+            visited.add(stageId)
+        }
+
+        stageIds.forEach(::visit)
     }
 
     private suspend fun executeMap(
@@ -520,7 +552,7 @@ class DefaultPipelineOrchestrator(
                 output = null,
                 error = e.message ?: "Stage ${stage.id} failed",
                 duration = 0,
-                metadata = emptyMap()
+                metadata = stageMetadata(stage)
             )
             pipelineContext.addStageResult(stage.id, failureResult)
             saveCheckpoint(pipelineId, pipelineContext.pipelineName, pipelineContext)
@@ -539,9 +571,12 @@ class DefaultPipelineOrchestrator(
                 output = null,
                 error = errorMessage,
                 duration = stage.timeoutMs ?: 0,
-                metadata = mapOf(
-                    "timeout" to "true",
-                    "failureCategory" to FailureCategory.TIMEOUT.name
+                metadata = stageMetadata(
+                    stage,
+                    mapOf(
+                        "timeout" to "true",
+                        "failureCategory" to FailureCategory.TIMEOUT.name
+                    )
                 )
             )
             pipelineContext.addStageResult(stage.id, timeoutResult)
@@ -556,22 +591,34 @@ class DefaultPipelineOrchestrator(
             return timeoutResult
         }
 
-        pipelineContext.addStageResult(stage.id, result)
+        val stageResult = result.withStageMetadata(stage)
+        pipelineContext.addStageResult(stage.id, stageResult)
 
-        if (result.isSuccess) {
+        if (stageResult.isSuccess) {
             saveCheckpoint(pipelineId, pipelineContext.pipelineName, pipelineContext)
-            durableRuntimeService.recordStageCompleted(pipelineContext, stage, result)
-            observability.completeStage(stageObservation, result)
-            eventBus.emit(StageCompletedEvent(stage.id, pipelineId, result))
+            durableRuntimeService.recordStageCompleted(pipelineContext, stage, stageResult)
+            observability.completeStage(stageObservation, stageResult)
+            eventBus.emit(StageCompletedEvent(stage.id, pipelineId, stageResult))
         } else {
             saveCheckpoint(pipelineId, pipelineContext.pipelineName, pipelineContext)
-            durableRuntimeService.recordStageFailed(pipelineContext, stage, result)
-            val error = RuntimeException(result.error ?: "Stage ${stage.id} failed")
+            durableRuntimeService.recordStageFailed(pipelineContext, stage, stageResult)
+            val error = RuntimeException(stageResult.error ?: "Stage ${stage.id} failed")
             observability.failStage(stageObservation, error)
             eventBus.emit(StageFailedEvent(stage.id, pipelineId, error))
         }
 
-        return result
+        return stageResult
+    }
+
+    private fun AgentResult.withStageMetadata(stage: PipelineStage): AgentResult {
+        return copy(metadata = stageMetadata(stage, metadata))
+    }
+
+    private fun stageMetadata(stage: PipelineStage, metadata: Map<String, String> = emptyMap()): Map<String, String> {
+        return metadata + mapOf(
+            "stageId" to stage.id,
+            "stageType" to stage.type.name
+        )
     }
 
     private suspend fun executeDecisionStage(
@@ -590,6 +637,8 @@ class DefaultPipelineOrchestrator(
             applySharedStateUpdates(outcome, pipelineContext)
 
             val metadata = mutableMapOf(
+                "stageId" to stage.id,
+                "stageType" to stage.type.name,
                 "conditionExpression" to condition.expression,
                 "conditionResult" to passed.toString(),
                 "nextAction" to outcome.action.name
@@ -676,9 +725,12 @@ class DefaultPipelineOrchestrator(
                 },
                 error = null,
                 duration = 0,
-                metadata = mapOf(
-                    "loopIteration" to completedIterations.toString(),
-                    "loopAction" to if (shouldRepeat) "CONTINUE" else "BREAK"
+                metadata = stageMetadata(
+                    stage,
+                    mapOf(
+                        "loopIteration" to completedIterations.toString(),
+                        "loopAction" to if (shouldRepeat) "CONTINUE" else "BREAK"
+                    )
                 )
             )
 

--- a/src/main/kotlin/com/cotor/integrations/linear/LinearTrackerAdapter.kt
+++ b/src/main/kotlin/com/cotor/integrations/linear/LinearTrackerAdapter.kt
@@ -10,6 +10,7 @@ package com.cotor.integrations.linear
 
 import com.cotor.app.CompanyIssue
 import com.cotor.app.LinearConnectionConfig
+import com.cotor.data.http.CotorHttpClients
 import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -53,7 +54,7 @@ interface LinearTrackerAdapter {
 
 class LinearClient(
     private val json: Json = Json { ignoreUnknownKeys = true },
-    private val httpClient: HttpClient = HttpClient.newBuilder().build()
+    private val httpClient: HttpClient = CotorHttpClients.newClient()
 ) {
     suspend fun graphql(
         config: LinearConnectionConfig,

--- a/src/main/kotlin/com/cotor/model/Models.kt
+++ b/src/main/kotlin/com/cotor/model/Models.kt
@@ -402,7 +402,8 @@ data class ExecutionContext(
     val workingDirectory: Path? = null,
     val pipelineContext: PipelineContext? = null,
     val currentStageId: String? = null,
-    val onProcessStarted: ((Long) -> Unit)? = null
+    val onProcessStarted: ((Long) -> Unit)? = null,
+    val validateCommand: ((List<String>) -> Unit)? = null
 )
 
 /**

--- a/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
@@ -9,6 +9,7 @@ package com.cotor.presentation.cli
  */
 
 import com.cotor.app.AppServer
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
@@ -33,6 +34,9 @@ class AppServerCommand : CliktCommand(
         .default(System.getenv("COTOR_APP_CONTROL_TOKEN").orEmpty())
 
     override fun run() {
+        if (requiresTokenForHost(host) && token.isBlank()) {
+            throw CliktError("--token or COTOR_APP_TOKEN is required when binding app-server to non-loopback host '$host'")
+        }
         AppServer().start(
             host = host,
             port = port,
@@ -40,4 +44,9 @@ class AppServerCommand : CliktCommand(
             controlToken = controlToken.ifBlank { null }
         )
     }
+}
+
+internal fun requiresTokenForHost(host: String): Boolean {
+    val normalized = host.trim().lowercase()
+    return normalized !in setOf("127.0.0.1", "localhost", "::1")
 }

--- a/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
@@ -9,8 +9,8 @@ package com.cotor.presentation.cli
  */
 
 import com.cotor.app.AppServer
-import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int

--- a/src/main/kotlin/com/cotor/presentation/cli/CompanyCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/CompanyCommand.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.switch
 import com.github.ajalt.clikt.parameters.types.choice
 import com.github.ajalt.clikt.parameters.types.int
 import kotlinx.coroutines.runBlocking
@@ -103,7 +104,12 @@ private class CompanyCreateCommand : CompanyServiceCommand(name = "create") {
     private val name by option("--name").required()
     private val rootPath by option("--root").required()
     private val baseBranch by option("--base-branch")
-    private val autonomyEnabled by option("--autonomy-enabled").flag(default = true)
+    private val autonomyEnabled by option("--autonomy-enabled", "--autonomy-disabled")
+        .switch(
+            "--autonomy-enabled" to true,
+            "--autonomy-disabled" to false
+        )
+        .default(true)
     private val dailyBudgetCents by option("--daily-budget-cents").int()
     private val monthlyBudgetCents by option("--monthly-budget-cents").int()
 

--- a/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
+++ b/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
@@ -27,8 +27,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.awt.Desktop
@@ -419,7 +419,7 @@ internal fun resolveEditorPath(
     }.toAbsolutePath().normalize()
 
     if (!candidate.startsWith(root)) {
-        throw IllegalArgumentException("Editor path must stay inside ${root}")
+        throw IllegalArgumentException("Editor path must stay inside $root")
     }
     return candidate
 }

--- a/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
+++ b/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
@@ -27,6 +27,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.awt.Desktop
@@ -152,6 +154,7 @@ class WebServer : KoinComponent {
 
     fun start(port: Int = 8080, openBrowser: Boolean = false, readOnly: Boolean = false, initialPath: String = "/") {
         ensureEditorDir()
+        val webToken = UUID.randomUUID().toString()
 
         if (openBrowser) {
             thread(name = "cotor-web-open") {
@@ -160,7 +163,7 @@ class WebServer : KoinComponent {
             }
         }
 
-        embeddedServer(Netty, port = port) {
+        embeddedServer(Netty, host = "127.0.0.1", port = port) {
             cotorWebModule(
                 configRepository = configRepository,
                 agentRegistry = agentRegistry,
@@ -168,6 +171,7 @@ class WebServer : KoinComponent {
                 desktopService = desktopService,
                 editorDir = editorDir,
                 readOnly = readOnly,
+                webToken = webToken,
                 buildTemplates = ::buildTemplates,
                 listSavedPipelines = ::listSavedPipelines,
                 loadPipelineDetail = ::loadPipelineDetail,
@@ -186,7 +190,7 @@ class WebServer : KoinComponent {
 
     private suspend fun savePipeline(request: EditorPipelineRequest): java.nio.file.Path {
         val safeName = sanitizeName(request.name)
-        val targetPath = request.path?.let { Path(it) } ?: editorDir.resolve("$safeName.yaml")
+        val targetPath = resolveEditorPath(editorDir, request.path, "$safeName.yaml")
 
         val agentNames = if (request.agents.isNotEmpty()) request.agents else request.stages.mapNotNull { it.agent }
         val agentConfigs = agentNames.distinct().map { agentName ->
@@ -400,6 +404,26 @@ class WebServer : KoinComponent {
     }
 }
 
+internal fun resolveEditorPath(
+    editorDir: java.nio.file.Path,
+    requestedPath: String?,
+    fallbackFileName: String
+): java.nio.file.Path {
+    val root = editorDir.toAbsolutePath().normalize()
+    val raw = requestedPath?.takeIf { it.isNotBlank() }
+    val candidate = if (raw == null) {
+        root.resolve(fallbackFileName)
+    } else {
+        val requested = Path(raw)
+        if (requested.isAbsolute) requested else root.resolve(requested)
+    }.toAbsolutePath().normalize()
+
+    if (!candidate.startsWith(root)) {
+        throw IllegalArgumentException("Editor path must stay inside ${root}")
+    }
+    return candidate
+}
+
 internal fun Application.cotorWebModule(
     configRepository: ConfigRepository,
     agentRegistry: AgentRegistry,
@@ -407,6 +431,7 @@ internal fun Application.cotorWebModule(
     desktopService: DesktopAppService,
     editorDir: java.nio.file.Path,
     readOnly: Boolean,
+    webToken: String? = null,
     buildTemplates: () -> List<EditorTemplatePayload>,
     listSavedPipelines: suspend () -> List<EditorPipelineSummary>,
     loadPipelineDetail: suspend (String) -> EditorPipelineDetail?,
@@ -418,7 +443,11 @@ internal fun Application.cotorWebModule(
         json()
     }
     install(CORS) {
-        anyHost()
+        allowHost("127.0.0.1", schemes = listOf("http"))
+        allowHost("localhost", schemes = listOf("http"))
+        allowHeader(HttpHeaders.Authorization)
+        allowHeader(HttpHeaders.ContentType)
+        allowHeader("X-Cotor-Web-Token")
     }
 
     routing {
@@ -427,11 +456,11 @@ internal fun Application.cotorWebModule(
         }
 
         get("/editor") {
-            call.respondText(editorHtml, ContentType.Text.Html)
+            call.respondText(editorHtml(webToken), ContentType.Text.Html)
         }
 
         get("/company") {
-            call.respondText(companyHtml, ContentType.Text.Html)
+            call.respondText(companyHtml(webToken), ContentType.Text.Html)
         }
 
         get("/help") {
@@ -533,6 +562,7 @@ internal fun Application.cotorWebModule(
         }
 
         post("/api/editor/save") {
+            if (!call.requireWebToken(webToken)) return@post
             if (readOnly) {
                 return@post call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Read-only mode"))
             }
@@ -543,18 +573,29 @@ internal fun Application.cotorWebModule(
             if (request.stages.isEmpty()) {
                 return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to "At least one stage is required"))
             }
-
-            val path = savePipeline(request)
-            call.respond(SaveResponse(ok = true, path = path.toString()))
+            try {
+                val path = savePipeline(request)
+                call.respond(SaveResponse(ok = true, path = path.toString()))
+            } catch (e: IllegalArgumentException) {
+                call.respond(HttpStatusCode.BadRequest, mapOf("error" to (e.message ?: "Invalid path")))
+            }
         }
 
         post("/api/editor/run") {
+            if (!call.requireWebToken(webToken)) return@post
             if (readOnly) {
                 return@post call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Read-only mode"))
             }
             val request = call.receive<EditorPipelineRequest>()
-            val configPath = request.path?.let { Path(it) }
-                ?: editorDir.resolve("${request.name.trim().lowercase().replace("[^a-z0-9-_]".toRegex(), "-")}.yaml")
+            val configPath = try {
+                resolveEditorPath(
+                    editorDir = editorDir,
+                    requestedPath = request.path,
+                    fallbackFileName = "${request.name.trim().lowercase().replace("[^a-z0-9-_]".toRegex(), "-")}.yaml"
+                )
+            } catch (e: IllegalArgumentException) {
+                return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to (e.message ?: "Invalid path")))
+            }
             if (!configPath.exists()) {
                 return@post call.respond(HttpStatusCode.NotFound, mapOf("error" to "Pipeline not saved yet"))
             }
@@ -619,6 +660,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 post {
+                    if (!call.requireWebToken(webToken)) return@post
                     val request = call.receive<CreateCompanyRequest>()
                     call.respond(
                         desktopService.createCompany(
@@ -645,6 +687,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 patch("/{companyId}") {
+                    if (!call.requireWebToken(webToken)) return@patch
                     val companyId = call.parameters["companyId"] ?: return@patch call.respond(HttpStatusCode.BadRequest)
                     val request = call.receive<UpdateCompanyRequest>()
                     call.respond(
@@ -661,6 +704,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 delete("/{companyId}") {
+                    if (!call.requireWebToken(webToken)) return@delete
                     val companyId = call.parameters["companyId"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.deleteCompany(companyId))
                 }
@@ -671,6 +715,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 patch("/{companyId}/agents/batch") {
+                    if (!call.requireWebToken(webToken)) return@patch
                     val companyId = call.parameters["companyId"] ?: return@patch call.respond(HttpStatusCode.BadRequest)
                     val request = call.receive<BatchUpdateCompanyAgentDefinitionsRequest>()
                     call.respond(
@@ -691,6 +736,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 post("/{companyId}/goals") {
+                    if (!call.requireWebToken(webToken)) return@post
                     val companyId = call.parameters["companyId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                     val request = call.receive<CreateGoalRequest>()
                     call.respond(
@@ -724,6 +770,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 post("/{companyId}/issues") {
+                    if (!call.requireWebToken(webToken)) return@post
                     val companyId = call.parameters["companyId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                     val request = call.receive<CreateIssueRequest>()
                     call.respond(
@@ -749,27 +796,32 @@ internal fun Application.cotorWebModule(
                 }
 
                 post("/{companyId}/runtime/start") {
+                    if (!call.requireWebToken(webToken)) return@post
                     val companyId = call.parameters["companyId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.startCompanyRuntime(companyId))
                 }
 
                 post("/{companyId}/runtime/stop") {
+                    if (!call.requireWebToken(webToken)) return@post
                     val companyId = call.parameters["companyId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.stopCompanyRuntime(companyId))
                 }
             }
 
             post("/issues/{issueId}/delegate") {
+                if (!call.requireWebToken(webToken)) return@post
                 val issueId = call.parameters["issueId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 call.respond(desktopService.delegateIssue(issueId))
             }
 
             post("/issues/{issueId}/run") {
+                if (!call.requireWebToken(webToken)) return@post
                 val issueId = call.parameters["issueId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 call.respond(desktopService.runIssue(issueId))
             }
 
             post("/review/{itemId}/merge") {
+                if (!call.requireWebToken(webToken)) return@post
                 val itemId = call.parameters["itemId"] ?: return@post call.respond(HttpStatusCode.BadRequest)
                 call.respond(desktopService.mergeReviewQueueItem(itemId))
             }
@@ -805,6 +857,30 @@ internal fun Application.cotorWebModule(
         durableRuntimeService = null
     )
 }
+
+private suspend fun ApplicationCall.requireWebToken(webToken: String?): Boolean {
+    val expected = webToken?.takeIf { it.isNotBlank() } ?: return true
+    val actualBearer = request.header(HttpHeaders.Authorization)
+    val actualHeader = request.header("X-Cotor-Web-Token")
+    if (actualBearer == "Bearer $expected" || actualHeader == expected) {
+        return true
+    }
+    respond(HttpStatusCode.Unauthorized, mapOf("error" to "Unauthorized"))
+    return false
+}
+
+private fun webTokenScript(webToken: String?): String {
+    val encoded = Json.encodeToString(webToken.orEmpty())
+    return "<script>window.COTOR_WEB_TOKEN = $encoded;</script>"
+}
+
+private fun webFetchHeaders(): String = """
+    function webHeaders(extra = {}) {
+      const headers = { ...extra };
+      if (window.COTOR_WEB_TOKEN) headers["X-Cotor-Web-Token"] = window.COTOR_WEB_TOKEN;
+      return headers;
+    }
+""".trimIndent()
 
 private fun openInBrowser(url: String) {
     try {
@@ -915,7 +991,7 @@ private val landingHtml = """
 </html>
 """.trimIndent()
 
-private val companyHtml = """
+private fun companyHtml(webToken: String?): String = """
 <!doctype html>
 <html lang="en">
 <head>
@@ -929,6 +1005,7 @@ private val companyHtml = """
     pre { background: #0f172a; color: #dbeafe; padding: 12px; border-radius: 12px; overflow: auto; }
     code { background: #e7eef8; padding: 2px 6px; border-radius: 6px; }
   </style>
+  ${webTokenScript(webToken)}
 </head>
 <body>
   <h1>Cotor Company Console</h1>
@@ -956,6 +1033,7 @@ private val companyHtml = """
     <pre id="output">Press "Load Dashboard" to fetch /api/company/dashboard</pre>
   </div>
   <script>
+    ${webFetchHeaders()}
     async function loadDashboard() {
       const response = await fetch('/api/company/dashboard');
       const data = await response.json();
@@ -1048,7 +1126,7 @@ private fun helpHtml(language: CliHelpLanguage): String {
 }
 
 // Lightweight HTML (single file) to keep the web UI self contained.
-private val editorHtml = """
+private fun editorHtml(webToken: String?): String = """
 <!doctype html>
 <html lang="ko">
 <head>
@@ -1112,6 +1190,7 @@ private val editorHtml = """
     .yaml-preview { font-family: "SFMono-Regular", ui-monospace, monospace; background: #0d1528; border: 1px solid var(--border); border-radius: 12px; padding: 12px; color: #cbd5e1; min-height: 160px; white-space: pre-wrap; }
     @media (max-width: 1024px) { .layout { grid-template-columns: 1fr; } }
   </style>
+  ${webTokenScript(webToken)}
 </head>
 <body>
   <div class="page">
@@ -1185,6 +1264,7 @@ private val editorHtml = """
   </div>
 
   <script>
+    ${webFetchHeaders()}
     const state = {
       name: "",
       description: "",
@@ -1430,7 +1510,7 @@ private val editorHtml = """
       try {
         const res = await fetch("/api/editor/save", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: webHeaders({ "Content-Type": "application/json" }),
           body: JSON.stringify({
             name: state.name,
             description: state.description,
@@ -1456,7 +1536,7 @@ private val editorHtml = """
       try {
         const res = await fetch("/api/editor/run", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: webHeaders({ "Content-Type": "application/json" }),
           body: JSON.stringify({ name: state.name, path: state.path })
         });
         const data = await res.json();

--- a/src/main/kotlin/com/cotor/security/SecurityValidator.kt
+++ b/src/main/kotlin/com/cotor/security/SecurityValidator.kt
@@ -69,7 +69,8 @@ class DefaultSecurityValidator(
         val executable = command.first()
 
         // Whitelist validation
-        if (config.useWhitelist && !config.allowedExecutables.contains(executable)) {
+        val executableName = runCatching { Path.of(executable).fileName?.toString() }.getOrNull()
+        if (config.useWhitelist && executable !in config.allowedExecutables && executableName !in config.allowedExecutables) {
             throw SecurityException("Executable not in whitelist: $executable")
         }
 

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -5,7 +5,7 @@ import com.cotor.app.AgentRunStatus
 import com.cotor.app.DesktopAppService
 import com.cotor.app.DesktopTuiSessionService
 import com.cotor.app.cotorAppModule
-import com.cotor.app.defaultDesktopAppHome
+import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -27,10 +27,12 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.nio.file.Files
 import kotlin.io.path.deleteRecursively
 import kotlin.io.path.exists
 
 @OptIn(kotlin.io.path.ExperimentalPathApi::class)
+@Isolate
 class A2aApiTest : FunSpec({
     val desktopService = mockk<DesktopAppService>(relaxed = true)
     val tuiSessionService = mockk<DesktopTuiSessionService>(relaxed = true)
@@ -38,9 +40,15 @@ class A2aApiTest : FunSpec({
 
     beforeTest {
         clearMocks(desktopService, tuiSessionService, answers = false, recordedCalls = true)
-        val a2aDir = defaultDesktopAppHome().resolve("a2a")
-        if (a2aDir.exists()) {
-            a2aDir.deleteRecursively()
+        val appHome = Files.createTempDirectory("a2a-api-test-home")
+        System.setProperty("cotor.desktop.app.home", appHome.toString())
+    }
+
+    afterTest {
+        val appHome = System.getProperty("cotor.desktop.app.home")?.let(java.nio.file.Paths::get)
+        System.clearProperty("cotor.desktop.app.home")
+        if (appHome != null && appHome.exists()) {
+            appHome.deleteRecursively()
         }
     }
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
@@ -3,6 +3,7 @@ package com.cotor.app
 import com.cotor.app.runtime.CompanyRuntimeBindingService
 import com.cotor.data.config.ConfigRepository
 import com.cotor.domain.executor.AgentExecutor
+import com.cotor.model.AgentResult
 import com.cotor.policy.PolicyEngine
 import com.cotor.policy.PolicyStore
 import com.cotor.providers.github.GitHubControlPlaneService
@@ -13,9 +14,12 @@ import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.runtime.durable.DurableRuntimeStore
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 import java.nio.file.Files
 
 class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
@@ -115,6 +119,98 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
 
         snapshot.lastAction shouldBe "idle-pending-issues"
         stateStore.load().tasks.shouldBeEmpty()
+    }
+
+    test("runCompanyRuntimeTick starts existing runnable issues when goal autonomy is disabled") {
+        val appHome = Files.createTempDirectory("desktop-runtime-manual-issue-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-manual-issue-repo").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedRuntimeDispositionWorkspace(stateStore, repoRoot)
+        val companyId = "company-manual"
+        val issueId = "issue-existing-manual"
+
+        val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+        coEvery { gitWorkspaceService.ensureWorktree(any(), any(), any(), any(), any()) } returns WorktreeBinding(
+            branchName = "codex/cotor/manual-issue/opencode",
+            worktreePath = repoRoot.resolve(".cotor/worktrees/manual-issue/opencode")
+        )
+        coEvery { gitWorkspaceService.publishRun(any(), any(), any(), any(), any(), any()) } returns PublishMetadata()
+
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } coAnswers {
+            delay(500)
+            AgentResult(
+                agentName = "opencode",
+                isSuccess = true,
+                output = "manual issue finished",
+                error = null,
+                duration = 500,
+                metadata = emptyMap()
+            )
+        }
+
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            agentExecutor = agentExecutor
+        )
+
+        val state = stateStore.load()
+        stateStore.save(
+            state.copy(
+                backendSettings = state.backendSettings.copy(codePublishMode = CodePublishMode.ALLOW_LOCAL_GIT),
+                companies = listOf(
+                    Company(
+                        id = companyId,
+                        name = "Manual Runtime Co",
+                        rootPath = repoRoot.toString(),
+                        repositoryId = "repo-1",
+                        defaultBaseBranch = "main",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                goals = listOf(
+                    CompanyGoal(
+                        id = "goal-manual",
+                        companyId = companyId,
+                        projectContextId = "project-1",
+                        title = "Manual goal",
+                        description = "Existing runnable work should run even when new autonomous planning is off.",
+                        status = GoalStatus.ACTIVE,
+                        autonomyEnabled = false,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                issues = listOf(
+                    CompanyIssue(
+                        id = issueId,
+                        companyId = companyId,
+                        projectContextId = "project-1",
+                        goalId = "goal-manual",
+                        workspaceId = "workspace-1",
+                        title = "Existing manual issue",
+                        description = "Run this issue.",
+                        status = IssueStatus.PLANNED,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                companyRuntimes = listOf(
+                    CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+                )
+            )
+        )
+
+        val snapshot = service.runCompanyRuntimeTick(companyId)
+        val refreshed = stateStore.load()
+
+        snapshot.lastAction shouldBe "started:$issueId"
+        refreshed.tasks.shouldNotBeEmpty()
+        refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
+        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 })
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -4351,13 +4351,23 @@ class DesktopAppServiceTest : FunSpec({
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-followup-nonrecoverable-test").resolve("repo"))
         val stateStore = DesktopStateStore { appHome }
         seedWorkspace(stateStore, repoRoot)
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } returns AgentResult(
+            agentName = "codex",
+            isSuccess = true,
+            output = "remediation task settled",
+            error = null,
+            duration = 100,
+            metadata = emptyMap()
+        )
         val service = testService(
             processManager = FakeGitProcessManager(
                 repoRoot = repoRoot,
                 remoteUrl = "https://github.com/heodongun/cotor.git",
                 defaultBranch = "master"
             ),
-            stateStore = stateStore
+            stateStore = stateStore,
+            agentExecutor = agentExecutor
         )
 
         val company = service.createCompany(
@@ -4412,19 +4422,38 @@ class DesktopAppServiceTest : FunSpec({
             updatedAt = System.currentTimeMillis()
         )
         val nonRecoverSnapshot = stateStore.load()
+        val siblingFollowUpIssueIds = nonRecoverSnapshot.issues
+            .filter { it.goalId == followUpGoal.id && it.kind == "execution" && it.id != remediationIssue.id }
+            .map { it.id }
+            .toSet()
+        val siblingFollowUpTaskIds = nonRecoverSnapshot.tasks
+            .filter { it.issueId in siblingFollowUpIssueIds }
+            .map { it.id }
+            .toSet()
+        val retryAt = System.currentTimeMillis()
         stateStore.save(
             nonRecoverSnapshot.copy(
                 issues = nonRecoverSnapshot.issues.map {
-                    if (it.id == remediationIssue.id) it.copy(status = IssueStatus.BLOCKED, updatedAt = System.currentTimeMillis()) else it
+                    when {
+                        it.id == remediationIssue.id -> it.copy(status = IssueStatus.BLOCKED, updatedAt = retryAt)
+                        it.goalId == followUpGoal.id && it.kind == "execution" -> it.copy(status = IssueStatus.DONE, updatedAt = retryAt)
+                        else -> it
+                    }
                 },
                 tasks = nonRecoverSnapshot.tasks.map {
-                    if (it.issueId == remediationIssue.id) {
-                        it.copy(status = DesktopTaskStatus.FAILED, updatedAt = System.currentTimeMillis())
+                    when {
+                        it.issueId == remediationIssue.id -> it.copy(status = DesktopTaskStatus.FAILED, updatedAt = retryAt)
+                        it.issueId in siblingFollowUpIssueIds -> it.copy(status = DesktopTaskStatus.COMPLETED, updatedAt = retryAt)
+                        else -> it
+                    }
+                },
+                runs = nonRecoverSnapshot.runs.map {
+                    if (it.taskId in siblingFollowUpTaskIds) {
+                        it.copy(status = AgentRunStatus.COMPLETED, updatedAt = retryAt)
                     } else {
                         it
                     }
-                },
-                runs = nonRecoverSnapshot.runs + failedRun
+                } + failedRun
             )
         )
 
@@ -6460,11 +6489,23 @@ class DesktopAppServiceTest : FunSpec({
             ready = true,
             originUrl = "https://github.com/heodongun/cotor-test.git"
         )
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } coAnswers {
+            delay(500)
+            AgentResult(
+                agentName = "codex",
+                isSuccess = true,
+                output = "recovery running",
+                error = null,
+                duration = 500,
+                metadata = emptyMap()
+            )
+        }
         val service = DesktopAppService(
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk(relaxed = true),
-            agentExecutor = mockk(relaxed = true)
+            agentExecutor = agentExecutor
         )
 
         val company = service.createCompany(
@@ -6547,11 +6588,15 @@ class DesktopAppServiceTest : FunSpec({
         service.runCompanyRuntimeTick(company.id)
 
         val finalState = stateStore.load()
-        finalState.issues.first { it.id == blockedIssue.id }.status shouldBe IssueStatus.PLANNED
+        finalState.issues.first { it.id == blockedIssue.id }.status shouldBe IssueStatus.IN_PROGRESS
         finalState.issues.first { it.id == blockedIssue.id }.blockedBy shouldBe emptyList()
         finalState.issues.first { it.id == blockedIssue.id }.transitionReason.shouldBeNull()
         finalState.issues.first { it.id == infraIssue.id }.status shouldBe IssueStatus.DONE
+        finalState.tasks.any { task ->
+            task.issueId == blockedIssue.id && task.status in setOf(DesktopTaskStatus.QUEUED, DesktopTaskStatus.RUNNING)
+        } shouldBe true
         coVerify(atLeast = 1) { gitWorkspaceService.ensureGitHubPublishReady(repoRoot, "master") }
+        service.shutdown()
     }
 
     test("QA pass reopens a blocked approval issue and clears stale CEO review metadata") {
@@ -9828,7 +9873,9 @@ private fun testService(
     processManager: ProcessManager,
     appHome: Path? = null,
     stateStore: DesktopStateStore? = null,
-    linearTracker: LinearTrackerAdapter = FakeLinearTrackerAdapter()
+    linearTracker: LinearTrackerAdapter = FakeLinearTrackerAdapter(),
+    agentExecutor: AgentExecutor = mockk(relaxed = true),
+    autoStartAutomationRefresh: Boolean = false
 ): DesktopAppService {
     val store = stateStore ?: DesktopStateStore { appHome ?: Files.createTempDirectory("cotor-home") }
     val gitWorkspaceService = GitWorkspaceService(
@@ -9840,8 +9887,9 @@ private fun testService(
         stateStore = store,
         gitWorkspaceService = gitWorkspaceService,
         configRepository = mockk<ConfigRepository>(relaxed = true),
-        agentExecutor = mockk<AgentExecutor>(relaxed = true),
-        linearTracker = linearTracker
+        agentExecutor = agentExecutor,
+        linearTracker = linearTracker,
+        autoStartAutomationRefresh = autoStartAutomationRefresh
     )
 }
 

--- a/src/test/kotlin/com/cotor/data/plugin/CommandPluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/CommandPluginTest.kt
@@ -1,0 +1,70 @@
+package com.cotor.data.plugin
+
+import com.cotor.data.process.ProcessManager
+import com.cotor.model.ExecutionContext
+import com.cotor.model.ProcessResult
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+
+class CommandPluginTest : FunSpec({
+    test("command plugin validates argv template before execution") {
+        val processManager = RecordingProcessManager()
+        val plugin = CommandPlugin()
+
+        shouldThrow<IllegalStateException> {
+            plugin.execute(
+                ExecutionContext(
+                    agentName = "command",
+                    input = null,
+                    parameters = mapOf("argvJson" to "[\"sh\",\"-c\",\"id\"]"),
+                    environment = emptyMap(),
+                    timeout = 1000,
+                    validateCommand = { throw IllegalStateException("blocked") }
+                ),
+                processManager
+            )
+        }
+
+        processManager.commands.size shouldBe 0
+    }
+
+    test("command plugin validates template while passing substituted input as literal argv") {
+        val processManager = RecordingProcessManager()
+        val validatedCommands = mutableListOf<List<String>>()
+        val plugin = CommandPlugin()
+
+        plugin.execute(
+            ExecutionContext(
+                agentName = "command",
+                input = "literal ; | < > input",
+                parameters = mapOf("argvJson" to "[\"/opt/homebrew/bin/qwen\",\"{input}\"]"),
+                environment = emptyMap(),
+                timeout = 1000,
+                validateCommand = { validatedCommands += it }
+            ),
+            processManager
+        )
+
+        validatedCommands.single().shouldContainExactly(listOf("/opt/homebrew/bin/qwen", "{input}"))
+        processManager.commands.single().shouldContainExactly(listOf("/opt/homebrew/bin/qwen", "literal ; | < > input"))
+    }
+})
+
+private class RecordingProcessManager : ProcessManager {
+    val commands = mutableListOf<List<String>>()
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        commands += command
+        return ProcessResult(exitCode = 0, stdout = "ok", stderr = "", isSuccess = true)
+    }
+}

--- a/src/test/kotlin/com/cotor/domain/executor/AgentExecutorTest.kt
+++ b/src/test/kotlin/com/cotor/domain/executor/AgentExecutorTest.kt
@@ -12,6 +12,7 @@ import com.cotor.data.plugin.AgentPlugin
 import com.cotor.data.plugin.PluginLoader
 import com.cotor.data.process.ProcessManager
 import com.cotor.model.AgentConfig
+import com.cotor.model.ExecutionContext
 import com.cotor.model.PluginExecutionOutput
 import com.cotor.model.ProcessExecutionException
 import com.cotor.security.SecurityValidator
@@ -22,6 +23,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.delay
 import org.slf4j.Logger
 
@@ -144,5 +146,29 @@ class AgentExecutorTest : FunSpec({
         result.isSuccess shouldBe false
         result.output shouldBe "{\"type\":\"error\",\"error\":{\"name\":\"UnknownError\",\"data\":{\"message\":\"Error: [DecimalError] Invalid argument: [object Object]\"}}}"
         result.error shouldBe "OpenCode execution failed (exit=1): {\"type\":\"error\",\"error\":{\"name\":\"UnknownError\",\"data\":{\"message\":\"Error: [DecimalError] Invalid argument: [object Object]\"}}}"
+    }
+
+    test("should wire command validation hook into execution context") {
+        val agentConfig = AgentConfig(
+            name = "command-agent",
+            pluginClass = "com.example.CommandPlugin",
+            timeout = 5000
+        )
+
+        val mockPlugin = mockk<AgentPlugin>()
+        coEvery { mockPlugin.execute(any(), any()) } coAnswers {
+            firstArg<ExecutionContext>().validateCommand?.invoke(listOf("git", "status"))
+            PluginExecutionOutput("validated")
+        }
+        every { mockPlugin.validateInput(any()) } returns com.cotor.model.ValidationResult.Success
+        every { mockPluginLoader.loadPlugin(any()) } returns mockPlugin
+        every { mockSecurityValidator.validate(any()) } just runs
+        every { mockSecurityValidator.validateCommand(any()) } just runs
+
+        val result = executor.executeAgent(agentConfig, null)
+
+        result.isSuccess shouldBe true
+        result.output shouldBe "validated"
+        verify(exactly = 1) { mockSecurityValidator.validateCommand(listOf("git", "status")) }
     }
 })

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorConditionalTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorConditionalTest.kt
@@ -33,6 +33,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
+import java.nio.file.Files
 
 class PipelineOrchestratorConditionalTest : FunSpec({
 
@@ -45,7 +46,10 @@ class PipelineOrchestratorConditionalTest : FunSpec({
         )
     }
 
-    fun createOrchestrator(executor: AgentExecutor): DefaultPipelineOrchestrator {
+    fun createOrchestrator(
+        executor: AgentExecutor,
+        statsManager: StatsManager = StatsManager(Files.createTempDirectory("conditional-stats").toString())
+    ): DefaultPipelineOrchestrator {
         return DefaultPipelineOrchestrator(
             agentExecutor = executor,
             resultAggregator = DefaultResultAggregator(DefaultResultAnalyzer()),
@@ -53,7 +57,7 @@ class PipelineOrchestratorConditionalTest : FunSpec({
             logger = LoggerFactory.getLogger("ConditionalTest"),
             agentRegistry = registry,
             outputValidator = DefaultOutputValidator(SyntaxValidator()),
-            statsManager = StatsManager()
+            statsManager = statsManager
         )
     }
 
@@ -114,6 +118,45 @@ class PipelineOrchestratorConditionalTest : FunSpec({
 
         executor.executionCount("draft") shouldBe 3 // initial + 2 loop iterations
         executor.executedStages.last() shouldBe "review"
+    }
+
+    test("loop stage statistics preserve every traversal by stage id") {
+        val executor = RecordingAgentExecutor()
+        val statsManager = StatsManager(Files.createTempDirectory("loop-stats").toString())
+        val orchestrator = createOrchestrator(executor, statsManager)
+
+        val pipeline = Pipeline(
+            name = "looping",
+            executionMode = ExecutionMode.SEQUENTIAL,
+            stages = listOf(
+                PipelineStage(id = "draft", agent = AgentReference("alpha")),
+                PipelineStage(
+                    id = "loop-controller",
+                    type = StageType.LOOP,
+                    loop = StageLoopConfig(
+                        targetStageId = "draft",
+                        maxIterations = 2
+                    )
+                ),
+                PipelineStage(id = "review", agent = AgentReference("alpha"))
+            )
+        )
+
+        runBlocking { orchestrator.executePipeline(pipeline) }
+
+        val execution = statsManager.loadStats("looping")!!.executions.single()
+        execution.stages.map { it.name }.shouldContainExactly(
+            listOf(
+                "draft",
+                "loop-controller",
+                "draft",
+                "loop-controller",
+                "draft",
+                "loop-controller",
+                "review"
+            )
+        )
+        execution.stages.map { it.duration }.shouldContainExactly(listOf(5L, 0L, 5L, 0L, 5L, 0L, 5L))
     }
 })
 

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorDagValidationTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorDagValidationTest.kt
@@ -1,0 +1,80 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.analysis.DefaultResultAnalyzer
+import com.cotor.data.registry.InMemoryAgentRegistry
+import com.cotor.domain.aggregator.DefaultResultAggregator
+import com.cotor.domain.executor.AgentExecutor
+import com.cotor.event.CoroutineEventBus
+import com.cotor.model.AgentConfig
+import com.cotor.model.AgentReference
+import com.cotor.model.ExecutionMode
+import com.cotor.model.Pipeline
+import com.cotor.model.PipelineException
+import com.cotor.model.PipelineStage
+import com.cotor.stats.StatsManager
+import com.cotor.validation.output.DefaultOutputValidator
+import com.cotor.validation.output.SyntaxValidator
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+
+class PipelineOrchestratorDagValidationTest : FunSpec({
+    fun createOrchestrator(executor: AgentExecutor): DefaultPipelineOrchestrator {
+        val registry = InMemoryAgentRegistry().apply {
+            registerAgent(AgentConfig(name = "alpha", pluginClass = "com.cotor.data.plugin.EchoPlugin"))
+        }
+        return DefaultPipelineOrchestrator(
+            agentExecutor = executor,
+            resultAggregator = DefaultResultAggregator(DefaultResultAnalyzer()),
+            eventBus = CoroutineEventBus(),
+            logger = LoggerFactory.getLogger("PipelineOrchestratorDagValidationTest"),
+            agentRegistry = registry,
+            outputValidator = DefaultOutputValidator(SyntaxValidator()),
+            statsManager = StatsManager(Files.createTempDirectory("dag-validation-stats").toString())
+        )
+    }
+
+    test("DAG mode rejects missing dependency before executing agents") {
+        val executor = mockk<AgentExecutor>(relaxed = true)
+        val orchestrator = createOrchestrator(executor)
+        val pipeline = Pipeline(
+            name = "missing-dependency",
+            executionMode = ExecutionMode.DAG,
+            stages = listOf(
+                PipelineStage(id = "a", agent = AgentReference("alpha"), dependencies = listOf("missing"))
+            )
+        )
+
+        val error = shouldThrow<PipelineException> {
+            runBlocking { orchestrator.executePipeline(pipeline) }
+        }
+
+        error.message shouldContain "Dependency 'missing' not found"
+        coVerify(exactly = 0) { executor.executeAgent(any(), any(), any()) }
+    }
+
+    test("DAG mode rejects circular dependency before executing agents") {
+        val executor = mockk<AgentExecutor>(relaxed = true)
+        val orchestrator = createOrchestrator(executor)
+        val pipeline = Pipeline(
+            name = "cycle",
+            executionMode = ExecutionMode.DAG,
+            stages = listOf(
+                PipelineStage(id = "a", agent = AgentReference("alpha"), dependencies = listOf("b")),
+                PipelineStage(id = "b", agent = AgentReference("alpha"), dependencies = listOf("a"))
+            )
+        )
+
+        val error = shouldThrow<PipelineException> {
+            runBlocking { orchestrator.executePipeline(pipeline) }
+        }
+
+        error.message shouldContain "Circular dependency detected"
+        coVerify(exactly = 0) { executor.executeAgent(any(), any(), any()) }
+    }
+})

--- a/src/test/kotlin/com/cotor/presentation/cli/AppServerCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/AppServerCommandTest.kt
@@ -1,0 +1,17 @@
+package com.cotor.presentation.cli
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AppServerCommandTest : FunSpec({
+    test("app-server allows loopback bind without token") {
+        requiresTokenForHost("127.0.0.1") shouldBe false
+        requiresTokenForHost("localhost") shouldBe false
+        requiresTokenForHost("::1") shouldBe false
+    }
+
+    test("app-server requires token for non-loopback bind") {
+        requiresTokenForHost("0.0.0.0") shouldBe true
+        requiresTokenForHost("192.168.0.10") shouldBe true
+    }
+})

--- a/src/test/kotlin/com/cotor/presentation/cli/CompanyCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/CompanyCommandTest.kt
@@ -53,6 +53,34 @@ class CompanyCommandTest : FunSpec({
         result.output shouldContain "\"name\": \"Test Company\""
     }
 
+    test("company create can disable autonomy at creation time") {
+        coEvery {
+            service.createCompany(
+                name = "Smoke",
+                rootPath = "/tmp/company",
+                defaultBaseBranch = null,
+                autonomyEnabled = false,
+                dailyBudgetCents = null,
+                monthlyBudgetCents = null
+            )
+        } returns Company(
+            id = "company-disabled",
+            name = "Smoke",
+            rootPath = "/tmp/company",
+            repositoryId = "repo-1",
+            defaultBaseBranch = "master",
+            autonomyEnabled = false,
+            createdAt = 1L,
+            updatedAt = 2L
+        )
+
+        val result = CompanyCommand().test("create --name Smoke --root /tmp/company --autonomy-disabled")
+
+        result.statusCode shouldBe 0
+        result.output shouldContain "\"id\": \"company-disabled\""
+        result.output shouldContain "\"autonomyEnabled\": false"
+    }
+
     test("company agent batch-update forwards selected patch fields") {
         coEvery {
             service.batchUpdateCompanyAgentDefinitions(

--- a/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
@@ -11,8 +11,16 @@ import com.cotor.domain.orchestrator.PipelineOrchestrator
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.assertions.throwables.shouldThrow
+import io.ktor.client.request.header
 import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -209,6 +217,133 @@ class WebServerTest : FunSpec({
             response.status.value shouldBe 200
             response.bodyAsText() shouldContain "\"roleName\":\"Engineering Lead\""
             response.bodyAsText() shouldContain "\"stdout\":\"Finished implementation.\""
+        }
+    }
+
+    test("mutating web editor routes reject missing token") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-token-test")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.post("/api/editor/save") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"demo","stages":[{"id":"a","agent":"echo"}]}""")
+            }
+
+            response.status shouldBe HttpStatusCode.Unauthorized
+            response.bodyAsText() shouldContain "Unauthorized"
+        }
+    }
+
+    test("mutating company routes accept valid web token") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-company-token-test")
+        coEvery { desktopService.createCompany(any(), any(), any(), any(), any(), any()) } returns com.cotor.app.Company(
+            id = "company-1",
+            name = "Demo",
+            rootPath = ".",
+            repositoryId = "repo-1",
+            defaultBaseBranch = "master",
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.post("/api/company/companies") {
+                header("X-Cotor-Web-Token", "secret-web-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"Demo","rootPath":"."}""")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.bodyAsText() shouldContain "\"id\":\"company-1\""
+            coVerify(exactly = 1) { desktopService.createCompany(any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
+    test("editor path resolution rejects traversal outside web directory") {
+        val editorDir = Files.createTempDirectory("cotor-web-path-test")
+
+        shouldThrow<IllegalArgumentException> {
+            resolveEditorPath(editorDir, "../outside.yaml", "demo.yaml")
+        }
+    }
+
+    test("editor run rejects outside absolute path before loading config") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-run-path-test")
+        val outside = Files.createTempFile("cotor-outside", ".yaml")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.post("/api/editor/run") {
+                header(HttpHeaders.Authorization, "Bearer secret-web-token")
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"demo","path":"$outside"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "Editor path must stay inside"
+            coVerify(exactly = 0) { orchestrator.executePipeline(any(), any(), any()) }
         }
     }
 })

--- a/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
@@ -8,12 +8,12 @@ import com.cotor.app.IssueStatus
 import com.cotor.data.config.ConfigRepository
 import com.cotor.data.registry.AgentRegistry
 import com.cotor.domain.orchestrator.PipelineOrchestrator
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.assertions.throwables.shouldThrow
-import io.ktor.client.request.header
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText

--- a/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
+++ b/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
@@ -25,8 +25,8 @@ class ProductionReliabilityBaselineTest {
             "Dockerfile should define a healthcheck against /health"
         )
         assertTrue(
-            dockerfile.contains("CMD [\"app-server\", \"--host\", \"0.0.0.0\", \"--port\", \"8787\"]"),
-            "Dockerfile should start app-server as the default command"
+            dockerfile.contains("CMD [\"app-server\", \"--host\", \"127.0.0.1\", \"--port\", \"8787\"]"),
+            "Dockerfile should start app-server on loopback by default"
         )
     }
 

--- a/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
@@ -1,0 +1,29 @@
+package com.cotor.security
+
+import com.cotor.model.SecurityConfig
+import com.cotor.model.SecurityException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import org.slf4j.LoggerFactory
+
+class SecurityValidatorTest : FunSpec({
+    test("command whitelist accepts absolute executable path by basename") {
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(allowedExecutables = setOf("qwen")),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        validator.validateCommand(listOf("/opt/homebrew/bin/qwen", "{input}"))
+    }
+
+    test("command whitelist rejects executable outside allowlist") {
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(allowedExecutables = setOf("qwen")),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        shouldThrow<SecurityException> {
+            validator.validateCommand(listOf("sh", "-c", "id"))
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- Harden local web/app-server security boundaries: token-gate mutating web routes, confine editor paths, restrict CORS, and prevent unauthenticated non-loopback app-server binds.
- Wire command validation into `CommandPlugin`, add basename allowlisting for absolute command paths, and reject invalid DAG dependency graphs at the orchestrator boundary.
- Include release-prep fixes already validated: Meeting Room redesign/projection fixes, A2A/runtime test isolation, autonomy creation flag, Homebrew formula checks, and shared HTTP client usage.

## Validation
- `./gradlew --no-parallel test`
- `./gradlew --no-parallel test -x jacocoTestCoverageVerification --rerun-tasks --tests "com.cotor.presentation.web.WebServerTest" --tests "com.cotor.domain.orchestrator.PipelineOrchestratorDagValidationTest" --tests "com.cotor.data.plugin.CommandPluginTest" --tests "com.cotor.security.SecurityValidatorTest" --tests "com.cotor.domain.executor.AgentExecutorTest" --tests "com.cotor.presentation.cli.AppServerCommandTest" --tests "com.cotor.reliability.ProductionReliabilityBaselineTest"`
- `./gradlew shadowJar`
- `swift build` in `macos/`
- Manual CLI smoke: `./shell/cotor app-server --host 0.0.0.0 --port 19090` now fails without a token.
- Manual web smoke: live `cotor web` token/page flow returned `401` without token, `200` with token, and `400` for an outside editor path.
- Prior release-prep QA: company sandbox workflow, app-server HTTP probes, desktop `.app` launch, source and packaged install simulations, Homebrew style/audit/test, Swift tests for Meeting Room projection and DesktopStore.

## Notes
- English/Korean docs were not changed because no existing user docs referenced the hardened Docker/non-loopback behavior.
- Local generated/runtime files were intentionally left out of the PR: `.cotor/stats/*`, `.opencode/`, `graphify-out/`.