### PR TITLE
fix: harden audit follow-up surfaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,7 @@ jobs:
           set -euo pipefail
           mkdir -p build/release
           cp "build/libs/cotor-${{ needs.detect-version.outputs.version }}-all.jar" "build/release/cotor-${{ needs.detect-version.outputs.version }}-all.jar"
+          shasum -a 256 "build/release/cotor-${{ needs.detect-version.outputs.version }}-all.jar" > "build/release/cotor-${{ needs.detect-version.outputs.version }}-all.jar.sha256"
 
       - name: Upload jar artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD ["curl", "--fail", "--silent", "http://127.0.0.1:8787/health"]
 
 ENTRYPOINT ["java", "-jar", "/app/cotor.jar"]
-CMD ["app-server", "--host", "127.0.0.1", "--port", "8787"]
+CMD ["app-server", "--host", "0.0.0.0", "--port", "8787"]

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -8,6 +8,57 @@ import SwiftUI
 // It collects declarations centered on desktop store so the native shell code stays easier to navigate.
 // Start with this file when tracing how the desktop client presents, stores, or moves state in this area.
 
+func parseCodexArguments(_ raw: String) -> [String] {
+    var args: [String] = []
+    var current = ""
+    var quote: Character?
+    var escaping = false
+
+    for character in raw {
+        if escaping {
+            current.append(character)
+            escaping = false
+            continue
+        }
+
+        if character == "\\" {
+            escaping = true
+            continue
+        }
+
+        if let activeQuote = quote {
+            if character == activeQuote {
+                quote = nil
+            } else {
+                current.append(character)
+            }
+            continue
+        }
+
+        if character == "\"" || character == "'" {
+            quote = character
+            continue
+        }
+
+        if character.isWhitespace {
+            if !current.isEmpty {
+                args.append(current)
+                current = ""
+            }
+        } else {
+            current.append(character)
+        }
+    }
+
+    if escaping {
+        current.append("\\")
+    }
+    if !current.isEmpty {
+        args.append(current)
+    }
+    return args
+}
+
 /// Tracks the high-level backend/runtime state shown in the shell header.
 ///
 /// The visible text is derived later through the active app language so the same
@@ -2664,9 +2715,7 @@ final class DesktopStore: ObservableObject {
                 codePublishMode: codePublishMode,
                 codexLaunchMode: codexLaunchMode,
                 codexCommand: trimmedOptional(codexCommand),
-                codexArgs: codexArgs
-                    .split(whereSeparator: \.isWhitespace)
-                    .map(String.init),
+                codexArgs: parseCodexArguments(codexArgs),
                 codexWorkingDirectory: trimmedOptional(codexWorkingDirectory),
                 codexPort: Int(trimmedOptional(codexPort) ?? ""),
                 codexStartupTimeoutSeconds: Int(trimmedOptional(codexStartupTimeoutSeconds) ?? ""),
@@ -2710,7 +2759,7 @@ final class DesktopStore: ObservableObject {
                 kind: "CODEX_APP_SERVER",
                 launchMode: codexLaunchMode,
                 command: trimmedOptional(codexCommand),
-                args: codexArgs.split(whereSeparator: \.isWhitespace).map(String.init),
+                args: parseCodexArguments(codexArgs),
                 workingDirectory: trimmedOptional(codexWorkingDirectory),
                 port: Int(trimmedOptional(codexPort) ?? ""),
                 startupTimeoutSeconds: Int(trimmedOptional(codexStartupTimeoutSeconds) ?? ""),
@@ -2779,7 +2828,7 @@ final class DesktopStore: ObservableObject {
                 backendKind: kind,
                 launchMode: codexLaunchMode,
                 command: trimmedOptional(codexCommand),
-                args: codexArgs.split(whereSeparator: \.isWhitespace).map(String.init),
+                args: parseCodexArguments(codexArgs),
                 workingDirectory: trimmedOptional(codexWorkingDirectory),
                 port: Int(trimmedOptional(codexPort) ?? ""),
                 startupTimeoutSeconds: Int(trimmedOptional(codexStartupTimeoutSeconds) ?? ""),

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -217,6 +217,20 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func codexArgumentParserPreservesQuotedArguments() {
+        let args = parseCodexArguments("app-server --host 127.0.0.1 --label \"local dev server\" --note 'quoted value'")
+
+        #expect(args == ["app-server", "--host", "127.0.0.1", "--label", "local dev server", "--note", "quoted value"])
+    }
+
+    @Test
+    func codexArgumentParserSupportsEscapedWhitespace() {
+        let args = parseCodexArguments("app-server --name local\\ server --port {port}")
+
+        #expect(args == ["app-server", "--name", "local server", "--port", "{port}"])
+    }
+
+    @Test
     func shellModeDefaultsToCompanyAndCanSwitchToTui() {
         let store = DesktopStore()
 

--- a/src/main/kotlin/com/cotor/a2a/A2aRouter.kt
+++ b/src/main/kotlin/com/cotor/a2a/A2aRouter.kt
@@ -38,6 +38,7 @@ class A2aRouter(
 
     suspend fun postMessage(envelope: A2aEnvelope, now: Long = System.currentTimeMillis()): A2aAckResponse {
         validateEnvelope(envelope, now)
+        validateSenderTenant(envelope, now)
         val freshAck = A2aAck(
             messageId = envelope.id,
             dedupeStatus = "accepted",
@@ -132,6 +133,13 @@ class A2aRouter(
         require(envelope.tenant.companyId.isNotBlank()) { "tenant.companyId is required" }
         if (envelope.ts + envelope.ttlMs < now) {
             error("expired_message")
+        }
+    }
+
+    private fun validateSenderTenant(envelope: A2aEnvelope, now: Long) {
+        val knownSessions = sessionStore.sessionsForAgent(envelope.from.agentId, now)
+        if (knownSessions.isNotEmpty() && knownSessions.none { it.tenant == envelope.tenant }) {
+            throw IllegalArgumentException("from.agentId is not authorized for tenant.companyId ${envelope.tenant.companyId}")
         }
     }
 

--- a/src/main/kotlin/com/cotor/a2a/A2aSessionStore.kt
+++ b/src/main/kotlin/com/cotor/a2a/A2aSessionStore.kt
@@ -51,6 +51,11 @@ class A2aSessionStore(
         return sessions.values.filter { it.tenant == tenant }
     }
 
+    fun sessionsForAgent(agentId: String, now: Long): List<A2aSession> {
+        prune(now)
+        return sessions.values.filter { it.agentId == agentId }
+    }
+
     fun enqueue(sessionId: String, envelope: A2aEnvelope, now: Long) {
         prune(now)
         val cursor = cursors.getOrPut(sessionId) { AtomicLong(0) }.incrementAndGet()

--- a/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
+++ b/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
@@ -377,6 +377,7 @@ class GitWorkspaceService(
         ensureBootstrapCommit(repositoryRoot)
         val normalizedPath = worktreePath.toAbsolutePath().normalize()
         if (normalizedPath.exists()) {
+            verifyExistingWorktreeLineage(repositoryRoot, branchName, normalizedPath)
             return WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
         }
 
@@ -397,6 +398,32 @@ class GitWorkspaceService(
         }
 
         return WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
+    }
+
+    private suspend fun verifyExistingWorktreeLineage(
+        repositoryRoot: Path,
+        branchName: String,
+        worktreePath: Path
+    ) {
+        val actualCommonRoot = runCatching { repositoryCommonRoot(worktreePath) }.getOrElse {
+            throw IllegalStateException("Existing worktree path is not a git checkout: $worktreePath")
+        }
+        val expectedRoot = repositoryRoot.toAbsolutePath().normalize()
+        if (actualCommonRoot != expectedRoot) {
+            throw IllegalStateException("Existing worktree path $worktreePath belongs to $actualCommonRoot, not $expectedRoot")
+        }
+
+        val actualBranch = runGit(
+            worktreePath,
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+            failOnError = false,
+            timeoutMs = 10_000
+        ).stdout.trim()
+        if (actualBranch != branchName) {
+            throw IllegalStateException("Existing worktree path $worktreePath is on branch $actualBranch, not $branchName")
+        }
     }
 
     /**
@@ -1306,7 +1333,7 @@ class GitWorkspaceService(
         )
         if (!fetchResult.isSuccess) {
             logger.warn("Could not fetch origin/$baseBranch while checking GitHub publish readiness")
-            return null
+            return "GitHub publishing cannot verify origin/$baseBranch because fetching the remote base failed."
         }
 
         val mergeBaseResult = runGit(

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeMachine.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeMachine.kt
@@ -31,14 +31,25 @@ object CompanyRuntimeMachine {
     ): List<RuntimeCommand.StartIssue> {
         val profileById = companyProfiles.associateBy { it.id }
         val usedProfiles = occupiedProfileIds.toMutableSet()
+        val usedExecutionAgents = occupiedExecutionAgents
+            .mapNotNull { it.normalizedExecutionAgentName() }
+            .toMutableSet()
         val commands = mutableListOf<RuntimeCommand.StartIssue>()
         runnableIssues.forEach { issue ->
             val profileId = issue.assigneeProfileId
+            val executionAgent = profileId
+                ?.let(profileById::get)
+                ?.executionAgentName
+                ?.normalizedExecutionAgentName()
             val canUseProfileSlot = profileId == null || usedProfiles.add(profileId)
-            if (canUseProfileSlot) {
+            val canUseExecutionAgent = executionAgent == null || usedExecutionAgents.add(executionAgent)
+            if (canUseProfileSlot && canUseExecutionAgent) {
                 commands += RuntimeCommand.StartIssue(issue.id)
             }
         }
         return commands
     }
+
+    private fun String.normalizedExecutionAgentName(): String? =
+        trim().lowercase().takeIf { it.isNotBlank() }
 }

--- a/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
+++ b/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNames
 import java.io.File
 import java.nio.file.Paths
+import java.security.MessageDigest
 import java.time.Instant
 
 /**
@@ -57,7 +58,7 @@ class CheckpointManager(
             completedStages = completedStages
         )
 
-        val checkpointFile = File(checkpointDir, "$pipelineId.json")
+        val checkpointFile = checkpointFile(pipelineId)
         checkpointFile.writeText(json.encodeToString(checkpoint))
 
         return checkpointFile.absolutePath
@@ -67,10 +68,8 @@ class CheckpointManager(
      * Load checkpoint for a pipeline
      */
     fun loadCheckpoint(pipelineId: String): PipelineCheckpoint? {
-        val checkpointFile = File(checkpointDir, "$pipelineId.json")
-        if (!checkpointFile.exists()) {
-            return null
-        }
+        val checkpointFile = checkpointFileCandidates(pipelineId).firstOrNull { it.exists() }
+            ?: return null
 
         return try {
             json.decodeFromString<PipelineCheckpoint>(checkpointFile.readText())
@@ -114,8 +113,9 @@ class CheckpointManager(
      * Delete checkpoint
      */
     fun deleteCheckpoint(pipelineId: String): Boolean {
-        val checkpointFile = File(checkpointDir, "$pipelineId.json")
-        return checkpointFile.delete()
+        return checkpointFileCandidates(pipelineId).any { file ->
+            file.exists() && file.delete()
+        }
     }
 
     /**
@@ -171,6 +171,35 @@ class CheckpointManager(
         }
         return deletedCount
     }
+
+    private fun checkpointFile(pipelineId: String): File {
+        val root = File(checkpointDir).canonicalFile
+        val file = File(root, "${safeCheckpointFileName(pipelineId)}.json").canonicalFile
+        require(file.parentFile == root) { "Checkpoint path must stay inside $root" }
+        return file
+    }
+
+    private fun checkpointFileCandidates(pipelineId: String): List<File> {
+        val root = File(checkpointDir).canonicalFile
+        val safe = checkpointFile(pipelineId)
+        val legacy = File(root, "$pipelineId.json").canonicalFile
+            .takeIf { it.parentFile == root }
+        return listOfNotNull(safe, legacy).distinctBy { it.absolutePath }
+    }
+}
+
+private fun safeCheckpointFileName(pipelineId: String): String {
+    val sanitized = pipelineId
+        .trim()
+        .replace(Regex("[^A-Za-z0-9._-]+"), "_")
+        .trim('.', '_', '-')
+        .ifBlank { "pipeline" }
+        .take(80)
+    val hash = MessageDigest.getInstance("SHA-256")
+        .digest(pipelineId.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+        .take(12)
+    return "$sanitized-$hash"
 }
 
 private fun defaultCheckpointDir(): String {

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -285,7 +285,10 @@ class DefaultPipelineOrchestrator(
         // Sequential mode is also the only mode that supports decision and loop stages. The index
         // is therefore mutable and may jump forward, backward, or terminate early depending on the
         // outcome of guard expressions and loop bookkeeping.
-        val results = pipelineContext.stageResults.values.toMutableList()
+        val results = pipelineContext.getStageExecutionHistory()
+            .map { it.result }
+            .ifEmpty { pipelineContext.stageResults.values.toList() }
+            .toMutableList()
         val stageIndexMap = pipeline.stages.mapIndexed { index, stage -> stage.id to index }.toMap()
         var previousOutput: String? = results.lastOrNull()?.output
 
@@ -774,8 +777,10 @@ class DefaultPipelineOrchestrator(
         context: PipelineContext
     ) {
         try {
-            val completedStages = context.stageResults.entries.map { entry ->
-                entry.value.toCheckpoint(entry.key)
+            val completedStages = context.getStageExecutionHistory().map { entry ->
+                entry.result.toCheckpoint(entry.stageId)
+            }.ifEmpty {
+                context.stageResults.entries.map { entry -> entry.value.toCheckpoint(entry.key) }
             }
 
             if (completedStages.isNotEmpty()) {

--- a/src/main/kotlin/com/cotor/model/Models.kt
+++ b/src/main/kotlin/com/cotor/model/Models.kt
@@ -11,6 +11,7 @@ package com.cotor.model
 import kotlinx.serialization.Serializable
 import java.nio.file.Path
 import java.time.Instant
+import java.util.Collections
 
 /**
  * Core configuration for the Cotor system
@@ -427,6 +428,16 @@ data class AgentExecutionMetadata(
 )
 
 /**
+ * Ordered record of every stage traversal. Repeated loop/MAP stage IDs still keep
+ * their latest value in [PipelineContext.stageResults], while this list preserves
+ * the full execution history for stats and checkpoints.
+ */
+data class StageExecutionRecord(
+    val stageId: String,
+    val result: AgentResult
+)
+
+/**
  * Shared pipeline context accessible to all stages
  */
 data class PipelineContext(
@@ -438,25 +449,34 @@ data class PipelineContext(
     val metadata: MutableMap<String, Any> = java.util.concurrent.ConcurrentHashMap(),
     val startTime: Long = System.currentTimeMillis()
 ) {
+    private val stageExecutionHistory = Collections.synchronizedList(mutableListOf<StageExecutionRecord>())
+
     @Volatile
     var currentStageIndex: Int = 0
 
     fun addStageResult(stageId: String, result: AgentResult) {
         stageResults[stageId] = result
+        stageExecutionHistory.add(StageExecutionRecord(stageId, result))
     }
 
     fun getStageResult(stageId: String): AgentResult? = stageResults[stageId]
 
     fun getStageOutput(stageId: String): String? = stageResults[stageId]?.output
 
+    fun getStageExecutionHistory(): List<StageExecutionRecord> = synchronized(stageExecutionHistory) {
+        stageExecutionHistory.toList()
+    }
+
     fun getAllOutputs(): String {
-        return stageResults.values
+        val results = getStageExecutionHistory().map { it.result }.ifEmpty { stageResults.values.toList() }
+        return results
             .mapNotNull { it.output }
             .joinToString("\n\n---\n\n")
     }
 
     fun getSuccessfulOutputs(): String {
-        return stageResults.values
+        val results = getStageExecutionHistory().map { it.result }.ifEmpty { stageResults.values.toList() }
+        return results
             .filter { it.isSuccess }
             .mapNotNull { it.output }
             .joinToString("\n\n---\n\n")

--- a/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
+++ b/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
@@ -27,8 +27,6 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.awt.Desktop
@@ -456,11 +454,13 @@ internal fun Application.cotorWebModule(
         }
 
         get("/editor") {
-            call.respondText(editorHtml(webToken), ContentType.Text.Html)
+            call.attachWebTokenCookie(webToken)
+            call.respondText(editorHtml(), ContentType.Text.Html)
         }
 
         get("/company") {
-            call.respondText(companyHtml(webToken), ContentType.Text.Html)
+            call.attachWebTokenCookie(webToken)
+            call.respondText(companyHtml(), ContentType.Text.Html)
         }
 
         get("/help") {
@@ -474,10 +474,12 @@ internal fun Application.cotorWebModule(
         }
 
         get("/api/runtime/runs") {
+            if (!call.requireWebToken(webToken)) return@get
             call.respond(durableRuntimeService?.listRuns().orEmpty())
         }
 
         get("/api/runtime/runs/{runId}") {
+            if (!call.requireWebToken(webToken)) return@get
             val runId = call.parameters["runId"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "runId is required"))
             val snapshot = durableRuntimeService?.inspectRun(runId)
@@ -486,34 +488,40 @@ internal fun Application.cotorWebModule(
         }
 
         get("/api/runtime/policy/decisions") {
+            if (!call.requireWebToken(webToken)) return@get
             val runId = call.request.queryParameters["runId"]
             val issueId = call.request.queryParameters["issueId"]
             call.respond(desktopService.policyDecisions(runId = runId, issueId = issueId))
         }
 
         get("/api/runtime/evidence/runs/{runId}") {
+            if (!call.requireWebToken(webToken)) return@get
             val runId = call.parameters["runId"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "runId is required"))
             call.respond(desktopService.evidenceForRun(runId))
         }
 
         get("/api/runtime/evidence/files") {
+            if (!call.requireWebToken(webToken)) return@get
             val path = call.request.queryParameters["path"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "path is required"))
             call.respond(desktopService.evidenceForFile(path))
         }
 
         get("/api/runtime/github/pull-requests") {
+            if (!call.requireWebToken(webToken)) return@get
             val companyId = call.request.queryParameters["companyId"]
             call.respond(desktopService.listGitHubPullRequests(companyId))
         }
 
         get("/api/runtime/github/events") {
+            if (!call.requireWebToken(webToken)) return@get
             val companyId = call.request.queryParameters["companyId"]
             call.respond(desktopService.listGitHubEvents(companyId))
         }
 
         get("/api/runtime/github/pull-requests/{pullRequestNumber}") {
+            if (!call.requireWebToken(webToken)) return@get
             val pullRequestNumber = call.parameters["pullRequestNumber"]?.toIntOrNull()
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "pullRequestNumber is required"))
             val snapshot = desktopService.inspectGitHubPullRequest(pullRequestNumber)
@@ -522,36 +530,43 @@ internal fun Application.cotorWebModule(
         }
 
         get("/api/runtime/knowledge/issues/{issueId}") {
+            if (!call.requireWebToken(webToken)) return@get
             val issueId = call.parameters["issueId"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "issueId is required"))
             call.respond(desktopService.issueKnowledge(issueId))
         }
 
         get("/api/runtime/verification/issues/{issueId}") {
+            if (!call.requireWebToken(webToken)) return@get
             val issueId = call.parameters["issueId"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "issueId is required"))
             call.respond(desktopService.verificationBundle(issueId))
         }
 
         get("/api/runtime/issues/{issueId}/projection") {
+            if (!call.requireWebToken(webToken)) return@get
             val issueId = call.parameters["issueId"]
                 ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "issueId is required"))
             call.respond(desktopService.issueRuntimeProjection(issueId))
         }
 
         get("/api/editor/config") {
+            if (!call.requireWebToken(webToken)) return@get
             call.respond(ConfigResponse(readOnly = readOnly))
         }
 
         get("/api/editor/templates") {
+            if (!call.requireWebToken(webToken)) return@get
             call.respond(buildTemplates())
         }
 
         get("/api/editor/pipelines") {
+            if (!call.requireWebToken(webToken)) return@get
             call.respond(listSavedPipelines())
         }
 
         get("/api/editor/pipelines/{name}") {
+            if (!call.requireWebToken(webToken)) return@get
             val name = call.parameters["name"] ?: return@get call.respond(HttpStatusCode.BadRequest)
             val detail = loadPipelineDetail(name)
             if (detail == null) {
@@ -646,16 +661,19 @@ internal fun Application.cotorWebModule(
 
         route("/api/company") {
             get("/dashboard") {
+                if (!call.requireWebToken(webToken)) return@get
                 call.respond(desktopService.companyDashboardReadOnly())
             }
 
             get("/issues/{issueId}/execution-details") {
+                if (!call.requireWebToken(webToken)) return@get
                 val issueId = call.parameters["issueId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                 call.respond(desktopService.issueExecutionDetails(issueId))
             }
 
             route("/companies") {
                 get {
+                    if (!call.requireWebToken(webToken)) return@get
                     call.respond(desktopService.listCompanies())
                 }
 
@@ -675,6 +693,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     val company = desktopService.getCompany(companyId)
                         ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "Company not found"))
@@ -682,6 +701,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/dashboard") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.companyDashboardReadOnly(companyId))
                 }
@@ -710,6 +730,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/agents") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.listCompanyAgentDefinitions(companyId))
                 }
@@ -731,6 +752,7 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/goals") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.listGoals().filter { it.companyId == companyId })
                 }
@@ -751,12 +773,14 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/issues") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     val goalId = call.request.queryParameters["goalId"]
                     call.respond(desktopService.listIssues(goalId, companyId))
                 }
 
                 get("/{companyId}/issues/{issueId}") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     val issueId = call.parameters["issueId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     val issue = desktopService.getIssueProjected(issueId)?.takeIf { it.companyId == companyId }
@@ -765,7 +789,11 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/issues/{issueId}/execution-details") {
+                    if (!call.requireWebToken(webToken)) return@get
+                    val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     val issueId = call.parameters["issueId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+                    desktopService.getIssueProjected(issueId)?.takeIf { it.companyId == companyId }
+                        ?: return@get call.respond(HttpStatusCode.NotFound, mapOf("error" to "Issue not found"))
                     call.respond(desktopService.issueExecutionDetails(issueId))
                 }
 
@@ -786,11 +814,13 @@ internal fun Application.cotorWebModule(
                 }
 
                 get("/{companyId}/review-queue") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.listReviewQueue(companyId))
                 }
 
                 get("/{companyId}/runtime") {
+                    if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
                     call.respond(desktopService.runtimeStatus(companyId))
                 }
@@ -862,23 +892,43 @@ private suspend fun ApplicationCall.requireWebToken(webToken: String?): Boolean 
     val expected = webToken?.takeIf { it.isNotBlank() } ?: return true
     val actualBearer = request.header(HttpHeaders.Authorization)
     val actualHeader = request.header("X-Cotor-Web-Token")
-    if (actualBearer == "Bearer $expected" || actualHeader == expected) {
+    val actualCookie = request.cookies[WEB_TOKEN_COOKIE]
+    if (actualBearer == "Bearer $expected" || actualHeader == expected || actualCookie == expected) {
         return true
     }
     respond(HttpStatusCode.Unauthorized, mapOf("error" to "Unauthorized"))
     return false
 }
 
-private fun webTokenScript(webToken: String?): String {
-    val encoded = Json.encodeToString(webToken.orEmpty())
-    return "<script>window.COTOR_WEB_TOKEN = $encoded;</script>"
+private const val WEB_TOKEN_COOKIE = "CotorWebToken"
+
+private fun ApplicationCall.attachWebTokenCookie(webToken: String?) {
+    val expected = webToken?.takeIf { it.isNotBlank() } ?: return
+    response.cookies.append(
+        Cookie(
+            name = WEB_TOKEN_COOKIE,
+            value = expected,
+            path = "/",
+            httpOnly = true,
+            extensions = mapOf("SameSite" to "Strict")
+        )
+    )
 }
 
 private fun webFetchHeaders(): String = """
     function webHeaders(extra = {}) {
-      const headers = { ...extra };
-      if (window.COTOR_WEB_TOKEN) headers["X-Cotor-Web-Token"] = window.COTOR_WEB_TOKEN;
-      return headers;
+      return { ...extra };
+    }
+    function escapeHtml(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    }
+    function escapeJsString(value) {
+      return JSON.stringify(String(value ?? "")).slice(1, -1).replace(/'/g, "\\'");
     }
 """.trimIndent()
 
@@ -901,7 +951,6 @@ private val landingHtml = """
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Cotor | 멀티 에이전트 워크플로 오케스트레이션</title>
-  <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
   <style>
     :root {
       --bg: #060912;
@@ -991,7 +1040,7 @@ private val landingHtml = """
 </html>
 """.trimIndent()
 
-private fun companyHtml(webToken: String?): String = """
+private fun companyHtml(): String = """
 <!doctype html>
 <html lang="en">
 <head>
@@ -1005,7 +1054,6 @@ private fun companyHtml(webToken: String?): String = """
     pre { background: #0f172a; color: #dbeafe; padding: 12px; border-radius: 12px; overflow: auto; }
     code { background: #e7eef8; padding: 2px 6px; border-radius: 6px; }
   </style>
-  ${webTokenScript(webToken)}
 </head>
 <body>
   <h1>Cotor Company Console</h1>
@@ -1035,7 +1083,7 @@ private fun companyHtml(webToken: String?): String = """
   <script>
     ${webFetchHeaders()}
     async function loadDashboard() {
-      const response = await fetch('/api/company/dashboard');
+      const response = await fetch('/api/company/dashboard', { headers: webHeaders() });
       const data = await response.json();
       document.getElementById('output').textContent = JSON.stringify(data, null, 2);
     }
@@ -1126,14 +1174,13 @@ private fun helpHtml(language: CliHelpLanguage): String {
 }
 
 // Lightweight HTML (single file) to keep the web UI self contained.
-private fun editorHtml(webToken: String?): String = """
+private fun editorHtml(): String = """
 <!doctype html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Cotor Flow Studio</title>
-  <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
   <style>
     :root {
       --bg: #0b1224;
@@ -1190,7 +1237,6 @@ private fun editorHtml(webToken: String?): String = """
     .yaml-preview { font-family: "SFMono-Regular", ui-monospace, monospace; background: #0d1528; border: 1px solid var(--border); border-radius: 12px; padding: 12px; color: #cbd5e1; min-height: 160px; white-space: pre-wrap; }
     @media (max-width: 1024px) { .layout { grid-template-columns: 1fr; } }
   </style>
-  ${webTokenScript(webToken)}
 </head>
 <body>
   <div class="page">
@@ -1306,25 +1352,25 @@ private fun editorHtml(webToken: String?): String = """
           <div class="stage-card" draggable="true" ondragstart="onDragStart(${ '$' }{i})" ondragover="onDragOver(event, ${ '$' }{i})" ondrop="onDrop(event, ${ '$' }{i})">
             <div class="stage-header">
               <span class="grip">⋮⋮</span>
-              <input class="input" style="max-width:200px;" value="${ '$' }{s.id}" onchange="updateStageField(${ '$' }{i}, 'id', this.value)" />
+              <input class="input" style="max-width:200px;" value="${ '$' }{escapeHtml(s.id)}" onchange="updateStageField(${ '$' }{i}, 'id', this.value)" />
               <select class="input" style="max-width:140px;" onchange="updateStageField(${ '$' }{i}, 'type', this.value)">
-                ${ '$' }{["EXECUTION"].map(t => `<option value="${ '$' }{t}" ${ '$' }{s.type===t?"selected":""}>${ '$' }{t}</option>`).join("")}
+                ${ '$' }{["EXECUTION"].map(t => `<option value="${ '$' }{escapeHtml(t)}" ${ '$' }{s.type===t?"selected":""}>${ '$' }{escapeHtml(t)}</option>`).join("")}
               </select>
               <button class="btn" style="padding:6px 10px;" onclick="removeStage(${ '$' }{i})">삭제</button>
             </div>
             <div class="grid-2">
               <div class="field">
                 <label>Agent</label>
-                <input class="input" value="${ '$' }{s.agent || ""}" onchange="updateStageField(${ '$' }{i}, 'agent', this.value)" placeholder="claude / gemini / ..." />
+                <input class="input" value="${ '$' }{escapeHtml(s.agent || "")}" onchange="updateStageField(${ '$' }{i}, 'agent', this.value)" placeholder="claude / gemini / ..." />
               </div>
               <div class="field">
                 <label>Dependencies</label>
-                <input class="input" value="${ '$' }{deps}" onchange="updateStageField(${ '$' }{i}, 'dependencies', this.value)" placeholder="comma 로 구분" />
+                <input class="input" value="${ '$' }{escapeHtml(deps)}" onchange="updateStageField(${ '$' }{i}, 'dependencies', this.value)" placeholder="comma 로 구분" />
               </div>
             </div>
             <div class="field">
               <label>Input / Prompt</label>
-              <textarea onchange="updateStageField(${ '$' }{i}, 'input', this.value)" placeholder="이 단계가 수행할 내용">${ '$' }{s.input || ""}</textarea>
+              <textarea onchange="updateStageField(${ '$' }{i}, 'input', this.value)" placeholder="이 단계가 수행할 내용">${ '$' }{escapeHtml(s.input || "")}</textarea>
             </div>
           </div>
         `;
@@ -1378,9 +1424,9 @@ private fun editorHtml(webToken: String?): String = """
         templates = await res.json();
         const list = document.getElementById("templateList");
         list.innerHTML = templates.map(t => `
-          <div class="template-card" onclick="applyTemplate('${'$'}{t.id}')">
-            <div style="font-weight:700;">${'$'}{t.name}</div>
-            <div style="color:var(--muted); font-size:0.9rem;">${'$'}{t.description}</div>
+          <div class="template-card" onclick="applyTemplate('${'$'}{escapeJsString(t.id)}')">
+            <div style="font-weight:700;">${'$'}{escapeHtml(t.name)}</div>
+            <div style="color:var(--muted); font-size:0.9rem;">${'$'}{escapeHtml(t.description)}</div>
           </div>
         `).join("");
       } catch (e) {
@@ -1410,7 +1456,7 @@ private fun editorHtml(webToken: String?): String = """
         const style = active
           ? 'background:linear-gradient(135deg,#8b5cf6,#6d28d9);border:none;color:white;'
           : '';
-        return `<button class="btn" style="padding:6px 10px;${'$'}{style}" onclick="toggleSavedTag('${'$'}{tag.replace(/'/g, "\\'")}')">#${'$'}{tag}</button>`;
+        return `<button class="btn" style="padding:6px 10px;${'$'}{style}" onclick="toggleSavedTag('${'$'}{escapeJsString(tag)}')">#${'$'}{escapeHtml(tag)}</button>`;
       }).join("");
     }
 
@@ -1437,14 +1483,14 @@ private fun editorHtml(webToken: String?): String = """
         return;
       }
       list.innerHTML = filtered.map(p => `
-        <div class="saved-card" onclick="loadPipeline('${'$'}{p.name}')">
-          <div style="font-weight:700;">${'$'}{p.name}</div>
-          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{p.description}</div>
+        <div class="saved-card" onclick="loadPipeline('${'$'}{escapeJsString(p.name)}')">
+          <div style="font-weight:700;">${'$'}{escapeHtml(p.name)}</div>
+          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{escapeHtml(p.description)}</div>
           <div class="tags">
-            <span class="pill">${'$'}{p.executionMode}</span>
-            <span class="pill">${'$'}{p.stageCount} stages</span>
-            ${'$'}{(p.agents || []).map(a => `<span class="pill">@${'$'}{a}</span>`).join("")}
-            ${'$'}{(p.tags || []).map(tag => `<span class="pill">#${'$'}{tag}</span>`).join("")}
+            <span class="pill">${'$'}{escapeHtml(p.executionMode)}</span>
+            <span class="pill">${'$'}{escapeHtml(p.stageCount)} stages</span>
+            ${'$'}{(p.agents || []).map(a => `<span class="pill">@${'$'}{escapeHtml(a)}</span>`).join("")}
+            ${'$'}{(p.tags || []).map(tag => `<span class="pill">#${'$'}{escapeHtml(tag)}</span>`).join("")}
           </div>
         </div>
       `).join("");
@@ -1552,15 +1598,15 @@ private fun editorHtml(webToken: String?): String = """
       const timeline = (data.timeline || []).map(t => {
         const cls = t.state === "FAILED" ? "fail" : "success";
         return `<div class="timeline-entry ${'$'}{cls}">
-          <div style="font-weight:700;">${'$'}{t.stageId}</div>
-          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{t.durationMs || "-"} ms</div>
-          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{t.message || t.outputPreview || ""}</div>
+          <div style="font-weight:700;">${'$'}{escapeHtml(t.stageId)}</div>
+          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{escapeHtml(t.durationMs || "-")} ms</div>
+          <div style="color:var(--muted);font-size:0.9rem;">${'$'}{escapeHtml(t.message || t.outputPreview || "")}</div>
         </div>`;
       }).join("");
       box.innerHTML = `
         <div class="status">
-          <span class="pill">${'$'}{data.executionMode}</span>
-          <span>${'$'}{data.successCount}/${'$'}{data.totalAgents} 성공 · ${'$'}{data.totalDuration}ms</span>
+          <span class="pill">${'$'}{escapeHtml(data.executionMode)}</span>
+          <span>${'$'}{escapeHtml(data.successCount)}/${'$'}{escapeHtml(data.totalAgents)} 성공 · ${'$'}{escapeHtml(data.totalDuration)}ms</span>
         </div>
         <div class="timeline">${'$'}{timeline || "타임라인 없음"}</div>
       `;

--- a/src/main/kotlin/com/cotor/providers/github/GitHubControlPlaneService.kt
+++ b/src/main/kotlin/com/cotor/providers/github/GitHubControlPlaneService.kt
@@ -10,11 +10,6 @@ class GitHubControlPlaneService(
     private val knowledgeService: KnowledgeService = KnowledgeService()
 ) {
     fun recordSnapshot(snapshot: PullRequestSnapshot, eventType: String, detail: String): PullRequestSnapshot {
-        val current = store.load()
-        val mergedPullRequests = current.pullRequests
-            .filterNot { it.number == snapshot.number }
-            .plus(snapshot)
-            .sortedByDescending { it.updatedAt }
         val dedupeKey = ProviderEventDedupeKey(
             type = eventType,
             pullRequestNumber = snapshot.number,
@@ -31,25 +26,30 @@ class GitHubControlPlaneService(
             detail = detail,
             dedupeKey = dedupeKey
         )
-        val mergedEvents = (current.events + event)
-            .reversed()
-            .distinctBy { existing ->
-                existing.dedupeKey ?: ProviderEventDedupeKey(
-                    type = existing.type,
-                    pullRequestNumber = existing.pullRequestNumber,
-                    companyId = existing.companyId,
-                    issueId = existing.issueId,
-                    detailFingerprint = existing.detail.trim().lowercase()
-                )
-            }
-            .reversed()
-        store.save(
+        store.update { current ->
+            val mergedPullRequests = current.pullRequests
+                .filterNot { it.number == snapshot.number }
+                .plus(snapshot)
+                .sortedByDescending { it.updatedAt }
+            val mergedEvents = (current.events + event)
+                .reversed()
+                .distinctBy { existing ->
+                    existing.dedupeKey ?: ProviderEventDedupeKey(
+                        type = existing.type,
+                        pullRequestNumber = existing.pullRequestNumber,
+                        companyId = existing.companyId,
+                        issueId = existing.issueId,
+                        detailFingerprint = existing.detail.trim().lowercase()
+                    )
+                }
+                .reversed()
+
             current.copy(
                 pullRequests = mergedPullRequests,
                 events = mergedEvents.takeLast(500),
                 updatedAt = System.currentTimeMillis()
             )
-        )
+        }
         provenanceService.recordPullRequestState(
             runId = snapshot.runId,
             pullRequestNumber = snapshot.number,

--- a/src/main/kotlin/com/cotor/providers/github/GitHubControlPlaneStore.kt
+++ b/src/main/kotlin/com/cotor/providers/github/GitHubControlPlaneStore.kt
@@ -2,7 +2,9 @@ package com.cotor.providers.github
 
 import com.cotor.app.defaultDesktopAppHome
 import kotlinx.serialization.json.Json
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.readText
@@ -20,6 +22,7 @@ class GitHubControlPlaneStore(
     private fun file(): Path =
         appHomeProvider().resolve("providers").resolve("github").resolve("state.json")
 
+    @Synchronized
     fun load(): GitHubProviderState {
         val file = file()
         if (!file.exists()) {
@@ -30,9 +33,33 @@ class GitHubControlPlaneStore(
         }.getOrDefault(GitHubProviderState())
     }
 
+    @Synchronized
     fun save(state: GitHubProviderState) {
+        writeState(state)
+    }
+
+    @Synchronized
+    fun update(transform: (GitHubProviderState) -> GitHubProviderState): GitHubProviderState {
+        val next = transform(loadUnlocked())
+        writeState(next)
+        return next
+    }
+
+    private fun loadUnlocked(): GitHubProviderState {
+        val file = file()
+        if (!file.exists()) {
+            return GitHubProviderState()
+        }
+        return runCatching {
+            json.decodeFromString(GitHubProviderState.serializer(), file.readText())
+        }.getOrDefault(GitHubProviderState())
+    }
+
+    private fun writeState(state: GitHubProviderState) {
         val file = file()
         file.parent?.createDirectories()
-        file.writeText(json.encodeToString(GitHubProviderState.serializer(), state))
+        val temp = Files.createTempFile(file.parent, "state", ".tmp")
+        temp.writeText(json.encodeToString(GitHubProviderState.serializer(), state))
+        Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
     }
 }

--- a/src/main/kotlin/com/cotor/security/SecurityValidator.kt
+++ b/src/main/kotlin/com/cotor/security/SecurityValidator.kt
@@ -8,6 +8,7 @@ package com.cotor.security
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
+import com.cotor.data.process.resolveExecutablePath
 import com.cotor.model.AgentConfig
 import com.cotor.model.SecurityConfig
 import com.cotor.model.SecurityException
@@ -66,12 +67,28 @@ class DefaultSecurityValidator(
             throw SecurityException("Empty command is not allowed")
         }
 
-        val executable = command.first()
+        val executable = command.first().trim()
+        val executableName = runCatching { Path.of(executable).fileName?.toString() }.getOrNull()
+
+        if (isShellInterpreter(executableName ?: executable) && command.drop(1).any { it == "-c" || it == "/c" }) {
+            throw SecurityException("Shell command execution is not allowed: $executable")
+        }
+
+        val resolvedExecutable = resolveExecutablePath(executable)
 
         // Whitelist validation
-        val executableName = runCatching { Path.of(executable).fileName?.toString() }.getOrNull()
-        if (config.useWhitelist && executable !in config.allowedExecutables && executableName !in config.allowedExecutables) {
+        val resolvedExecutableName = resolvedExecutable?.fileName?.toString()
+        if (config.useWhitelist &&
+            executable !in config.allowedExecutables &&
+            executableName !in config.allowedExecutables &&
+            resolvedExecutable?.toString() !in config.allowedExecutables &&
+            resolvedExecutableName !in config.allowedExecutables
+        ) {
             throw SecurityException("Executable not in whitelist: $executable")
+        }
+
+        if (resolvedExecutable != null && config.enablePathValidation && config.allowedDirectories.isNotEmpty()) {
+            validatePath(resolvedExecutable)
         }
 
         // Dangerous commands check
@@ -110,7 +127,9 @@ class DefaultSecurityValidator(
 
         // Validate symbolic links
         if (path.isSymbolicLink()) {
-            val target = Files.readSymbolicLink(path)
+            val target = Files.readSymbolicLink(path).let { linkTarget ->
+                if (linkTarget.isAbsolute) linkTarget else path.toAbsolutePath().parent.resolve(linkTarget)
+            }
             validatePath(target)
         }
     }
@@ -142,5 +161,9 @@ class DefaultSecurityValidator(
         return injectionPatterns.any { pattern ->
             input.contains(pattern)
         }
+    }
+
+    private fun isShellInterpreter(executableName: String): Boolean {
+        return executableName.lowercase() in setOf("sh", "bash", "zsh", "fish", "cmd", "cmd.exe", "powershell", "powershell.exe", "pwsh")
     }
 }

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -163,6 +163,39 @@ class A2aApiTest : FunSpec({
         }
     }
 
+    test("message tenant must match existing sender session tenant") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val hello = client.post("/api/a2a/v1/sessions") {
+                header(HttpHeaders.Authorization, "Bearer secret-token")
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(A2aHelloRequest(agentId = "agent-ceo", capabilities = listOf("task.assign"), tenant = A2aTenant("company-1"))))
+            }
+            hello.status shouldBe HttpStatusCode.OK
+
+            val spoofed = envelope(dedupeKey = "tenant-spoof-key").copy(
+                tenant = A2aTenant(companyId = "company-2")
+            )
+
+            val response = client.post("/api/a2a/v1/messages") {
+                header(HttpHeaders.Authorization, "Bearer secret-token")
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(spoofed))
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "not authorized for tenant.companyId company-2"
+            coVerify(exactly = 0) { desktopService.ingestA2aTaskAssignment(any(), any(), any(), any(), any(), any(), any()) }
+        }
+    }
+
     test("task.assign routes through canonical task assignment ingestion") {
         testApplication {
             application {

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceParallelDispatchTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceParallelDispatchTest.kt
@@ -12,7 +12,7 @@ import io.mockk.mockk
 import java.nio.file.Files
 
 class DesktopAppServiceParallelDispatchTest : FunSpec({
-    test("runtime starts multiple runnable issues even when assignees share the same execution cli") {
+    test("runtime starts only one runnable issue when assignees share the same execution cli") {
         val appHome = Files.createTempDirectory("desktop-runtime-shared-cli-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-shared-cli-repo").resolve("repo"))
         val worktreeRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-shared-cli-worktrees"))
@@ -82,7 +82,7 @@ class DesktopAppServiceParallelDispatchTest : FunSpec({
                 companyId = company.id,
                 projectContextId = projectContext.id,
                 title = "Parallel shared-cli execution",
-                description = "Start two runnable issues on the same execution CLI.",
+                description = "Start only one runnable issue on the same execution CLI.",
                 status = GoalStatus.ACTIVE,
                 autonomyEnabled = true,
                 createdAt = now,
@@ -139,10 +139,11 @@ class DesktopAppServiceParallelDispatchTest : FunSpec({
             service.runCompanyRuntimeTick(company.id)
 
             val finalState = stateStore.load()
-            finalState.tasks.filter { it.issueId in setOf(issueOne.id, issueTwo.id) } shouldHaveSize 2
-            finalState.issues
-                .filter { it.id in setOf(issueOne.id, issueTwo.id) }
-                .all { issue -> issue.status != IssueStatus.DELEGATED && issue.status != IssueStatus.PLANNED && issue.status != IssueStatus.BACKLOG } shouldBe true
+            val startedTasks = finalState.tasks.filter { it.issueId in setOf(issueOne.id, issueTwo.id) }
+            startedTasks shouldHaveSize 1
+            startedTasks.single().issueId shouldBe issueOne.id
+            finalState.issues.first { it.id == issueOne.id }.status shouldBe IssueStatus.IN_PROGRESS
+            finalState.issues.first { it.id == issueTwo.id }.status shouldBe IssueStatus.DELEGATED
         } finally {
             service.shutdown()
         }

--- a/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
@@ -211,6 +211,41 @@ class GitWorkspaceServiceTest : FunSpec({
         processManager.remainingSteps() shouldBe 0
     }
 
+    test("ensureExistingWorktreeLineage rejects existing worktree on the wrong branch") {
+        val repositoryRoot = Files.createTempDirectory("git-workspace-existing-lineage-mismatch")
+        val worktreePath = repositoryRoot.resolve(".cotor").resolve("worktrees").resolve("existing-pr").resolve("codex")
+        Files.createDirectories(worktreePath)
+        val processManager = FakeProcessManager(
+            listOf(
+                FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--verify", "HEAD"),
+                    ProcessResult(0, "abc1234567890\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--git-common-dir"),
+                    ProcessResult(0, repositoryRoot.resolve(".git").toString() + "\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--abbrev-ref", "HEAD"),
+                    ProcessResult(0, "somebody-elses-branch\n", "", true)
+                )
+            )
+        )
+        val service = GitWorkspaceService(processManager, mockk(relaxed = true), mockk<Logger>(relaxed = true))
+
+        val error = shouldThrow<IllegalStateException> {
+            service.ensureExistingWorktreeLineage(
+                repositoryRoot = repositoryRoot,
+                branchName = "codex/cotor/existing-pr/codex",
+                worktreePath = worktreePath,
+                baseBranch = "master"
+            )
+        }
+
+        error.message shouldContain "not codex/cotor/existing-pr/codex"
+        processManager.remainingSteps() shouldBe 0
+    }
+
     test("ensureInitializedRepositoryRoot bootstraps an existing repo that has no commits yet") {
         val repositoryRoot = Files.createTempDirectory("git-workspace-existing-repo")
         val processManager = FakeProcessManager(
@@ -288,6 +323,42 @@ class GitWorkspaceServiceTest : FunSpec({
         readiness.ready shouldBe false
         readiness.originUrl shouldBe "https://github.com/heodongun/cotor.git"
         readiness.error shouldContain "no history in common"
+        processManager.remainingSteps() shouldBe 0
+    }
+
+    test("ensureGitHubPublishReady rejects repositories when remote base fetch fails") {
+        val repositoryRoot = Files.createTempDirectory("git-workspace-publish-fetch-failure")
+        val processManager = FakeProcessManager(
+            listOf(
+                FakeProcessManager.Step(
+                    listOf("git", "config", "--get", "remote.origin.url"),
+                    ProcessResult(0, "https://github.com/heodongun/cotor.git\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "config", "--get", "remote.origin.url"),
+                    ProcessResult(0, "https://github.com/heodongun/cotor.git\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "show-ref", "--verify", "--quiet", "refs/heads/master"),
+                    ProcessResult(0, "", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "ls-remote", "--heads", "origin", "master"),
+                    ProcessResult(0, "abc123\trefs/heads/master\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "fetch", "--no-tags", "origin", "refs/heads/master:refs/remotes/origin/master"),
+                    ProcessResult(1, "", "network down", false)
+                )
+            )
+        )
+        val service = GitWorkspaceService(processManager, mockk(relaxed = true), mockk<Logger>(relaxed = true))
+
+        val readiness = service.ensureGitHubPublishReady(repositoryRoot, "master")
+
+        readiness.ready shouldBe false
+        readiness.originUrl shouldBe "https://github.com/heodongun/cotor.git"
+        readiness.error shouldContain "fetching the remote base failed"
         processManager.remainingSteps() shouldBe 0
     }
 

--- a/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeMachineTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeMachineTest.kt
@@ -51,7 +51,7 @@ class CompanyRuntimeMachineTest : FunSpec({
         ) shouldContainExactly listOf(RuntimeCommand.EnsurePlanningIssue("goal-a"))
     }
 
-    test("planIssueStarts limits concurrent work by profile only") {
+    test("planIssueStarts limits concurrent work by profile and execution agent") {
         val profiles = listOf(
             OrgAgentProfile(
                 id = "profile-a",
@@ -121,7 +121,61 @@ class CompanyRuntimeMachineTest : FunSpec({
             occupiedExecutionAgents = emptySet()
         )
 
-        commands.map { (it as RuntimeCommand.StartIssue).issueId } shouldContainExactly listOf("issue-a", "issue-b", "issue-c")
-        commands.size shouldBe 3
+        commands.map { (it as RuntimeCommand.StartIssue).issueId } shouldContainExactly listOf("issue-a", "issue-c")
+        commands.size shouldBe 2
+    }
+
+    test("planIssueStarts skips issues whose execution agent is already occupied") {
+        val profiles = listOf(
+            OrgAgentProfile(
+                id = "profile-a",
+                companyId = "company-1",
+                roleName = "Builder",
+                executionAgentName = "opencode"
+            ),
+            OrgAgentProfile(
+                id = "profile-c",
+                companyId = "company-1",
+                roleName = "Backend",
+                executionAgentName = "codex"
+            )
+        )
+        val issues = listOf(
+            CompanyIssue(
+                id = "issue-a",
+                companyId = "company-1",
+                goalId = "goal-1",
+                workspaceId = "workspace-1",
+                title = "A",
+                description = "A",
+                status = IssueStatus.DELEGATED,
+                kind = "execution",
+                assigneeProfileId = "profile-a",
+                createdAt = 1,
+                updatedAt = 1
+            ),
+            CompanyIssue(
+                id = "issue-c",
+                companyId = "company-1",
+                goalId = "goal-1",
+                workspaceId = "workspace-1",
+                title = "C",
+                description = "C",
+                status = IssueStatus.DELEGATED,
+                kind = "execution",
+                assigneeProfileId = "profile-c",
+                createdAt = 2,
+                updatedAt = 2
+            )
+        )
+
+        val commands = CompanyRuntimeMachine.planIssueStarts(
+            runnableIssues = issues,
+            companyProfiles = profiles,
+            occupiedProfileIds = emptySet(),
+            occupiedExecutionAgents = setOf(" OpenCode ")
+        )
+
+        commands.map { (it as RuntimeCommand.StartIssue).issueId } shouldContainExactly listOf("issue-c")
     }
 })

--- a/src/test/kotlin/com/cotor/checkpoint/CheckpointManagerTest.kt
+++ b/src/test/kotlin/com/cotor/checkpoint/CheckpointManagerTest.kt
@@ -37,9 +37,12 @@ class CheckpointManagerTest : FunSpec({
             jvm = "17"
         )
 
-        val expected = defaultDesktopAppHome().resolve("checkpoints").resolve("$pipelineId.json").toFile()
-        expected.exists() shouldBe true
-        expected.delete() shouldBe true
+        val checkpointRoot = defaultDesktopAppHome().resolve("checkpoints").toFile()
+        val expected = checkpointRoot.listFiles()?.singleOrNull { file ->
+            file.name.startsWith(pipelineId) && file.name.endsWith(".json")
+        }
+        expected shouldNotBe null
+        expected?.delete() shouldBe true
     }
 
     beforeTest {
@@ -80,6 +83,45 @@ class CheckpointManagerTest : FunSpec({
         loadedCheckpoint?.os shouldBe "Test OS"
         loadedCheckpoint?.jvm shouldBe "11"
         loadedCheckpoint?.completedStages?.size shouldBe 1
+    }
+
+    test("checkpoint filenames are derived safely from untrusted pipeline ids") {
+        val pipelineId = "../outside/pipeline"
+
+        val path = checkpointManager.saveCheckpoint(
+            pipelineId = pipelineId,
+            pipelineName = "Unsafe Pipeline",
+            completedStages = emptyList(),
+            cotorVersion = "1.0.0",
+            gitCommit = "abcdef",
+            os = "Test OS",
+            jvm = "11"
+        )
+
+        val root = File(checkpointDir).canonicalFile
+        val saved = File(path).canonicalFile
+        saved.parentFile shouldBe root
+        File(root.parentFile, "outside").exists() shouldBe false
+        checkpointManager.loadCheckpoint(pipelineId)?.pipelineId shouldBe pipelineId
+        checkpointManager.deleteCheckpoint(pipelineId) shouldBe true
+    }
+
+    test("checkpoint files preserve repeated stage history order") {
+        val first = StageCheckpoint("stage-1", "agent", "first", true, 10, Instant.now().toString())
+        val second = StageCheckpoint("stage-1", "agent", "second", true, 11, Instant.now().toString())
+
+        checkpointManager.saveCheckpoint(
+            pipelineId = "repeated-stage-pipeline",
+            pipelineName = "Repeated Stage Pipeline",
+            completedStages = listOf(first, second),
+            cotorVersion = "1.0.0",
+            gitCommit = "abcdef",
+            os = "Test OS",
+            jvm = "11"
+        )
+
+        val loaded = checkpointManager.loadCheckpoint("repeated-stage-pipeline")
+        loaded?.completedStages?.map { it.output } shouldBe listOf("first", "second")
     }
 
     test("list checkpoints with metadata") {

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorConditionalTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorConditionalTest.kt
@@ -9,6 +9,8 @@ package com.cotor.domain.orchestrator
  */
 
 import com.cotor.analysis.DefaultResultAnalyzer
+import com.cotor.checkpoint.CheckpointManager
+import com.cotor.context.TemplateEngine
 import com.cotor.data.registry.InMemoryAgentRegistry
 import com.cotor.domain.aggregator.DefaultResultAggregator
 import com.cotor.domain.executor.AgentExecutor
@@ -26,6 +28,7 @@ import com.cotor.model.StageConditionConfig
 import com.cotor.model.StageLoopConfig
 import com.cotor.model.StageType
 import com.cotor.stats.StatsManager
+import com.cotor.validation.PipelineTemplateValidator
 import com.cotor.validation.output.DefaultOutputValidator
 import com.cotor.validation.output.SyntaxValidator
 import io.kotest.core.spec.style.FunSpec
@@ -48,7 +51,8 @@ class PipelineOrchestratorConditionalTest : FunSpec({
 
     fun createOrchestrator(
         executor: AgentExecutor,
-        statsManager: StatsManager = StatsManager(Files.createTempDirectory("conditional-stats").toString())
+        statsManager: StatsManager = StatsManager(Files.createTempDirectory("conditional-stats").toString()),
+        checkpointManager: CheckpointManager = CheckpointManager(Files.createTempDirectory("conditional-checkpoints").toString())
     ): DefaultPipelineOrchestrator {
         return DefaultPipelineOrchestrator(
             agentExecutor = executor,
@@ -57,7 +61,9 @@ class PipelineOrchestratorConditionalTest : FunSpec({
             logger = LoggerFactory.getLogger("ConditionalTest"),
             agentRegistry = registry,
             outputValidator = DefaultOutputValidator(SyntaxValidator()),
-            statsManager = statsManager
+            statsManager = statsManager,
+            checkpointManager = checkpointManager,
+            templateValidator = PipelineTemplateValidator(TemplateEngine())
         )
     }
 
@@ -157,6 +163,44 @@ class PipelineOrchestratorConditionalTest : FunSpec({
             )
         )
         execution.stages.map { it.duration }.shouldContainExactly(listOf(5L, 0L, 5L, 0L, 5L, 0L, 5L))
+    }
+
+    test("loop stage checkpoints preserve every traversal by stage id") {
+        val executor = RecordingAgentExecutor()
+        val checkpointManager = CheckpointManager(Files.createTempDirectory("loop-checkpoints").toString())
+        val orchestrator = createOrchestrator(executor, checkpointManager = checkpointManager)
+
+        val pipeline = Pipeline(
+            name = "looping-checkpoint",
+            executionMode = ExecutionMode.SEQUENTIAL,
+            stages = listOf(
+                PipelineStage(id = "draft", agent = AgentReference("alpha")),
+                PipelineStage(
+                    id = "loop-controller",
+                    type = StageType.LOOP,
+                    loop = StageLoopConfig(
+                        targetStageId = "draft",
+                        maxIterations = 2
+                    )
+                ),
+                PipelineStage(id = "review", agent = AgentReference("alpha"))
+            )
+        )
+
+        runBlocking { orchestrator.executePipeline(pipeline) }
+
+        val checkpoint = checkpointManager.getCheckpoints().single()
+        checkpoint.completedStages.map { it.stageId }.shouldContainExactly(
+            listOf(
+                "draft",
+                "loop-controller",
+                "draft",
+                "loop-controller",
+                "draft",
+                "loop-controller",
+                "review"
+            )
+        )
     }
 })
 

--- a/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
@@ -220,6 +220,54 @@ class WebServerTest : FunSpec({
         }
     }
 
+    test("company issue execution details reject mismatched company path") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-company-scope-test")
+        coEvery { desktopService.getIssueProjected("issue-1") } returns CompanyIssue(
+            id = "issue-1",
+            companyId = "company-2",
+            projectContextId = "project-1",
+            goalId = "goal-1",
+            workspaceId = "workspace-1",
+            title = "Issue",
+            description = "desc",
+            status = IssueStatus.IN_PROGRESS,
+            runtimeDisposition = "RUNNABLE",
+            createdAt = 1L,
+            updatedAt = 2L
+        )
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.get("/api/company/companies/company-1/issues/issue-1/execution-details") {
+                header("X-Cotor-Web-Token", "secret-web-token")
+            }
+
+            response.status shouldBe HttpStatusCode.NotFound
+            coVerify(exactly = 1) { desktopService.getIssueProjected("issue-1") }
+            coVerify(exactly = 0) { desktopService.issueExecutionDetails("issue-1") }
+        }
+    }
+
     test("mutating web editor routes reject missing token") {
         val configRepository = mockk<ConfigRepository>(relaxed = true)
         val agentRegistry = mockk<AgentRegistry>(relaxed = true)
@@ -252,6 +300,77 @@ class WebServerTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.Unauthorized
             response.bodyAsText() shouldContain "Unauthorized"
+        }
+    }
+
+    test("sensitive web get routes reject missing token") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-get-token-test")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.get("/api/company/dashboard")
+
+            response.status shouldBe HttpStatusCode.Unauthorized
+            response.bodyAsText() shouldContain "Unauthorized"
+            coVerify(exactly = 0) { desktopService.companyDashboardReadOnly() }
+        }
+    }
+
+    test("served web pages do not expose web token or external capture script") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-page-token-test")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val editorPage = client.get("/editor")
+            val companyPage = client.get("/company")
+
+            editorPage.status shouldBe HttpStatusCode.OK
+            companyPage.status shouldBe HttpStatusCode.OK
+            editorPage.bodyAsText().contains("window.COTOR_WEB_TOKEN") shouldBe false
+            companyPage.bodyAsText().contains("window.COTOR_WEB_TOKEN") shouldBe false
+            editorPage.bodyAsText().contains("capture.js") shouldBe false
+            companyPage.bodyAsText().contains("capture.js") shouldBe false
+            editorPage.bodyAsText() shouldContain "function escapeHtml"
         }
     }
 

--- a/src/test/kotlin/com/cotor/providers/github/GitHubControlPlaneServiceTest.kt
+++ b/src/test/kotlin/com/cotor/providers/github/GitHubControlPlaneServiceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import java.nio.file.Files
+import kotlin.concurrent.thread
 
 class GitHubControlPlaneServiceTest : FunSpec({
     test("recordSnapshot upserts PR state and keeps one current snapshot per PR") {
@@ -46,5 +47,23 @@ class GitHubControlPlaneServiceTest : FunSpec({
         service.listPullRequests("company-1") shouldHaveSize 1
         service.inspectPullRequest(12)?.state shouldBe "MERGED"
         service.listEvents("company-1") shouldHaveSize 2
+    }
+
+    test("store update preserves concurrent pull request changes") {
+        val appHome = Files.createTempDirectory("github-control-plane-store-concurrency-test")
+        val store = GitHubControlPlaneStore { appHome }
+
+        val threads = (1..2).map { number ->
+            thread {
+                store.update { current ->
+                    current.copy(
+                        pullRequests = current.pullRequests + PullRequestSnapshot(number = number, companyId = "company-1")
+                    )
+                }
+            }
+        }
+        threads.forEach { it.join() }
+
+        store.load().pullRequests.map { it.number }.sorted() shouldBe listOf(1, 2)
     }
 })

--- a/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
+++ b/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
@@ -25,8 +25,8 @@ class ProductionReliabilityBaselineTest {
             "Dockerfile should define a healthcheck against /health"
         )
         assertTrue(
-            dockerfile.contains("CMD [\"app-server\", \"--host\", \"127.0.0.1\", \"--port\", \"8787\"]"),
-            "Dockerfile should start app-server on loopback by default"
+            dockerfile.contains("CMD [\"app-server\", \"--host\", \"0.0.0.0\", \"--port\", \"8787\"]"),
+            "Dockerfile should bind app-server to all container interfaces for published ports"
         )
     }
 
@@ -36,6 +36,7 @@ class ProductionReliabilityBaselineTest {
 
         assertTrue(workflow.contains("- master"), "Release workflow should trigger on pushes to master")
         assertTrue(workflow.contains("build/release/cotor-"), "Release workflow should publish the shaded jar artifact")
+        assertTrue(workflow.contains("shasum -a 256 \"build/release/cotor-"), "Release workflow should generate the shaded jar checksum")
         assertTrue(workflow.contains("build/release/Cotor-"), "Release workflow should publish the desktop DMG artifact")
     }
 

--- a/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
@@ -5,6 +5,7 @@ import com.cotor.model.SecurityException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import org.slf4j.LoggerFactory
+import java.nio.file.Files
 
 class SecurityValidatorTest : FunSpec({
     test("command whitelist accepts absolute executable path by basename") {
@@ -24,6 +25,36 @@ class SecurityValidatorTest : FunSpec({
 
         shouldThrow<SecurityException> {
             validator.validateCommand(listOf("sh", "-c", "id"))
+        }
+    }
+
+    test("command validation rejects shell interpreter execution even when shell is allowlisted") {
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(allowedExecutables = setOf("sh")),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        shouldThrow<SecurityException> {
+            validator.validateCommand(listOf("sh", "-c", "id"))
+        }
+    }
+
+    test("command validation checks resolved absolute path against allowed directories") {
+        val blockedDir = Files.createTempDirectory("cotor-blocked-bin")
+        val executable = blockedDir.resolve("qwen").toFile()
+        executable.writeText("#!/bin/sh\nexit 0\n")
+        executable.setExecutable(true)
+        val allowedDir = Files.createTempDirectory("cotor-allowed-bin")
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(
+                allowedExecutables = setOf("qwen"),
+                allowedDirectories = listOf(allowedDir)
+            ),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        shouldThrow<SecurityException> {
+            validator.validateCommand(listOf(executable.absolutePath))
         }
     }
 })


### PR DESCRIPTION
## Summary
- Harden local web console auth/scoping/HTML output, command/checkpoint boundaries, A2A tenant binding, and runtime scheduling/worktree safety.
- Preserve repeated stage execution history for loop checkpoints and make GitHub provider state updates atomic.
- Add release checksum generation, container app-server binding, and quoted Codex argument parsing in the desktop app.

## Validation
- `./gradlew --no-daemon test`
- `./gradlew --no-daemon shadowJar`
- `./gradlew --no-daemon formatCheck`
- `swift build` in `macos/`
- `swift test` in `macos/`
- `git diff --check`
- `graphify update .`
- Manual web QA: `/api/company/dashboard` returns 401 without cookie/token, `/editor` sets `CotorWebToken`, `/api/editor/config` returns 200 with cookie, and the page does not expose `window.COTOR_WEB_TOKEN` or `capture.js`.
- Manual A2A QA: known sender session for `company-1` posting a message under `company-2` returns 400 with `not authorized for tenant.companyId company-2`.
- Manual release/container QA: shaded jar checksum file is generated and Docker app-server default command binds `0.0.0.0`.

## Notes
- Kotlin LSP diagnostics could not run because `kotlin-lsp` is not installed locally; Gradle compile/test covered Kotlin validation.
- Swift diagnostics on the edited test file still show the pre-existing `swift-testing` package deprecation warning.
- English/Korean docs were not updated because the committed changes do not alter documented user command behavior.