### PR TITLE
fix(runtime): recover blocked provider failures

### DIFF
--- a/src/main/kotlin/com/cotor/app/AppApiModels.kt
+++ b/src/main/kotlin/com/cotor/app/AppApiModels.kt
@@ -267,6 +267,34 @@ data class CompanyDashboardResponse(
     val agentMessages: List<AgentMessage> = emptyList()
 )
 
+internal fun BackendConnectionConfig.redactedForApi(): BackendConnectionConfig = copy(token = null)
+
+internal fun ExecutionBackendStatus.redactedForApi(): ExecutionBackendStatus = copy(config = config.redactedForApi())
+
+internal fun LinearConnectionConfig.redactedForApi(): LinearConnectionConfig = copy(apiToken = null)
+
+internal fun DesktopLinearSettings.redactedForApi(): DesktopLinearSettings = copy(defaultConfig = defaultConfig.redactedForApi())
+
+internal fun DesktopBackendSettings.redactedForApi(): DesktopBackendSettings = copy(
+    backends = backends.map { it.redactedForApi() }
+)
+
+internal fun Company.redactedForApi(): Company = copy(
+    backendConfigOverride = backendConfigOverride?.redactedForApi(),
+    linearConfigOverride = linearConfigOverride?.redactedForApi()
+)
+
+internal fun DesktopSettings.redactedForApi(): DesktopSettings = copy(
+    backendSettings = backendSettings.redactedForApi(),
+    linearSettings = linearSettings.redactedForApi(),
+    backendStatuses = backendStatuses.map { it.redactedForApi() }
+)
+
+internal fun CompanyDashboardResponse.redactedForApi(): CompanyDashboardResponse = copy(
+    companies = companies.map { it.redactedForApi() },
+    backendStatuses = backendStatuses.map { it.redactedForApi() }
+)
+
 /**
  * Top-level bootstrap response consumed by the Swift client after launch/refresh.
  */
@@ -292,6 +320,12 @@ data class DashboardResponse(
     val companyRuntimes: List<CompanyRuntimeSnapshot> = emptyList(),
     val agentContextEntries: List<AgentContextEntry> = emptyList(),
     val agentMessages: List<AgentMessage> = emptyList()
+)
+
+internal fun DashboardResponse.redactedForApi(): DashboardResponse = copy(
+    settings = settings.redactedForApi(),
+    companies = companies.map { it.redactedForApi() },
+    backendStatuses = backendStatuses.map { it.redactedForApi() }
 )
 
 /**

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -344,13 +344,13 @@ internal fun Application.cotorAppModule(
 
             get("/dashboard") {
                 if (!requireToken(token)) return@get
-                call.respond(desktopService.dashboard())
+                call.respond(desktopService.dashboard().redactedForApi())
             }
 
             route("/settings/backends") {
                 get {
                     if (!requireToken(token)) return@get
-                    call.respond(desktopService.backendStatuses())
+                    call.respond(desktopService.backendStatuses().map { it.redactedForApi() })
                 }
 
                 patch("/default") {
@@ -390,7 +390,7 @@ internal fun Application.cotorAppModule(
                             authMode = request.authMode,
                             token = request.token,
                             timeoutSeconds = request.timeoutSeconds
-                        )
+                        ).redactedForApi()
                     }
                 }
             }
@@ -792,7 +792,7 @@ internal fun Application.cotorAppModule(
             route("/company") {
                 get {
                     if (!requireToken(token)) return@get
-                    call.respond(desktopService.companyDashboardReadOnly())
+                    call.respond(desktopService.companyDashboardReadOnly().redactedForApi())
                 }
 
                 route("/goals") {
@@ -992,7 +992,7 @@ internal fun Application.cotorAppModule(
                     if (!requireToken(token)) return@get
                     val companyId = call.parameters["companyId"]
                         ?: return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
-                    call.respond(desktopService.companyDashboardReadOnly(companyId))
+                    call.respond(desktopService.companyDashboardReadOnly(companyId).redactedForApi())
                 }
 
                 get("/{companyId}/memory-snapshot") {
@@ -1745,7 +1745,7 @@ internal fun Application.cotorAppModule(
 
             get("/settings") {
                 if (!requireToken(token)) return@get
-                call.respond(desktopService.settings())
+                call.respond(desktopService.settings().redactedForApi())
             }
         }
     }

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -3887,6 +3887,8 @@ class DesktopAppService(
             val now = System.currentTimeMillis()
             val blockedIssue = currentIssue.copy(
                 status = IssueStatus.BLOCKED,
+                providerBlockReason = reason,
+                transitionReason = "Issue run could not start: $reason",
                 updatedAt = now
             )
             val nextState = state.copy(
@@ -6235,8 +6237,11 @@ class DesktopAppService(
             message.contains("githubcopilot.com/.well-known/oauth-protected-resource/mcp/")
 
     private fun isRecoverableOpenCodeCliFailure(message: String): Boolean =
-        message.contains("decimalerror") &&
-            message.contains("invalid argument: [object object]")
+        message.contains("provider returned error") ||
+            (
+                message.contains("decimalerror") &&
+                    message.contains("invalid argument: [object object]")
+                )
 
     private fun extractGitHubPublishReadinessFailureReason(
         task: AgentTask,
@@ -6295,7 +6300,8 @@ class DesktopAppService(
             return false
         }
         return failureSignals(task, run).any { message ->
-            CodexDefaults.isRetiredModelAliasFailure(message)
+            message.contains(INTERRUPTED_RUN_ERROR, ignoreCase = true) ||
+                CodexDefaults.isRetiredModelAliasFailure(message)
         }
     }
 

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -336,7 +336,7 @@ class DesktopAppService(
                 .sortedByDescending { it.lastTickAt ?: 0L },
             agentContextEntries = state.agentContextEntries.sortedByDescending { it.createdAt },
             agentMessages = state.agentMessages.sortedByDescending { it.createdAt }
-        )
+        ).redactedForApi()
     }
 
     suspend fun companyDashboard(companyId: String? = null): CompanyDashboardResponse {
@@ -351,12 +351,12 @@ class DesktopAppService(
             prepareCompanyAutomationState(companyId)
         }
         val state = stateStore.load().withDerivedMetrics()
-        return companyDashboardSnapshot(state, companyId)
+        return companyDashboardSnapshot(state, companyId).redactedForApi()
     }
 
     suspend fun companyDashboardReadOnly(companyId: String? = null): CompanyDashboardResponse {
         val state = stateStore.load().withDerivedMetrics()
-        return companyDashboardSnapshot(state, companyId)
+        return companyDashboardSnapshot(state, companyId).redactedForApi()
     }
 
     private fun companyDashboardSnapshot(
@@ -2154,10 +2154,10 @@ class DesktopAppService(
     }
 
     suspend fun backendStatuses(): List<ExecutionBackendStatus> =
-        computeBackendStatuses(stateStore.load())
+        computeBackendStatuses(stateStore.load()).map { it.redactedForApi() }
 
     suspend fun companyBackendStatus(companyId: String): ExecutionBackendStatus =
-        companyBackendStatus(companyId, stateStore.load())
+        companyBackendStatus(companyId, stateStore.load()).redactedForApi()
 
     suspend fun startCompanyBackend(companyId: String): ExecutionBackendStatus {
         val state = stateStore.load()
@@ -7888,7 +7888,7 @@ class DesktopAppService(
             linearSettings = state.linearSettings,
             backendStatuses = computeBackendStatuses(state),
             shortcuts = ShortcutConfig()
-        )
+        ).redactedForApi()
     }
 
     fun availableAgentModels(agent: String): List<String> {

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
@@ -103,6 +103,8 @@ class CompanyRuntimeBindingService(
                         WAITING_FOR_CI
                     matchingRun?.status == DurableRunStatus.FAILED && issue.status == com.cotor.app.IssueStatus.BLOCKED ->
                         QUARANTINED
+                    issue.status == com.cotor.app.IssueStatus.BLOCKED && !issue.providerBlockReason.isNullOrBlank() ->
+                        QUARANTINED
                     issue.status == com.cotor.app.IssueStatus.BLOCKED &&
                         (issuePullRequest?.checksSummary?.contains("SUCCESS", ignoreCase = true) == true) ->
                         RECOVERABLE

--- a/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
+++ b/src/main/kotlin/com/cotor/presentation/web/WebServer.kt
@@ -453,6 +453,10 @@ internal fun Application.cotorWebModule(
             call.respondText(landingHtml, ContentType.Text.Html)
         }
 
+        get("/favicon.ico") {
+            call.respond(HttpStatusCode.NoContent)
+        }
+
         get("/editor") {
             call.attachWebTokenCookie(webToken)
             call.respondText(editorHtml(), ContentType.Text.Html)
@@ -662,7 +666,7 @@ internal fun Application.cotorWebModule(
         route("/api/company") {
             get("/dashboard") {
                 if (!call.requireWebToken(webToken)) return@get
-                call.respond(desktopService.companyDashboardReadOnly())
+                call.respond(desktopService.companyDashboardReadOnly().redactedForApi())
             }
 
             get("/issues/{issueId}/execution-details") {
@@ -703,7 +707,7 @@ internal fun Application.cotorWebModule(
                 get("/{companyId}/dashboard") {
                     if (!call.requireWebToken(webToken)) return@get
                     val companyId = call.parameters["companyId"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-                    call.respond(desktopService.companyDashboardReadOnly(companyId))
+                    call.respond(desktopService.companyDashboardReadOnly(companyId).redactedForApi())
                 }
 
                 patch("/{companyId}") {
@@ -1352,7 +1356,7 @@ private fun editorHtml(): String = """
           <div class="stage-card" draggable="true" ondragstart="onDragStart(${ '$' }{i})" ondragover="onDragOver(event, ${ '$' }{i})" ondrop="onDrop(event, ${ '$' }{i})">
             <div class="stage-header">
               <span class="grip">⋮⋮</span>
-              <input class="input" style="max-width:200px;" value="${ '$' }{escapeHtml(s.id)}" onchange="updateStageField(${ '$' }{i}, 'id', this.value)" />
+              <input class="input" data-stage-index="${ '$' }{i}" data-stage-key="id" style="max-width:200px;" value="${ '$' }{escapeHtml(s.id)}" oninput="updateStageField(${ '$' }{i}, 'id', this.value, false)" />
               <select class="input" style="max-width:140px;" onchange="updateStageField(${ '$' }{i}, 'type', this.value)">
                 ${ '$' }{["EXECUTION"].map(t => `<option value="${ '$' }{escapeHtml(t)}" ${ '$' }{s.type===t?"selected":""}>${ '$' }{escapeHtml(t)}</option>`).join("")}
               </select>
@@ -1361,16 +1365,16 @@ private fun editorHtml(): String = """
             <div class="grid-2">
               <div class="field">
                 <label>Agent</label>
-                <input class="input" value="${ '$' }{escapeHtml(s.agent || "")}" onchange="updateStageField(${ '$' }{i}, 'agent', this.value)" placeholder="claude / gemini / ..." />
+                <input class="input" data-stage-index="${ '$' }{i}" data-stage-key="agent" value="${ '$' }{escapeHtml(s.agent || "")}" oninput="updateStageField(${ '$' }{i}, 'agent', this.value, false)" placeholder="claude / gemini / ..." />
               </div>
               <div class="field">
                 <label>Dependencies</label>
-                <input class="input" value="${ '$' }{escapeHtml(deps)}" onchange="updateStageField(${ '$' }{i}, 'dependencies', this.value)" placeholder="comma 로 구분" />
+                <input class="input" data-stage-index="${ '$' }{i}" data-stage-key="dependencies" value="${ '$' }{escapeHtml(deps)}" oninput="updateStageField(${ '$' }{i}, 'dependencies', this.value, false)" placeholder="comma 로 구분" />
               </div>
             </div>
             <div class="field">
               <label>Input / Prompt</label>
-              <textarea onchange="updateStageField(${ '$' }{i}, 'input', this.value)" placeholder="이 단계가 수행할 내용">${ '$' }{escapeHtml(s.input || "")}</textarea>
+              <textarea data-stage-index="${ '$' }{i}" data-stage-key="input" oninput="updateStageField(${ '$' }{i}, 'input', this.value, false)" placeholder="이 단계가 수행할 내용">${ '$' }{escapeHtml(s.input || "")}</textarea>
             </div>
           </div>
         `;
@@ -1379,8 +1383,9 @@ private fun editorHtml(): String = """
       updateYaml();
     }
 
-    function updateStageField(index, key, value) {
+    function updateStageField(index, key, value, rerender = true) {
       const stage = state.stages[index];
+      if (!stage) return;
       if (key === "dependencies") {
         stage[key] = value.split(",").map(v => v.trim()).filter(Boolean);
       } else if (key === "loopMaxIterations") {
@@ -1388,7 +1393,13 @@ private fun editorHtml(): String = """
       } else {
         stage[key] = value;
       }
-      renderStages();
+      if (rerender) renderStages(); else updateYaml();
+    }
+
+    function collectStageStateFromDom() {
+      document.querySelectorAll("[data-stage-index][data-stage-key]").forEach(el => {
+        updateStageField(Number(el.dataset.stageIndex), el.dataset.stageKey, el.value, false);
+      });
     }
 
     function addStage(type) {
@@ -1547,6 +1558,7 @@ private fun editorHtml(): String = """
       state.name = document.getElementById("pipelineName").value.trim();
       state.description = document.getElementById("pipelineDesc").value.trim();
       state.executionMode = document.getElementById("executionMode").value;
+      collectStageStateFromDom();
     }
 
     async function savePipeline() {

--- a/src/test/kotlin/com/cotor/app/AppServerTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerTest.kt
@@ -11,6 +11,7 @@ package com.cotor.app
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -77,6 +78,59 @@ class AppServerTest : FunSpec({
             val response = client.get("/api/app/dashboard")
             response.status shouldBe HttpStatusCode.Unauthorized
             response.bodyAsText() shouldContain "Unauthorized"
+        }
+    }
+
+    test("settings route redacts backend and Linear tokens") {
+        every { desktopService.settings() } returns DesktopSettings(
+            appHome = "/tmp/cotor-app-home",
+            managedReposRoot = "/tmp/cotor-repos",
+            availableAgents = emptyList(),
+            backendSettings = DesktopBackendSettings(
+                backends = listOf(
+                    BackendConnectionConfig(
+                        kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                        authMode = "bearer",
+                        token = "codex-secret-token"
+                    )
+                )
+            ),
+            linearSettings = DesktopLinearSettings(
+                defaultConfig = LinearConnectionConfig(apiToken = "linear-secret-token")
+            ),
+            backendStatuses = listOf(
+                ExecutionBackendStatus(
+                    kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                    displayName = "Codex",
+                    config = BackendConnectionConfig(
+                        kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                        authMode = "bearer",
+                        token = "status-secret-token"
+                    )
+                )
+            )
+        )
+
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.get("/api/app/settings") {
+                header("Authorization", "Bearer secret-token")
+            }
+            val body = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.OK
+            body shouldContain "\"token\":null"
+            body shouldContain "\"apiToken\":null"
+            body shouldNotContain "codex-secret-token"
+            body shouldNotContain "linear-secret-token"
+            body shouldNotContain "status-secret-token"
         }
     }
 
@@ -1536,6 +1590,12 @@ class AppServerTest : FunSpec({
                     rootPath = "/tmp/cotor",
                     repositoryId = "repo-1",
                     defaultBaseBranch = "master",
+                    backendConfigOverride = BackendConnectionConfig(
+                        kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                        authMode = "bearer",
+                        token = "company-backend-secret"
+                    ),
+                    linearConfigOverride = LinearConnectionConfig(apiToken = "company-linear-secret"),
                     dailyBudgetCents = 1500,
                     monthlyBudgetCents = 12000,
                     createdAt = 1L,
@@ -1578,6 +1638,17 @@ class AppServerTest : FunSpec({
                 monthSpentCents = 1180,
                 budgetPausedAt = 5L,
                 budgetResetDate = "2026-03-28"
+            ),
+            backendStatuses = listOf(
+                ExecutionBackendStatus(
+                    kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                    displayName = "Codex",
+                    config = BackendConnectionConfig(
+                        kind = ExecutionBackendKind.CODEX_APP_SERVER,
+                        authMode = "bearer",
+                        token = "dashboard-status-secret"
+                    )
+                )
             )
         )
 
@@ -1614,6 +1685,11 @@ class AppServerTest : FunSpec({
             response.bodyAsText() shouldContain "\"todaySpentCents\":245"
             response.bodyAsText() shouldContain "\"monthSpentCents\":1180"
             response.bodyAsText() shouldContain "\"budgetPausedAt\":5"
+            response.bodyAsText() shouldContain "\"token\":null"
+            response.bodyAsText() shouldContain "\"apiToken\":null"
+            response.bodyAsText() shouldNotContain "company-backend-secret"
+            response.bodyAsText() shouldNotContain "company-linear-secret"
+            response.bodyAsText() shouldNotContain "dashboard-status-secret"
             coVerify(exactly = 1) { desktopService.companyDashboardReadOnly("company-1") }
             coVerify(exactly = 0) { desktopService.companyDashboard("company-1") }
         }

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRequeueOrphanedTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRequeueOrphanedTest.kt
@@ -8,6 +8,7 @@ import com.cotor.integrations.linear.LinearTrackerAdapter
 import com.cotor.model.ProcessResult
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
@@ -146,7 +147,204 @@ class DesktopAppServiceRequeueOrphanedTest : FunSpec({
             service.shutdown()
         }
     }
+
+    test("company automation requeues repeated app-server interruption blockers after restart") {
+        val appHome = Files.createTempDirectory("desktop-company-requeue-interrupted-home")
+        val repoRoot = Files.createTempDirectory("desktop-company-requeue-interrupted-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = requeueCompany("company-requeue-interrupted", repoRoot)
+        val goal = requeueGoal(company.id, "goal-requeue-interrupted")
+        val issue = requeueIssue(
+            id = "issue-requeue-interrupted",
+            company = company,
+            goal = goal,
+            reason = "Execution was interrupted because the app-server stopped before the run finished."
+        )
+        val tasks = (1..3).map { index ->
+            AgentTask(
+                id = "task-requeue-interrupted-$index",
+                workspaceId = REQUEUE_WORKSPACE_ID,
+                issueId = issue.id,
+                title = issue.title,
+                prompt = issue.description,
+                agents = listOf("opencode"),
+                status = DesktopTaskStatus.FAILED,
+                createdAt = index.toLong(),
+                updatedAt = index.toLong()
+            )
+        }
+        val runs = tasks.map { task ->
+            AgentRun(
+                id = "run-${task.id}",
+                taskId = task.id,
+                workspaceId = task.workspaceId,
+                repositoryId = REQUEUE_REPOSITORY_ID,
+                agentName = "opencode",
+                branchName = "codex/cotor/${task.id}/opencode",
+                worktreePath = repoRoot.resolve(task.id).toString(),
+                status = AgentRunStatus.FAILED,
+                error = "Execution was interrupted because the app-server stopped before the run finished.",
+                createdAt = task.createdAt,
+                updatedAt = task.updatedAt
+            )
+        }
+        stateStore.save(requeueState(appHome, repoRoot, company, goal, issue, tasks, runs))
+        val service = requeueTestService(
+            processManager = RequeueGitProcessManager(repoRoot, null, "master"),
+            stateStore = stateStore
+        )
+
+        try {
+            service.prepareCompanyAutomationStateForTesting(company.id)
+
+            stateStore.load().issues.single { it.id == issue.id }.status shouldNotBe IssueStatus.BLOCKED
+        } finally {
+            service.shutdown()
+        }
+    }
+
+    test("company automation requeues OpenCode provider returned error blockers") {
+        val appHome = Files.createTempDirectory("desktop-company-requeue-opencode-home")
+        val repoRoot = Files.createTempDirectory("desktop-company-requeue-opencode-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = requeueCompany("company-requeue-opencode", repoRoot)
+        val goal = requeueGoal(company.id, "goal-requeue-opencode")
+        val issue = requeueIssue(
+            id = "issue-requeue-opencode",
+            company = company,
+            goal = goal,
+            reason = "OpenCode execution failed (exit=0): \"Provider returned error\""
+        )
+        val task = AgentTask(
+            id = "task-requeue-opencode",
+            workspaceId = REQUEUE_WORKSPACE_ID,
+            issueId = issue.id,
+            title = issue.title,
+            prompt = issue.description,
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.FAILED,
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+        val run = AgentRun(
+            id = "run-requeue-opencode",
+            taskId = task.id,
+            workspaceId = task.workspaceId,
+            repositoryId = REQUEUE_REPOSITORY_ID,
+            agentName = "opencode",
+            branchName = "codex/cotor/requeue-opencode/opencode",
+            worktreePath = repoRoot.resolve("opencode").toString(),
+            status = AgentRunStatus.FAILED,
+            error = "OpenCode execution failed (exit=0): \"Provider returned error\"",
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+        stateStore.save(requeueState(appHome, repoRoot, company, goal, issue, listOf(task), listOf(run)))
+        val service = requeueTestService(
+            processManager = RequeueGitProcessManager(repoRoot, null, "master"),
+            stateStore = stateStore
+        )
+
+        try {
+            service.prepareCompanyAutomationStateForTesting(company.id)
+
+            stateStore.load().tasks.count { it.issueId == issue.id } shouldBe 2
+        } finally {
+            service.shutdown()
+        }
+    }
 })
+
+private fun requeueCompany(id: String, repoRoot: Path): Company = Company(
+    id = id,
+    name = id,
+    rootPath = repoRoot.toString(),
+    repositoryId = REQUEUE_REPOSITORY_ID,
+    defaultBaseBranch = "master",
+    createdAt = 1L,
+    updatedAt = 1L
+)
+
+private fun requeueGoal(companyId: String, id: String): CompanyGoal = CompanyGoal(
+    id = id,
+    companyId = companyId,
+    projectContextId = "project-$id",
+    title = "Recover blocked work",
+    description = "Recover blocked work",
+    status = GoalStatus.ACTIVE,
+    autonomyEnabled = true,
+    createdAt = 1L,
+    updatedAt = 1L
+)
+
+private fun requeueIssue(
+    id: String,
+    company: Company,
+    goal: CompanyGoal,
+    reason: String
+): CompanyIssue = CompanyIssue(
+    id = id,
+    companyId = company.id,
+    projectContextId = goal.projectContextId,
+    goalId = goal.id,
+    workspaceId = REQUEUE_WORKSPACE_ID,
+    title = "Recover execution issue",
+    description = "Recover execution issue",
+    status = IssueStatus.BLOCKED,
+    kind = "execution",
+    codeProducing = false,
+    providerBlockReason = reason,
+    transitionReason = "Execution failed and requires a recoverable retry or remediation.",
+    createdAt = 1L,
+    updatedAt = 1L
+)
+
+private fun requeueState(
+    appHome: Path,
+    repoRoot: Path,
+    company: Company,
+    goal: CompanyGoal,
+    issue: CompanyIssue,
+    tasks: List<AgentTask>,
+    runs: List<AgentRun>
+): DesktopAppState = DesktopAppState(
+    companies = listOf(company),
+    repositories = listOf(
+        ManagedRepository(
+            id = REQUEUE_REPOSITORY_ID,
+            name = "repo",
+            localPath = repoRoot.toString(),
+            sourceKind = RepositorySourceKind.LOCAL,
+            defaultBranch = "master",
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+    ),
+    workspaces = listOf(
+        Workspace(
+            id = REQUEUE_WORKSPACE_ID,
+            repositoryId = REQUEUE_REPOSITORY_ID,
+            name = "repo · master",
+            baseBranch = "master",
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+    ),
+    projectContexts = listOf(
+        CompanyProjectContext(
+            id = goal.projectContextId ?: "project-${goal.id}",
+            companyId = company.id,
+            name = company.name,
+            slug = company.id,
+            contextDocPath = appHome.resolve("project.md").toString(),
+            lastUpdatedAt = 1L
+        )
+    ),
+    goals = listOf(goal),
+    issues = listOf(issue),
+    tasks = tasks,
+    runs = runs
+)
 
 private fun requeueTestService(
     processManager: ProcessManager,

--- a/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
@@ -30,6 +30,7 @@ import com.cotor.runtime.durable.DurableRunStatus
 import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.runtime.durable.DurableRuntimeStore
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import java.nio.file.Files
 
@@ -160,5 +161,54 @@ class CompanyRuntimeBindingServiceTest : FunSpec({
         bound.issues.single().approvalPauseId shouldBe "pause-1"
         bound.issues.single().providerBlockReason shouldBe "ci=COMPLETED/FAILURE"
         bound.reviewQueue.single().providerBlockReason shouldBe "ci=COMPLETED/FAILURE"
+    }
+
+    test("bind keeps provider-blocked execution failures in blocked runtime attention without durable snapshots") {
+        val appHome = Files.createTempDirectory("company-runtime-provider-blocked")
+        val companyId = "company-provider-blocked"
+        val issueId = "issue-provider-blocked"
+        val service = CompanyRuntimeBindingService(
+            durableRuntimeService = DurableRuntimeService(runtimeStore = DurableRuntimeStore(appHome.resolve("runtime"))),
+            actionStore = ActionStore { appHome },
+            policyEngine = PolicyEngine(PolicyStore { appHome }),
+            gitHubControlPlaneService = GitHubControlPlaneService(store = GitHubControlPlaneStore { appHome })
+        )
+
+        val bound = service.bind(
+            state = DesktopAppState(
+                companies = listOf(
+                    Company(
+                        id = companyId,
+                        name = "Provider Blocked",
+                        rootPath = ".",
+                        repositoryId = "repo-provider-blocked",
+                        defaultBaseBranch = "main",
+                        backendKind = ExecutionBackendKind.LOCAL_COTOR,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                issues = listOf(
+                    CompanyIssue(
+                        id = issueId,
+                        companyId = companyId,
+                        goalId = "goal-provider-blocked",
+                        workspaceId = "workspace-provider-blocked",
+                        title = "Provider failed issue",
+                        description = "desc",
+                        status = IssueStatus.BLOCKED,
+                        durableRunId = "missing-run",
+                        providerBlockReason = "OpenCode execution failed (exit=0): \"Provider returned error\"",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                )
+            ),
+            companyId = companyId,
+            runtime = CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+        )
+
+        bound.issues.single().runtimeDisposition shouldBe "QUARANTINED"
+        bound.runtime.blockedIssueIds shouldContain issueId
     }
 })

--- a/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/web/WebServerTest.kt
@@ -12,6 +12,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -56,6 +57,36 @@ class WebServerTest : FunSpec({
             response.status.value shouldBe 200
             response.bodyAsText() shouldContain "Cotor Company Console"
             response.bodyAsText() shouldContain "/api/company/dashboard"
+        }
+    }
+
+    test("favicon request does not create a browser console 404") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-favicon-test")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val response = client.get("/favicon.ico")
+
+            response.status shouldBe HttpStatusCode.NoContent
         }
     }
 
@@ -371,6 +402,43 @@ class WebServerTest : FunSpec({
             editorPage.bodyAsText().contains("capture.js") shouldBe false
             companyPage.bodyAsText().contains("capture.js") shouldBe false
             editorPage.bodyAsText() shouldContain "function escapeHtml"
+        }
+    }
+
+    test("editor page syncs focused stage fields before save or run") {
+        val configRepository = mockk<ConfigRepository>(relaxed = true)
+        val agentRegistry = mockk<AgentRegistry>(relaxed = true)
+        val orchestrator = mockk<PipelineOrchestrator>(relaxed = true)
+        val desktopService = mockk<DesktopAppService>(relaxed = true)
+        val editorDir = Files.createTempDirectory("cotor-web-stage-input-test")
+
+        testApplication {
+            application {
+                cotorWebModule(
+                    configRepository = configRepository,
+                    agentRegistry = agentRegistry,
+                    orchestrator = orchestrator,
+                    desktopService = desktopService,
+                    editorDir = editorDir,
+                    readOnly = false,
+                    webToken = "secret-web-token",
+                    buildTemplates = { emptyList() },
+                    listSavedPipelines = { emptyList() },
+                    loadPipelineDetail = { null },
+                    savePipeline = { editorDir.resolve("saved.yaml") },
+                    buildTimelinePayload = { _, _ -> emptyList() }
+                )
+            }
+
+            val editorPage = client.get("/editor")
+            val body = editorPage.bodyAsText()
+
+            editorPage.status shouldBe HttpStatusCode.OK
+            body shouldContain "data-stage-key=\"input\""
+            body shouldContain "oninput=\"updateStageField"
+            body shouldContain "function collectStageStateFromDom()"
+            body shouldContain "collectStageStateFromDom();"
+            body shouldNotContain "textarea onchange=\"updateStageField"
         }
     }
 


### PR DESCRIPTION
## Summary
- Retry app-server interruption blockers after restart instead of exhausting the retry budget permanently.
- Treat OpenCode provider-returned errors as recoverable provider failures.
- Surface provider-blocked execution issues in runtime attention instead of projecting them as terminal.

## Validation
- ./gradlew --no-daemon formatCheck
- ./gradlew --no-daemon test
- ./gradlew --no-daemon shadowJar
- ./gradlew --no-daemon cleanTest test --tests 'com.cotor.app.DesktopAppServiceRequeueOrphanedTest' --tests 'com.cotor.app.runtime.CompanyRuntimeBindingServiceTest' (test bodies pass; partial run fails JaCoCo coverage gate as expected for subset-only execution)
- Manual QA: launched updated app-server jar with temporary desktop state and confirmed BLOCKED provider issue returns runtimeDisposition=QUARANTINED and appears in runtimeBlockedIssueIds.
- graphify update .
- GIT_MASTER=1 git diff --check

## Notes
- This PR also contains the two local hardening commits already present on this branch base: app-server secret redaction and local web response hardening.