### PR TITLE
Redesign Meeting Room as pixel office

### DIFF
--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -5994,37 +5994,64 @@ private struct CenterPaneView: View {
     private var companyMeetingRoomPanel: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 8) {
-                meetingRoomSurfaceButton(
-                    surface: .map,
-                    title: l("Map", "지도"),
-                    systemImage: "point.3.connected.trianglepath.dotted"
-                )
-                meetingRoomSurfaceButton(
-                    surface: .meeting,
-                    title: l("Agent Meeting", "에이전트 회의"),
-                    systemImage: "person.3.sequence"
-                )
-                meetingRoomSurfaceButton(
-                    surface: .floor,
-                    title: l("Live Floor", "라이브 플로어"),
-                    systemImage: "person.2.wave.2"
-                )
+                ShellTag(text: l("Live Office", "라이브 오피스"), tint: ShellPalette.accent)
+                ShellTag(text: "\(meetingRoomProjection.agents.count) \(l("agents", "에이전트"))", tint: ShellPalette.accentWarm)
+                ShellTag(text: "\(meetingRoomProjection.reviewCount) \(l("reviews", "리뷰"))", tint: ShellPalette.warning)
                 Spacer(minLength: 0)
+                Button {
+                    withAnimation(ShellMotion.spring) {
+                        detailDrawerOpen.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 7) {
+                        Image(systemName: "sidebar.right")
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(detailDrawerOpen ? l("Hide Activity", "활동 숨김") : l("Activity", "활동"))
+                            .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    }
+                    .foregroundStyle(detailDrawerOpen ? ShellPalette.text : ShellPalette.muted)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(detailDrawerOpen ? ShellPalette.panelRaised : ShellPalette.panelAlt)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous)
+                            .stroke(detailDrawerOpen ? ShellPalette.accent.opacity(0.42) : ShellPalette.line, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(detailDrawerOpen ? l("Hide activity drawer", "활동 drawer 숨기기") : l("Show activity drawer", "활동 drawer 보기"))
             }
 
             meetingRoomAgendaStrip
 
-            switch meetingRoomSurface {
-            case .map:
-                meetingRoomMapSurface
-            case .meeting:
-                meetingRoomMeetingSurface
-            case .floor:
-                meetingRoomFloorSurface
+            if layoutMode == .wide {
+                HStack(alignment: .top, spacing: 12) {
+                    meetingRoomFloorSurface
+                        .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)
+                    if detailDrawerOpen {
+                        meetingRoomActivityDrawer
+                            .frame(width: 340, alignment: .topLeading)
+                    }
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    meetingRoomFloorSurface
+                    if detailDrawerOpen {
+                        meetingRoomActivityDrawer
+                    }
+                }
             }
         }
         .padding(12)
         .shellInset()
+    }
+
+    private var meetingRoomActivityDrawer: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            meetingRoomEventWallZone
+            meetingRoomReviewDeskZone
+        }
     }
 
     @ViewBuilder

--- a/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
@@ -13,6 +13,7 @@ enum MeetingRoomVisualState: String, Hashable {
 enum MeetingRoomExpression: String, Hashable {
     case idle
     case focused
+    case talking
     case confused
     case sad
     case happy
@@ -205,7 +206,7 @@ struct MeetingRoomProjection: Hashable {
                 currentIssueTitle: issue?.title,
                 status: session?.status ?? issue?.status ?? (agent.enabled ? "IDLE" : "PAUSED"),
                 visualState: visualState,
-                expression: expression(for: visualState),
+                expression: messageCount > 0 ? .talking : expression(for: visualState),
                 zone: zone(for: visualState),
                 actionLine: actionLine(for: visualState, role: agent.title),
                 detailLine: detailLine(agent: agent, session: session, issue: issue, reviewCount: scopedReviews.count, runtime: runtime),

--- a/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
@@ -1,0 +1,534 @@
+import CoreGraphics
+import Foundation
+
+enum MeetingRoomSpriteAction: String, Hashable {
+    case sitting
+    case typing
+    case walking
+    case reviewing
+    case talking
+    case blocked
+}
+
+enum MeetingRoomSceneKeyframeKind: String, Hashable {
+    case issueCreated
+    case issueAssigned
+    case agentTyping
+    case a2aMessage
+    case reviewRequested
+    case mergeCompleted
+    case blockedJump
+    case costPaused
+
+    var usesScheduler: Bool {
+        switch self {
+        case .issueCreated, .issueAssigned, .agentTyping, .a2aMessage, .reviewRequested:
+            return true
+        case .mergeCompleted, .blockedJump, .costPaused:
+            return false
+        }
+    }
+}
+
+struct MeetingRoomRenderPlan: Hashable {
+    enum Mode: String, Hashable {
+        case full
+        case simplified
+        case grouped
+
+        var label: String {
+            switch self {
+            case .full:
+                return "FULL"
+            case .simplified:
+                return "LOW"
+            case .grouped:
+                return "GROUPED"
+            }
+        }
+    }
+
+    let mode: Mode
+    let visibleAgents: [MeetingRoomProjectionAgent]
+    let hiddenAgentCount: Int
+    let visibleFlows: [MeetingRoomFlowItem]
+    let shouldAnimate: Bool
+    let frameInterval: TimeInterval
+
+    var animationKey: String {
+        [
+            mode.rawValue,
+            visibleAgents.map { "\($0.id):\($0.visualState.rawValue):\($0.currentIssueId ?? "-")" }.joined(separator: "|"),
+            visibleFlows.map { "\($0.id):\($0.kind.rawValue):\($0.progress)" }.joined(separator: "|"),
+        ].joined(separator: "::")
+    }
+
+    static func build(
+        projection: MeetingRoomProjection,
+        isCompact: Bool,
+        reduceMotion: Bool,
+        lowResourceMode: Bool,
+        isSceneActive: Bool
+    ) -> MeetingRoomRenderPlan {
+        let agentCount = projection.agents.count
+        let mode: Mode
+        if agentCount >= 50 {
+            mode = .grouped
+        } else if agentCount >= 20 || lowResourceMode || reduceMotion || isCompact {
+            mode = .simplified
+        } else {
+            mode = .full
+        }
+
+        let maxAgents: Int
+        let maxFlows: Int
+        switch mode {
+        case .full:
+            maxAgents = agentCount
+            maxFlows = 8
+        case .simplified:
+            maxAgents = min(agentCount, isCompact ? 10 : 20)
+            maxFlows = 6
+        case .grouped:
+            maxAgents = min(agentCount, 12)
+            maxFlows = 6
+        }
+
+        let prioritizedAgents = projection.agents.sorted { lhs, rhs in
+            if lhs.visualState.renderPriority != rhs.visualState.renderPriority {
+                return lhs.visualState.renderPriority > rhs.visualState.renderPriority
+            }
+            return lhs.id < rhs.id
+        }
+        let visibleAgents = Array(prioritizedAgents.prefix(maxAgents))
+        let visibleFlows = Array(projection.flows.prefix(maxFlows))
+        let hasLiveMotion = visibleAgents.contains { agent in
+            switch agent.visualState {
+            case .running, .review:
+                return true
+            case .idle, .blocked, .failed, .done, .costBlocked:
+                return false
+            }
+        }
+        let hasActiveFlow = visibleFlows.contains { flow in
+            switch flow.kind {
+            case .goalToIssue, .issueToAgent, .agentWorking, .a2aMessage, .agentToReview:
+                return true
+            case .reviewToMerge, .blocked, .costBlocked:
+                return false
+            }
+        }
+        let hasActiveMotion = hasLiveMotion || hasActiveFlow
+        let shouldAnimate = isSceneActive &&
+            !reduceMotion &&
+            !lowResourceMode &&
+            mode == .full &&
+            agentCount < 20 &&
+            hasActiveMotion
+
+        return MeetingRoomRenderPlan(
+            mode: mode,
+            visibleAgents: visibleAgents,
+            hiddenAgentCount: max(0, agentCount - visibleAgents.count),
+            visibleFlows: visibleFlows,
+            shouldAnimate: shouldAnimate,
+            frameInterval: shouldAnimate ? (1.0 / 15.0) : 1.0
+        )
+    }
+}
+
+struct PixelOfficeLayout: Hashable {
+    let size: CGSize
+    let isCompact: Bool
+    let mode: MeetingRoomRenderPlan.Mode
+
+    var grid: CGFloat { 8 }
+
+    func snapped(_ value: CGFloat) -> CGFloat {
+        (value / grid).rounded() * grid
+    }
+
+    func snapped(_ point: CGPoint) -> CGPoint {
+        CGPoint(x: snapped(point.x), y: snapped(point.y))
+    }
+
+    func zonePoint(_ zone: MeetingRoomOfficeZone) -> CGPoint {
+        let point: (CGFloat, CGFloat)
+        switch zone {
+        case .agentDesk:
+            point = (0.52, 0.62)
+        case .planningBoard:
+            point = (0.24, 0.23)
+        case .reviewDesk:
+            point = (0.78, 0.34)
+        case .blockerZone:
+            point = (0.16, 0.75)
+        case .costPanel:
+            point = (0.84, 0.18)
+        case .activityWall:
+            point = (0.52, 0.16)
+        case .mergeLane:
+            point = (0.82, 0.78)
+        }
+        return snapped(CGPoint(x: size.width * point.0, y: size.height * point.1))
+    }
+
+    func deskPoint(for agent: MeetingRoomProjectionAgent, index: Int, count: Int) -> CGPoint {
+        let role = agent.role.lowercased()
+        if role.contains("ceo") || role.contains("lead") {
+            return snapped(CGPoint(x: size.width * 0.30, y: size.height * 0.40))
+        }
+        if role.contains("qa") || role.contains("review") {
+            return snapped(CGPoint(x: size.width * 0.70, y: size.height * 0.48))
+        }
+        if role.contains("ux") || role.contains("ui") || role.contains("design") || role.contains("product") {
+            return snapped(CGPoint(x: size.width * 0.38, y: size.height * 0.48))
+        }
+
+        let columns = max(2, min(isCompact ? 3 : 4, Int(ceil(sqrt(Double(max(1, count)))))))
+        let row = index / columns
+        let column = index % columns
+        let rowCount = max(1, Int(ceil(Double(max(1, count)) / Double(columns))))
+        let x = 0.30 + 0.34 * CGFloat(column) / CGFloat(max(1, columns - 1))
+        let y = 0.60 + 0.22 * CGFloat(row) / CGFloat(max(1, rowCount - 1))
+        return snapped(CGPoint(x: size.width * x, y: size.height * y))
+    }
+
+    func targetPoint(for agent: MeetingRoomProjectionAgent, index: Int, count: Int) -> CGPoint {
+        switch agent.zone {
+        case .agentDesk:
+            return deskPoint(for: agent, index: index, count: count)
+        case .reviewDesk, .blockerZone, .costPanel:
+            let base = zonePoint(agent.zone)
+            let offset = CGFloat(index % 4) * 14 - 21
+            return snapped(CGPoint(x: base.x + offset, y: base.y + CGFloat(index % 2) * 18))
+        case .planningBoard, .activityWall, .mergeLane:
+            return zonePoint(agent.zone)
+        }
+    }
+}
+
+struct MeetingRoomSceneAgent: Identifiable, Hashable {
+    let id: String
+    let projection: MeetingRoomProjectionAgent
+    let action: MeetingRoomSpriteAction
+    let fromPoint: CGPoint
+    let targetPoint: CGPoint
+    let movementStartedAt: TimeInterval
+    let movementDuration: TimeInterval
+    let isSimplified: Bool
+
+    func point(at time: TimeInterval, animate: Bool) -> CGPoint {
+        guard animate, action == .walking, movementDuration > 0 else {
+            return targetPoint
+        }
+        let raw = CGFloat((time - movementStartedAt) / movementDuration)
+        let progress = min(1, max(0, raw))
+        let eased = progress * progress * (3 - 2 * progress)
+        return CGPoint(
+            x: fromPoint.x + (targetPoint.x - fromPoint.x) * eased,
+            y: fromPoint.y + (targetPoint.y - fromPoint.y) * eased
+        )
+    }
+}
+
+struct MeetingRoomSceneIssueCard: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let status: String
+    let zone: MeetingRoomOfficeZone
+    let point: CGPoint
+    let flow: MeetingRoomFlowItem?
+}
+
+struct MeetingRoomSceneKeyframe: Identifiable, Hashable {
+    let id: String
+    let kind: MeetingRoomSceneKeyframeKind
+    let title: String
+    let detail: String
+    let issueId: String?
+    let flow: MeetingRoomFlowItem?
+    let fromZone: MeetingRoomOfficeZone
+    let toZone: MeetingRoomOfficeZone
+    let fromPoint: CGPoint
+    let toPoint: CGPoint
+    let fromAgentId: String?
+    let toAgentId: String?
+    let startedAt: TimeInterval
+    let duration: TimeInterval
+
+    var usesScheduler: Bool {
+        kind.usesScheduler
+    }
+
+    func point(at time: TimeInterval, animate: Bool) -> CGPoint {
+        guard animate, duration > 0 else {
+            return toPoint
+        }
+        let raw = CGFloat((time - startedAt) / duration)
+        let progress = min(1, max(0, raw))
+        let eased = progress * progress * (3 - 2 * progress)
+        return CGPoint(
+            x: fromPoint.x + (toPoint.x - fromPoint.x) * eased,
+            y: fromPoint.y + (toPoint.y - fromPoint.y) * eased
+        )
+    }
+}
+
+struct MeetingRoomSceneState: Hashable {
+    let projectionIdentity: Int
+    let layout: PixelOfficeLayout
+    let renderPlan: MeetingRoomRenderPlan
+    let agents: [MeetingRoomSceneAgent]
+    let issueCards: [MeetingRoomSceneIssueCard]
+    let keyframes: [MeetingRoomSceneKeyframe]
+    let startedAt: TimeInterval
+
+    var shouldAnimate: Bool {
+        renderPlan.shouldAnimate && keyframes.contains { $0.usesScheduler }
+    }
+
+    var frameInterval: TimeInterval {
+        shouldAnimate ? (1.0 / 15.0) : 1.0
+    }
+
+    var cacheKey: String {
+        [
+            "\(projectionIdentity)",
+            "\(Int(layout.size.width))x\(Int(layout.size.height))",
+            layout.mode.rawValue,
+            renderPlan.animationKey,
+        ].joined(separator: "::")
+    }
+}
+
+enum MeetingRoomSceneReducer {
+    static func reduce(
+        previous: MeetingRoomSceneState?,
+        projection: MeetingRoomProjection,
+        layout: PixelOfficeLayout,
+        isCompact: Bool,
+        reduceMotion: Bool,
+        lowResourceMode: Bool,
+        isSceneActive: Bool,
+        now: TimeInterval = Date().timeIntervalSinceReferenceDate
+    ) -> MeetingRoomSceneState {
+        let plan = MeetingRoomRenderPlan.build(
+            projection: projection,
+            isCompact: isCompact,
+            reduceMotion: reduceMotion,
+            lowResourceMode: lowResourceMode,
+            isSceneActive: isSceneActive
+        )
+        let previousAgentsById = Dictionary(uniqueKeysWithValues: (previous?.agents ?? []).map { ($0.id, $0) })
+        let sceneAgents = plan.visibleAgents.enumerated().map { index, agent in
+            let target = layout.targetPoint(for: agent, index: index, count: plan.visibleAgents.count)
+            let previousAgent = previousAgentsById[agent.id]
+            let from = previousAgent?.targetPoint ?? layout.deskPoint(for: agent, index: index, count: plan.visibleAgents.count)
+            let moved = distance(from, target) > 4
+            let action = spriteAction(for: agent, moved: moved && !reduceMotion && !lowResourceMode)
+            return MeetingRoomSceneAgent(
+                id: agent.id,
+                projection: agent,
+                action: action,
+                fromPoint: from,
+                targetPoint: target,
+                movementStartedAt: moved ? now : (previousAgent?.movementStartedAt ?? now),
+                movementDuration: moved ? 1.25 : 0,
+                isSimplified: plan.mode != .full
+            )
+        }
+        let agentsByRole = Dictionary(sceneAgents.map { ($0.projection.role.normalizedSceneKey, $0) }, uniquingKeysWith: { first, _ in first })
+        let agentsByCli = Dictionary(sceneAgents.map { ($0.projection.cli.normalizedSceneKey, $0) }, uniquingKeysWith: { first, _ in first })
+        let keyframes = plan.visibleFlows.map { flow in
+            keyframe(
+                for: flow,
+                agentsByRole: agentsByRole,
+                agentsByCli: agentsByCli,
+                layout: layout,
+                previous: previous,
+                now: now
+            )
+        }
+        let flowByIssueId = Dictionary(plan.visibleFlows.compactMap { flow in
+            flow.issueId.map { ($0, flow) }
+        }, uniquingKeysWith: { first, _ in first })
+        let issueCards = projection.issues.prefix(plan.mode == .full ? 14 : 8).enumerated().map { index, issue in
+            let zone = issueZone(for: issue)
+            let base = layout.zonePoint(zone)
+            let offset = cardOffset(index: index, mode: plan.mode)
+            return MeetingRoomSceneIssueCard(
+                id: issue.id,
+                title: issue.title,
+                status: issue.status,
+                zone: zone,
+                point: layout.snapped(CGPoint(x: base.x + offset.x, y: base.y + offset.y)),
+                flow: flowByIssueId[issue.id]
+            )
+        }
+        return MeetingRoomSceneState(
+            projectionIdentity: projection.hashValue,
+            layout: layout,
+            renderPlan: plan,
+            agents: sceneAgents,
+            issueCards: issueCards,
+            keyframes: keyframes,
+            startedAt: previous?.startedAt ?? now
+        )
+    }
+
+    private static func spriteAction(for agent: MeetingRoomProjectionAgent, moved: Bool) -> MeetingRoomSpriteAction {
+        if moved {
+            return .walking
+        }
+        if agent.messageCount > 0 {
+            return .talking
+        }
+        switch agent.visualState {
+        case .idle, .done:
+            return .sitting
+        case .running:
+            return .typing
+        case .review:
+            return .reviewing
+        case .blocked, .failed, .costBlocked:
+            return .blocked
+        }
+    }
+
+    private static func keyframe(
+        for flow: MeetingRoomFlowItem,
+        agentsByRole: [String: MeetingRoomSceneAgent],
+        agentsByCli: [String: MeetingRoomSceneAgent],
+        layout: PixelOfficeLayout,
+        previous: MeetingRoomSceneState?,
+        now: TimeInterval
+    ) -> MeetingRoomSceneKeyframe {
+        let kind = keyframeKind(for: flow.kind)
+        let existing = previous?.keyframes.first { $0.id == flow.id }
+        let agentEndpoints = a2aEndpoints(for: flow, agentsByRole: agentsByRole, agentsByCli: agentsByCli)
+        let fromPoint = agentEndpoints?.from.targetPoint ?? layout.zonePoint(flow.from)
+        let toPoint = agentEndpoints?.to.targetPoint ?? layout.zonePoint(flow.to)
+        return MeetingRoomSceneKeyframe(
+            id: flow.id,
+            kind: kind,
+            title: flow.title,
+            detail: flow.detail,
+            issueId: flow.issueId,
+            flow: flow,
+            fromZone: flow.from,
+            toZone: flow.to,
+            fromPoint: fromPoint,
+            toPoint: toPoint,
+            fromAgentId: agentEndpoints?.from.id,
+            toAgentId: agentEndpoints?.to.id,
+            startedAt: existing?.startedAt ?? now,
+            duration: keyframeDuration(for: kind)
+        )
+    }
+
+    private static func keyframeKind(for flowKind: MeetingRoomFlowKind) -> MeetingRoomSceneKeyframeKind {
+        switch flowKind {
+        case .goalToIssue:
+            return .issueCreated
+        case .issueToAgent:
+            return .issueAssigned
+        case .agentWorking:
+            return .agentTyping
+        case .a2aMessage:
+            return .a2aMessage
+        case .agentToReview:
+            return .reviewRequested
+        case .reviewToMerge:
+            return .mergeCompleted
+        case .blocked:
+            return .blockedJump
+        case .costBlocked:
+            return .costPaused
+        }
+    }
+
+    private static func keyframeDuration(for kind: MeetingRoomSceneKeyframeKind) -> TimeInterval {
+        switch kind {
+        case .a2aMessage:
+            return 1.4
+        case .issueCreated, .issueAssigned, .reviewRequested:
+            return 1.2
+        case .agentTyping:
+            return 0.8
+        case .mergeCompleted, .blockedJump, .costPaused:
+            return 0
+        }
+    }
+
+    private static func a2aEndpoints(
+        for flow: MeetingRoomFlowItem,
+        agentsByRole: [String: MeetingRoomSceneAgent],
+        agentsByCli: [String: MeetingRoomSceneAgent]
+    ) -> (from: MeetingRoomSceneAgent, to: MeetingRoomSceneAgent)? {
+        guard flow.kind == .a2aMessage else {
+            return nil
+        }
+        let parts = flow.title.components(separatedBy: "→").map { $0.normalizedSceneKey }
+        guard parts.count == 2 else {
+            return nil
+        }
+        let from = agentsByRole[parts[0]] ?? agentsByCli[parts[0]]
+        let to = agentsByRole[parts[1]] ?? agentsByCli[parts[1]]
+        guard let from, let to else {
+            return nil
+        }
+        return (from, to)
+    }
+
+    private static func issueZone(for issue: MeetingRoomIssueSummary) -> MeetingRoomOfficeZone {
+        let status = issue.status.uppercased()
+        if status.contains("BLOCK") || status.contains("FAIL") {
+            return .blockerZone
+        }
+        if status.contains("REVIEW") || issue.pullRequestState?.uppercased() == "OPEN" {
+            return .reviewDesk
+        }
+        if status == "DONE" || status == "MERGED" || issue.pullRequestState?.uppercased() == "MERGED" {
+            return .mergeLane
+        }
+        if status.contains("PROGRESS") || status.contains("RUN") {
+            return .agentDesk
+        }
+        return .planningBoard
+    }
+
+    private static func cardOffset(index: Int, mode: MeetingRoomRenderPlan.Mode) -> CGPoint {
+        let columns = mode == .full ? 3 : 2
+        let column = index % columns
+        let row = index / columns
+        return CGPoint(x: CGFloat(column - 1) * 32, y: CGFloat(row) * 18)
+    }
+
+    private static func distance(_ lhs: CGPoint, _ rhs: CGPoint) -> CGFloat {
+        hypot(lhs.x - rhs.x, lhs.y - rhs.y)
+    }
+}
+
+private extension MeetingRoomVisualState {
+    var renderPriority: Int {
+        switch self {
+        case .running:
+            return 700
+        case .review:
+            return 600
+        case .blocked, .failed, .costBlocked:
+            return 500
+        case .done:
+            return 300
+        case .idle:
+            return 100
+        }
+    }
+}
+
+private extension String {
+    var normalizedSceneKey: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
@@ -4,165 +4,6 @@ extension MeetingRoomOfficeZone: Identifiable {
     var id: String { rawValue }
 }
 
-struct MeetingRoomRenderPlan: Hashable {
-    enum Mode: String, Hashable {
-        case full
-        case simplified
-        case grouped
-
-        var label: String {
-            switch self {
-            case .full:
-                return "FULL"
-            case .simplified:
-                return "LOW"
-            case .grouped:
-                return "GROUPED"
-            }
-        }
-    }
-
-    let mode: Mode
-    let visibleAgents: [MeetingRoomProjectionAgent]
-    let hiddenAgentCount: Int
-    let visibleFlows: [MeetingRoomFlowItem]
-    let shouldAnimate: Bool
-    let frameInterval: TimeInterval
-
-    var animationKey: String {
-        [
-            mode.rawValue,
-            visibleAgents.map { "\($0.id):\($0.visualState.rawValue):\($0.currentIssueId ?? "-")" }.joined(separator: "|"),
-            visibleFlows.map { "\($0.id):\($0.kind.rawValue):\($0.progress)" }.joined(separator: "|"),
-        ].joined(separator: "::")
-    }
-
-    static func build(
-        projection: MeetingRoomProjection,
-        isCompact: Bool,
-        reduceMotion: Bool,
-        lowResourceMode: Bool,
-        isSceneActive: Bool
-    ) -> MeetingRoomRenderPlan {
-        let agentCount = projection.agents.count
-        let mode: Mode
-        if agentCount >= 50 {
-            mode = .grouped
-        } else if agentCount >= 8 || lowResourceMode || reduceMotion || isCompact {
-            mode = .simplified
-        } else {
-            mode = .full
-        }
-
-        let maxAgents: Int
-        let maxFlows: Int
-        switch mode {
-        case .full:
-            maxAgents = agentCount
-            maxFlows = 5
-        case .simplified:
-            maxAgents = min(agentCount, isCompact ? 6 : 7)
-            maxFlows = 4
-        case .grouped:
-            maxAgents = min(agentCount, 12)
-            maxFlows = 4
-        }
-
-        let prioritizedAgents = projection.agents.sorted { lhs, rhs in
-            if lhs.visualState.renderPriority != rhs.visualState.renderPriority {
-                return lhs.visualState.renderPriority > rhs.visualState.renderPriority
-            }
-            return lhs.id < rhs.id
-        }
-        let visibleAgents = Array(prioritizedAgents.prefix(maxAgents))
-        let visibleFlows = Array(projection.flows.prefix(maxFlows))
-        let hasLiveMotion = visibleAgents.contains { agent in
-            switch agent.visualState {
-            case .running, .review:
-                return true
-            case .idle, .blocked, .failed, .done, .costBlocked:
-                return false
-            }
-        }
-        let hasActiveFlow = visibleFlows.contains { flow in
-            switch flow.kind {
-            case .issueToAgent, .agentWorking, .a2aMessage, .agentToReview:
-                return true
-            case .goalToIssue, .reviewToMerge, .blocked, .costBlocked:
-                return false
-            }
-        }
-        let hasActiveMotion = hasLiveMotion || hasActiveFlow
-        let shouldAnimate = isSceneActive &&
-            !reduceMotion &&
-            !lowResourceMode &&
-            mode == .full &&
-            agentCount <= 24 &&
-            hasActiveMotion
-
-        return MeetingRoomRenderPlan(
-            mode: mode,
-            visibleAgents: visibleAgents,
-            hiddenAgentCount: max(0, agentCount - visibleAgents.count),
-            visibleFlows: visibleFlows,
-            shouldAnimate: shouldAnimate,
-            frameInterval: shouldAnimate ? (1.0 / 15.0) : 1.0
-        )
-    }
-}
-
-private enum MeetingRoomDecorStyle: String, CaseIterable, Identifiable {
-    case studio
-    case glass
-    case lounge
-
-    var id: String { rawValue }
-
-    func label(_ language: AppLanguage) -> String {
-        switch self {
-        case .studio:
-            return language("Studio", "스튜디오")
-        case .glass:
-            return language("Glass", "글래스")
-        case .lounge:
-            return language("Lounge", "라운지")
-        }
-    }
-
-    var floorBase: Color {
-        switch self {
-        case .studio:
-            return Color(red: 0.62, green: 0.40, blue: 0.18)
-        case .glass:
-            return Color(red: 0.43, green: 0.47, blue: 0.45)
-        case .lounge:
-            return Color(red: 0.55, green: 0.34, blue: 0.19)
-        }
-    }
-
-    var wall: Color {
-        switch self {
-        case .studio:
-            return Color(red: 0.20, green: 0.13, blue: 0.18)
-        case .glass:
-            return Color(red: 0.10, green: 0.18, blue: 0.22)
-        case .lounge:
-            return Color(red: 0.23, green: 0.11, blue: 0.23)
-        }
-    }
-
-    var accent: Color {
-        switch self {
-        case .studio:
-            return Color(red: 0.77, green: 0.47, blue: 0.22)
-        case .glass:
-            return Color(red: 0.41, green: 0.78, blue: 0.82)
-        case .lounge:
-            return Color(red: 0.57, green: 0.25, blue: 0.62)
-        }
-    }
-}
-
 struct MeetingRoomView: View {
     let projection: MeetingRoomProjection
     let language: AppLanguage
@@ -172,39 +13,50 @@ struct MeetingRoomView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("meetingRoomLowResourceMode") private var lowResourceMode = false
-    @AppStorage("meetingRoomDecorStyle") private var decorStyleRaw = MeetingRoomDecorStyle.studio.rawValue
-    @AppStorage("meetingRoomShowPlacementGrid") private var showPlacementGrid = true
-    @AppStorage("meetingRoomShowDecor") private var showDecor = true
+    @State private var sceneState: MeetingRoomSceneState?
     @State private var selectedAgent: MeetingRoomProjectionAgent?
+    @State private var selectedIssue: MeetingRoomIssueSummary?
     @State private var selectedFlow: MeetingRoomFlowItem?
     @State private var selectedZone: MeetingRoomOfficeZone?
 
-    private var decorStyle: MeetingRoomDecorStyle {
-        MeetingRoomDecorStyle(rawValue: decorStyleRaw) ?? .studio
-    }
-
-    private var renderPlan: MeetingRoomRenderPlan {
-        MeetingRoomRenderPlan.build(
-            projection: projection,
-            isCompact: isCompact,
-            reduceMotion: reduceMotion,
-            lowResourceMode: lowResourceMode,
-            isSceneActive: scenePhase == .active
-        )
-    }
-
     var body: some View {
-        let plan = renderPlan
-        return VStack(alignment: .leading, spacing: 10) {
-            header(plan: plan)
+        VStack(alignment: .leading, spacing: 10) {
+            header
 
             GeometryReader { geometry in
-                officeStage(size: geometry.size, plan: plan)
+                let plan = MeetingRoomRenderPlan.build(
+                    projection: projection,
+                    isCompact: isCompact,
+                    reduceMotion: reduceMotion,
+                    lowResourceMode: lowResourceMode,
+                    isSceneActive: scenePhase == .active
+                )
+                let layout = PixelOfficeLayout(size: geometry.size, isCompact: isCompact, mode: plan.mode)
+                let state = MeetingRoomSceneReducer.reduce(
+                    previous: sceneState,
+                    projection: projection,
+                    layout: layout,
+                    isCompact: isCompact,
+                    reduceMotion: reduceMotion,
+                    lowResourceMode: lowResourceMode,
+                    isSceneActive: scenePhase == .active
+                )
+
+                officeStage(state: state)
+                    .onAppear {
+                        sceneState = state
+                    }
+                    .onChange(of: state.cacheKey) { _, _ in
+                        sceneState = state
+                    }
             }
-            .frame(height: isCompact ? 360 : 500)
+            .frame(height: isCompact ? 380 : 560)
         }
         .sheet(item: $selectedAgent) { agent in
             MeetingRoomProjectionAgentSheet(agent: agent, language: language)
+        }
+        .sheet(item: $selectedIssue) { issue in
+            MeetingRoomProjectionIssueSheet(issue: issue, language: language)
         }
         .sheet(item: $selectedFlow) { flow in
             MeetingRoomProjectionFlowSheet(
@@ -222,749 +74,200 @@ struct MeetingRoomView: View {
         }
     }
 
-    private func officeStage(size: CGSize, plan: MeetingRoomRenderPlan) -> some View {
-        ZStack {
-            officeBackdrop(size: size)
-
-            if plan.shouldAnimate {
-                TimelineView(.periodic(from: .now, by: plan.frameInterval)) { timeline in
-                    animatedOfficeLayer(
-                        size: size,
-                        plan: plan,
-                        phase: timeline.date.timeIntervalSinceReferenceDate
+    private var header: some View {
+        HStack(spacing: 8) {
+            ShellTag(text: language("Live Office", "라이브 오피스"), tint: ShellPalette.accent)
+            ShellTag(text: "\(language("Agents", "에이전트")) \(projection.agents.count)", tint: ShellPalette.accentWarm)
+            ShellTag(text: "\(language("Running", "작업 중")) \(projection.agents.filter { $0.visualState == .running }.count)", tint: ShellPalette.success)
+            ShellTag(text: "\(language("Review", "리뷰")) \(projection.reviewCount)", tint: ShellPalette.warning)
+            if projection.isCostBlocked {
+                ShellTag(text: language("COST PAUSED", "비용 일시정지"), tint: ShellPalette.warning)
+            }
+            Spacer(minLength: 0)
+            Text("\(projection.runtimeStatus) · \(projection.runtimeBackendHealth)")
+                .font(.system(size: 10, weight: .heavy, design: .monospaced))
+                .foregroundStyle(ShellPalette.muted)
+                .lineLimit(1)
+            Button {
+                lowResourceMode.toggle()
+            } label: {
+                Image(systemName: lowResourceMode ? "bolt.slash.fill" : "bolt.fill")
+                    .font(.system(size: 11, weight: .black))
+                    .foregroundStyle(lowResourceMode ? ShellPalette.warning : ShellPalette.success)
+                    .frame(width: 24, height: 22)
+                    .background(ShellPalette.panelAlt)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .stroke(ShellPalette.line, lineWidth: 1)
                     )
-                }
-            } else {
-                animatedOfficeLayer(size: size, plan: plan, phase: 0)
+                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
             }
-
-            ForEach(zoneButtons(size: size), id: \.zone) { item in
-                zoneButton(item)
-                    .position(item.point)
-                    .zIndex(4)
-            }
-
-            hiddenAgentsBadge(size: size, plan: plan)
-            inboxBoard(size: size)
-        }
-        .animation(plan.shouldAnimate ? .easeInOut(duration: 0.35) : nil, value: plan.animationKey)
-    }
-
-    private func animatedOfficeLayer(size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval) -> some View {
-        ZStack {
-            handoffLines(size: size, plan: plan, phase: phase)
-
-            ForEach(plan.visibleFlows) { flow in
-                workCard(flow, size: size, phase: phase, animated: plan.shouldAnimate)
-            }
-
-            ForEach(Array(plan.visibleAgents.enumerated()), id: \.element.id) { index, agent in
-                agentButton(agent, index: index, size: size, plan: plan, phase: phase)
-            }
-        }
-    }
-
-    private func header(plan: MeetingRoomRenderPlan) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 8) {
-                ShellTag(text: "\(language("Agents", "에이전트")) \(projection.agents.count)", tint: ShellPalette.accent)
-                ShellTag(text: "\(language("Running", "작업 중")) \(projection.agents.filter { $0.visualState == .running }.count)", tint: ShellPalette.success)
-                ShellTag(text: "\(language("Review", "리뷰")) \(projection.reviewCount)", tint: ShellPalette.warning)
-                ShellTag(text: "\(language("Signals", "신호")) \(projection.activityCount)", tint: ShellPalette.panelRaised)
-                if plan.mode != .full {
-                    ShellTag(text: plan.mode.label, tint: ShellPalette.warning)
-                }
-                Spacer(minLength: 0)
-                Text(runtimeLabel)
-                    .font(.system(size: 10, weight: .heavy, design: .monospaced))
-                    .foregroundStyle(ShellPalette.muted)
-                    .lineLimit(1)
-            }
-
-            HStack(spacing: 8) {
-                meetingControlButton(
-                    text: "\(language("Style", "스타일")) \(decorStyle.label(language))",
-                    tint: decorStyle.accent,
-                    accessibilityLabel: language("Change Meeting Room style", "미팅룸 스타일 변경"),
-                    action: cycleDecorStyle
-                )
-                meetingControlButton(
-                    text: showPlacementGrid ? language("Grid on", "그리드 켬") : language("Grid off", "그리드 끔"),
-                    tint: showPlacementGrid ? ShellPalette.accentWarm : ShellPalette.muted,
-                    accessibilityLabel: language("Toggle Meeting Room placement grid", "미팅룸 배치 그리드 전환"),
-                    action: { showPlacementGrid.toggle() }
-                )
-                meetingControlButton(
-                    text: showDecor ? language("Props on", "소품 켬") : language("Props off", "소품 끔"),
-                    tint: showDecor ? ShellPalette.warning : ShellPalette.muted,
-                    accessibilityLabel: language("Toggle Meeting Room props", "미팅룸 소품 전환"),
-                    action: { showDecor.toggle() }
-                )
-                meetingControlButton(
-                    text: lowResourceMode ? language("Low on", "저전력 켬") : language("Low off", "저전력 끔"),
-                    tint: lowResourceMode ? ShellPalette.warning : ShellPalette.muted,
-                    accessibilityLabel: language("Toggle Meeting Room low resource mode", "미팅룸 저자원 모드 전환"),
-                    action: { lowResourceMode.toggle() }
-                )
-                Spacer(minLength: 0)
-            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(lowResourceMode ? language("Disable low resource mode", "저자원 모드 끄기") : language("Enable low resource mode", "저자원 모드 켜기"))
         }
         .accessibilityElement(children: .combine)
     }
 
-    private func meetingControlButton(text: String, tint: Color, accessibilityLabel: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(text)
-                .font(.system(size: 9, weight: .heavy, design: .monospaced))
-                .foregroundStyle(tint)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 4)
-                .background(ShellPalette.panelAlt)
-                .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private func cycleDecorStyle() {
-        let styles = MeetingRoomDecorStyle.allCases
-        guard let currentIndex = styles.firstIndex(of: decorStyle) else {
-            decorStyleRaw = MeetingRoomDecorStyle.studio.rawValue
-            return
-        }
-        decorStyleRaw = styles[(currentIndex + 1) % styles.count].rawValue
-    }
-
-    private var runtimeLabel: String {
-        "\(projection.runtimeStatus) · \(projection.runtimeBackendHealth)"
-    }
-
-    private func officeBackdrop(size: CGSize) -> some View {
+    private func officeStage(state: MeetingRoomSceneState) -> some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(decorStyle.wall)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(ShellPalette.line, lineWidth: 1)
-                )
-
-            roomFloor(size: size)
-            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-
-            wallFrame(size: size)
-
-            if showPlacementGrid {
-                floorGrid(size: size)
-                placementFootprints(size: size)
-            }
-
-            meetingTable(size: size)
-            glassRoom(size: size)
-            workstationCluster(size: size)
-            loungeCluster(size: size)
-            utilityCorner(size: size)
-            entranceDoor(size: size)
-
-            if showDecor {
-                pixelShelf(size: size, x: 0.18, y: 0.14)
-                pixelShelf(size: size, x: 0.70, y: 0.14)
-                pixelPlant(size: size, x: 0.07, y: 0.84)
-                pixelPlant(size: size, x: 0.92, y: 0.84)
-                pixelPlant(size: size, x: 0.54, y: 0.24)
-            }
-
-            Text(language("✦ COTOR MEETING ROOM ✦", "✦ COTOR 회의실 ✦"))
-                .font(.system(size: 12, weight: .heavy, design: .monospaced))
-                .tracking(1)
-                .foregroundStyle(ShellPalette.text)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 7)
-                .background(decorStyle.wall.opacity(0.92))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 3, style: .continuous)
-                        .stroke(decorStyle.accent.opacity(0.46), lineWidth: 1)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
-                .position(x: size.width * 0.50, y: size.height * 0.06)
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text(language("LIVE COMPANY", "회사 라이브"))
-                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
-                    .foregroundStyle(ShellPalette.accent)
-                Text("\(projection.activeIssueCount) \(language("active", "활성")) · \(projection.blockedIssueCount) \(language("blocked", "차단"))")
-                    .font(.system(size: 10, weight: .bold, design: .monospaced))
-                    .foregroundStyle(ShellPalette.text)
-            }
-            .padding(8)
-            .frame(width: min(size.width * 0.25, 160), alignment: .leading)
-            .background(ShellPalette.panelRaised.opacity(0.72))
-            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-            .position(x: size.width * 0.50, y: size.height * 0.14)
-        }
-        .accessibilityHidden(true)
-    }
-
-    private func floorGrid(size: CGSize) -> some View {
-        ZStack {
-            ForEach(1..<7, id: \.self) { index in
-                Rectangle()
-                    .fill(ShellPalette.line.opacity(0.10))
-                    .frame(width: 1, height: size.height)
-                    .position(x: size.width * CGFloat(index) / 7, y: size.height / 2)
-                Rectangle()
-                    .fill(ShellPalette.line.opacity(0.10))
-                    .frame(width: size.width, height: 1)
-                    .position(x: size.width / 2, y: size.height * CGFloat(index) / 7)
-            }
-        }
-        .accessibilityHidden(true)
-    }
-
-    private func roomFloor(size: CGSize) -> some View {
-        ZStack {
-            Rectangle()
-                .fill(decorStyle.floorBase)
-
-            ForEach(0..<14, id: \.self) { index in
-                Rectangle()
-                    .fill(index.isMultiple(of: 2) ? Color.white.opacity(0.045) : Color.black.opacity(0.045))
-                    .frame(height: max(16, size.height / 22))
-                    .position(x: size.width / 2, y: size.height * (0.10 + CGFloat(index) * 0.055))
-            }
-
-            ForEach(1..<8, id: \.self) { index in
-                Rectangle()
-                    .fill(Color.black.opacity(0.12))
-                    .frame(width: 1, height: size.height * 0.78)
-                    .position(x: size.width * CGFloat(index) / 8, y: size.height * 0.52)
-            }
-
-            Rectangle()
-                .fill(Color(red: 0.78, green: 0.90, blue: 0.84).opacity(0.94))
-                .frame(width: size.width * 0.27, height: size.height * 0.28)
-                .overlay(tilePattern(size: CGSize(width: size.width * 0.27, height: size.height * 0.28)))
-                .position(x: size.width * 0.82, y: size.height * 0.18)
-
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(decorStyle == .lounge ? Color(red: 0.79, green: 0.66, blue: 0.44).opacity(0.92) : Color(red: 0.72, green: 0.55, blue: 0.34).opacity(0.72))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .stroke(decorStyle.accent.opacity(0.30), lineWidth: 2)
-                )
-                .frame(width: size.width * 0.28, height: size.height * 0.26)
-                .position(x: size.width * 0.79, y: size.height * 0.73)
-        }
-        .accessibilityHidden(true)
-    }
-
-    private func tilePattern(size: CGSize) -> some View {
-        ZStack {
-            ForEach(1..<4, id: \.self) { index in
-                Rectangle()
-                    .fill(Color.white.opacity(0.34))
-                    .frame(width: 1, height: size.height)
-                    .position(x: size.width * CGFloat(index) / 4, y: size.height / 2)
-                Rectangle()
-                    .fill(Color.white.opacity(0.34))
-                    .frame(width: size.width, height: 1)
-                    .position(x: size.width / 2, y: size.height * CGFloat(index) / 4)
-            }
-        }
-    }
-
-    private func wallFrame(size: CGSize) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(decorStyle.wall.opacity(0.92), lineWidth: 18)
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(decorStyle.accent.opacity(0.32), lineWidth: 3)
-                .padding(13)
-            HStack(spacing: 8) {
-                ForEach(0..<3, id: \.self) { _ in
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(Color(red: 0.62, green: 0.82, blue: 0.89).opacity(0.64))
-                        .frame(width: 38, height: 18)
-                        .overlay(Rectangle().stroke(Color.white.opacity(0.25), lineWidth: 1))
-                }
-            }
-            .position(x: size.width * 0.20, y: size.height * 0.055)
-        }
-        .accessibilityHidden(true)
-    }
-
-    private func placementFootprints(size: CGSize) -> some View {
-        ZStack {
-            footprint(size: size, x: 0.23, y: 0.63, width: 0.18, height: 0.16, tint: ShellPalette.accentWarm)
-            footprint(size: size, x: 0.47, y: 0.63, width: 0.18, height: 0.16, tint: ShellPalette.accentWarm)
-            footprint(size: size, x: 0.79, y: 0.72, width: 0.24, height: 0.20, tint: decorStyle.accent)
-            footprint(size: size, x: 0.47, y: 0.29, width: 0.28, height: 0.20, tint: ShellPalette.accent)
-        }
-        .accessibilityHidden(true)
-    }
-
-    private func footprint(size: CGSize, x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat, tint: Color) -> some View {
-        RoundedRectangle(cornerRadius: 3, style: .continuous)
-            .fill(tint.opacity(0.10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .stroke(tint.opacity(0.32), style: StrokeStyle(lineWidth: 1, dash: [5, 5]))
+            PixelOfficeCanvas(
+                projection: projection,
+                layout: state.layout,
+                language: language,
+                inboxCount: inboxCount
             )
-            .frame(width: size.width * width, height: size.height * height)
-            .position(x: size.width * x, y: size.height * y)
-    }
 
-    private func meetingTable(size: CGSize) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color(red: 0.47, green: 0.24, blue: 0.12))
-                .frame(width: size.width * 0.21, height: size.height * 0.075)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .stroke(Color.black.opacity(0.28), lineWidth: 2)
-                )
-                .position(x: size.width * 0.21, y: size.height * 0.31)
-            ForEach(0..<4, id: \.self) { index in
-                pixelChair
-                    .position(
-                        x: size.width * (0.13 + CGFloat(index) * 0.052),
-                        y: size.height * 0.255
-                    )
-                pixelChair
-                    .position(
-                        x: size.width * (0.13 + CGFloat(index) * 0.052),
-                        y: size.height * 0.365
-                    )
+            if state.shouldAnimate {
+                TimelineView(.periodic(from: .now, by: state.frameInterval)) { timeline in
+                    spriteLayer(state: state, time: timeline.date.timeIntervalSinceReferenceDate)
+                }
+            } else {
+                spriteLayer(state: state, time: state.startedAt)
             }
-        }
-        .frame(width: size.width, height: size.height)
-        .accessibilityHidden(true)
-    }
 
-    private func glassRoom(size: CGSize) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
-                .fill(Color(red: 0.66, green: 0.84, blue: 0.90).opacity(decorStyle == .glass ? 0.34 : 0.22))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .stroke(Color.white.opacity(0.42), lineWidth: 2)
-                )
-                .frame(width: size.width * 0.27, height: size.height * 0.22)
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(Color(red: 0.45, green: 0.29, blue: 0.16).opacity(0.78))
-                .frame(width: size.width * 0.18, height: size.height * 0.045)
-            Rectangle()
-                .fill(Color.white.opacity(0.32))
-                .frame(width: 2, height: size.height * 0.20)
-                .offset(x: -size.width * 0.055)
-            Rectangle()
-                .fill(Color.white.opacity(0.32))
-                .frame(width: 2, height: size.height * 0.20)
-                .offset(x: size.width * 0.055)
+            hitTargetLayer(state: state)
         }
-        .position(x: size.width * 0.49, y: size.height * 0.29)
-        .accessibilityHidden(true)
-    }
-
-    private func workstationCluster(size: CGSize) -> some View {
-        ZStack {
-            pixelDesk(size: size, x: 0.26, y: 0.61, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
-            pixelDesk(size: size, x: 0.42, y: 0.61, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
-            pixelDesk(size: size, x: 0.26, y: 0.78, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
-            pixelDesk(size: size, x: 0.42, y: 0.78, tint: Color(red: 0.58, green: 0.31, blue: 0.14))
-        }
-        .frame(width: size.width, height: size.height)
-        .accessibilityHidden(true)
-    }
-
-    private func loungeCluster(size: CGSize) -> some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color(red: 0.47, green: 0.22, blue: 0.58))
-                .frame(width: size.width * 0.16, height: size.height * 0.055)
-                .position(x: size.width * 0.78, y: size.height * 0.64)
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color(red: 0.40, green: 0.18, blue: 0.52))
-                .frame(width: size.width * 0.055, height: size.height * 0.15)
-                .position(x: size.width * 0.68, y: size.height * 0.73)
-            Circle()
-                .fill(Color(red: 0.88, green: 0.86, blue: 0.78))
-                .frame(width: 42, height: 42)
-                .overlay(Circle().stroke(Color.black.opacity(0.15), lineWidth: 2))
-                .position(x: size.width * 0.80, y: size.height * 0.74)
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color(red: 0.47, green: 0.22, blue: 0.58))
-                .frame(width: size.width * 0.11, height: size.height * 0.055)
-                .position(x: size.width * 0.87, y: size.height * 0.82)
-        }
-        .frame(width: size.width, height: size.height)
-        .accessibilityHidden(true)
-    }
-
-    private func utilityCorner(size: CGSize) -> some View {
-        ZStack {
-            pixelShelf(size: size, x: 0.79, y: 0.10)
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(ShellPalette.panelDeeper)
-                .frame(width: 54, height: 34)
-                .overlay(Text("TV").font(.system(size: 9, weight: .black, design: .monospaced)).foregroundStyle(ShellPalette.faint))
-                .position(x: size.width * 0.91, y: size.height * 0.20)
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(Color(red: 0.82, green: 0.86, blue: 0.82))
-                .frame(width: 26, height: 44)
-                .overlay(Rectangle().fill(ShellPalette.accentWarm.opacity(0.7)).frame(width: 12, height: 10).offset(y: -10))
-                .position(x: size.width * 0.72, y: size.height * 0.22)
-        }
-        .frame(width: size.width, height: size.height)
-        .accessibilityHidden(true)
-    }
-
-    private func entranceDoor(size: CGSize) -> some View {
-        HStack(spacing: 3) {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(Color(red: 0.15, green: 0.76, blue: 0.89).opacity(0.86))
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(Color(red: 0.13, green: 0.68, blue: 0.82).opacity(0.86))
-        }
-        .frame(width: size.width * 0.12, height: size.height * 0.07)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .stroke(decorStyle.wall.opacity(0.92), lineWidth: 4)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(ShellPalette.lineStrong.opacity(0.72), lineWidth: 1)
         )
-        .position(x: size.width * 0.50, y: size.height * 0.965)
-        .accessibilityHidden(true)
+        .animation(state.shouldAnimate ? .easeInOut(duration: 0.18) : nil, value: state.cacheKey)
     }
 
-    private var pixelChair: some View {
-        VStack(spacing: 1) {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(Color(red: 0.12, green: 0.16, blue: 0.25))
-                .frame(width: 18, height: 13)
-            Rectangle()
-                .fill(Color.black.opacity(0.38))
-                .frame(width: 13, height: 4)
-        }
-        .frame(width: 22, height: 20)
-    }
-
-    private func zoneButtons(size: CGSize) -> [MeetingRoomZoneButton] {
-        [
-            MeetingRoomZoneButton(zone: .planningBoard, title: language("Planning", "기획"), count: projection.activeIssueCount, point: zonePoint(.planningBoard, size: size)),
-            MeetingRoomZoneButton(zone: .reviewDesk, title: language("Review", "리뷰"), count: projection.reviewCount, point: zonePoint(.reviewDesk, size: size)),
-            MeetingRoomZoneButton(zone: .blockerZone, title: language("Blocked", "차단"), count: projection.blockedIssueCount, point: zonePoint(.blockerZone, size: size)),
-            MeetingRoomZoneButton(zone: .costPanel, title: language("Cost", "비용"), count: projection.todaySpentCents, point: zonePoint(.costPanel, size: size)),
-            MeetingRoomZoneButton(zone: .activityWall, title: language("Activity", "활동"), count: projection.activityCount, point: zonePoint(.activityWall, size: size)),
-        ]
-    }
-
-    private func zoneButton(_ item: MeetingRoomZoneButton) -> some View {
-        Button {
-            selectedZone = item.zone
-        } label: {
-            HStack(spacing: 5) {
-                Text(item.title)
-                Text("\(item.count)")
-                    .foregroundStyle(zoneTint(item.zone))
-            }
-            .font(.system(size: 8, weight: .heavy, design: .monospaced))
-            .padding(.horizontal, 7)
-            .padding(.vertical, 4)
-            .background(ShellPalette.panel.opacity(0.82))
-            .overlay(
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .stroke(zoneTint(item.zone).opacity(0.38), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(item.title), \(item.count)")
-    }
-
-    private func handoffLines(size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval) -> some View {
+    private func spriteLayer(state: MeetingRoomSceneState, time: TimeInterval) -> some View {
         ZStack {
-            ForEach(Array(plan.visibleAgents.enumerated()), id: \.element.id) { index, agent in
-                if agent.messageCount > 0 || agent.visualState == .review || agent.visualState == .running {
-                    let from = agentPosition(agent, index: index, size: size, plan: plan, phase: phase)
-                    let to = zonePoint(agent.visualState == .review ? .reviewDesk : .activityWall, size: size)
-                    Path { path in
-                        path.move(to: from)
-                        path.addLine(to: to)
+            ForEach(state.keyframes) { keyframe in
+                PixelOfficeKeyframeView(
+                    keyframe: keyframe,
+                    language: language,
+                    time: time,
+                    animate: state.shouldAnimate
+                ) {
+                    if let flow = keyframe.flow {
+                        selectedFlow = flow
                     }
-                    .stroke(stateTint(agent.visualState).opacity(0.2), lineWidth: 1.5)
-
-                    Circle()
-                        .fill(stateTint(agent.visualState))
-                        .frame(width: 6, height: 6)
-                        .position(
-                            x: from.x + (to.x - from.x) * CGFloat((sin(phase + Double(index)) + 1) / 2),
-                            y: from.y + (to.y - from.y) * CGFloat((sin(phase + Double(index)) + 1) / 2)
-                        )
                 }
             }
+
+            ForEach(state.issueCards) { card in
+                PixelIssueCardView(card: card, language: language) {
+                    selectedIssue = projection.issues.first { $0.id == card.id }
+                }
+                .position(card.point)
+                .zIndex(2)
+            }
+
+            ForEach(state.agents) { sceneAgent in
+                PixelAgentSprite(
+                    sceneAgent: sceneAgent,
+                    language: language,
+                    phase: time,
+                    animate: state.shouldAnimate
+                ) {
+                    selectedAgent = sceneAgent.projection
+                }
+                .position(sceneAgent.point(at: time, animate: state.shouldAnimate))
+                .zIndex(agentZIndex(sceneAgent))
+            }
+
+            if state.renderPlan.hiddenAgentCount > 0 {
+                groupedAgentsBadge(count: state.renderPlan.hiddenAgentCount, layout: state.layout)
+                    .zIndex(10)
+            }
         }
-        .accessibilityHidden(true)
     }
 
-    private func workCard(_ flow: MeetingRoomFlowItem, size: CGSize, phase: TimeInterval, animated: Bool) -> some View {
-        let from = zonePoint(flow.from, size: size)
-        let to = zonePoint(flow.to, size: size)
-        let baseProgress = CGFloat(min(max(flow.progress, 0), 1))
-        let pulse = animated ? CGFloat((sin(phase * 0.9 + Double(abs(flow.id.hashValue % 11))) + 1) / 2) * 0.10 : 0
-        let progress = min(1, max(0, baseProgress + pulse))
-        let point = CGPoint(
-            x: from.x + (to.x - from.x) * progress,
-            y: from.y + (to.y - from.y) * progress
-        )
-
-        return Button {
-            selectedFlow = flow
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: flowIcon(flow.kind))
-                    .font(.system(size: 9, weight: .black))
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(flowLabel(flow.kind))
-                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
-                    Text(roomLine(flow.title, limit: 22))
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .lineLimit(1)
+    private func hitTargetLayer(state: MeetingRoomSceneState) -> some View {
+        ZStack {
+            ForEach(zoneButtons(layout: state.layout), id: \.zone) { item in
+                Button {
+                    selectedZone = item.zone
+                } label: {
+                    HStack(spacing: 5) {
+                        Text(item.title)
+                        Text("\(item.count)")
+                            .foregroundStyle(zoneTint(item.zone))
+                    }
+                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                    .foregroundStyle(ShellPalette.text)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(ShellPalette.panel.opacity(0.82))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 3, style: .continuous)
+                            .stroke(zoneTint(item.zone).opacity(0.46), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
                 }
+                .buttonStyle(.plain)
+                .position(item.point)
+                .accessibilityLabel("\(item.title), \(item.count)")
+            }
+        }
+    }
+
+    private func groupedAgentsBadge(count: Int, layout: PixelOfficeLayout) -> some View {
+        Button {
+            selectedZone = .agentDesk
+        } label: {
+            VStack(spacing: 2) {
+                Text("+\(count)")
+                    .font(.system(size: 16, weight: .heavy, design: .monospaced))
+                Text(language("cluster", "클러스터"))
+                    .font(.system(size: 8, weight: .heavy, design: .monospaced))
             }
             .foregroundStyle(ShellPalette.text)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 5)
-            .frame(width: min(size.width * 0.15, 136), alignment: .leading)
-            .background(flowTint(flow.kind).opacity(0.88))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(ShellPalette.panelRaised.opacity(0.92))
             .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(ShellPalette.text.opacity(0.18), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .stroke(ShellPalette.warning.opacity(0.55), lineWidth: 1)
             )
-            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
         }
         .buttonStyle(.plain)
-        .position(point)
-        .accessibilityLabel("\(flowLabel(flow.kind)): \(flow.title)")
+        .position(layout.zonePoint(.agentDesk))
+        .accessibilityLabel(language("\(count) grouped agents", "\(count)명 에이전트 클러스터"))
     }
 
-    private func agentButton(_ agent: MeetingRoomProjectionAgent, index: Int, size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval) -> some View {
-        Button {
-            selectedAgent = agent
-        } label: {
-            PixelAgentSprite(agent: agent, language: language, phase: phase, isAnimated: plan.shouldAnimate)
-                .frame(width: agentWidth, height: 98)
-                .accessibilityHidden(true)
-        }
-        .buttonStyle(.plain)
-        .position(agentPosition(agent, index: index, size: size, plan: plan, phase: phase))
-        .accessibilityLabel("\(agent.role), \(agent.status), \(agent.actionLine)")
-    }
-
-    private var agentWidth: CGFloat {
-        if isCompact {
-            return projection.agents.count > 8 ? 58 : 66
-        }
-        return projection.agents.count > 10 ? 62 : 70
-    }
-
-    private func agentPosition(_ agent: MeetingRoomProjectionAgent, index: Int, size: CGSize, plan: MeetingRoomRenderPlan, phase: TimeInterval = 0) -> CGPoint {
-        let seat = seatPoint(index: index, count: plan.visibleAgents.count, size: size)
-        let target = zonePoint(agent.zone, size: size)
-        let weight: CGFloat
-        switch agent.visualState {
-        case .idle, .done:
-            weight = 0.0
-        case .running:
-            weight = 0.28
-        case .review, .blocked, .failed, .costBlocked:
-            weight = 0.86
-        }
-        let seed = Double(index) * 1.31
-        let walk = plan.shouldAnimate ? CGFloat(sin(phase * 0.8 + seed)) : 0
-        let bob = plan.shouldAnimate ? CGFloat(cos(phase * 0.65 + seed)) : 0
-        let activityScale: CGFloat = agent.visualState == .idle ? 2 : 7
-        return CGPoint(
-            x: seat.x + (target.x - seat.x) * weight + walk * activityScale,
-            y: seat.y + (target.y - seat.y) * weight + bob * (activityScale * 0.55)
-        )
-    }
-
-    private func seatPoint(index: Int, count: Int, size: CGSize) -> CGPoint {
-        let points: [(CGFloat, CGFloat)] = [
-            (0.20, 0.64),
-            (0.36, 0.40),
-            (0.64, 0.40),
-            (0.80, 0.64),
-            (0.32, 0.80),
-            (0.68, 0.80),
-            (0.50, 0.61),
-            (0.19, 0.39),
-            (0.81, 0.39),
-            (0.50, 0.82),
+    private func zoneButtons(layout: PixelOfficeLayout) -> [MeetingRoomZoneButton] {
+        [
+            MeetingRoomZoneButton(zone: .planningBoard, title: language("Board", "보드"), count: planningCount, point: layout.zonePoint(.planningBoard)),
+            MeetingRoomZoneButton(zone: .reviewDesk, title: language("Review", "리뷰"), count: projection.reviewCount, point: layout.zonePoint(.reviewDesk)),
+            MeetingRoomZoneButton(zone: .blockerZone, title: language("Blocked", "차단"), count: projection.blockedIssueCount, point: layout.zonePoint(.blockerZone)),
+            MeetingRoomZoneButton(zone: .activityWall, title: language("Activity", "활동"), count: projection.activityCount, point: layout.zonePoint(.activityWall)),
+            MeetingRoomZoneButton(zone: .mergeLane, title: language("Merge", "머지"), count: mergeCount, point: layout.zonePoint(.mergeLane)),
         ]
-        if count <= points.count {
-            let point = points[index % points.count]
-            return CGPoint(x: size.width * point.0, y: size.height * point.1)
-        }
-
-        let columns = min(5, max(3, Int(ceil(sqrt(Double(count))))))
-        let row = index / columns
-        let column = index % columns
-        let x = 0.15 + 0.70 * CGFloat(column) / CGFloat(max(1, columns - 1))
-        let y = 0.32 + 0.44 * CGFloat(row) / CGFloat(max(1, Int(ceil(Double(count) / Double(columns))) - 1))
-        return CGPoint(x: size.width * x, y: size.height * y)
     }
 
-    @ViewBuilder
-    private func hiddenAgentsBadge(size: CGSize, plan: MeetingRoomRenderPlan) -> some View {
-        if plan.hiddenAgentCount > 0 {
-            Button {
-                selectedZone = .agentDesk
-            } label: {
-                VStack(spacing: 3) {
-                    Text("+\(plan.hiddenAgentCount)")
-                        .font(.system(size: 15, weight: .heavy, design: .monospaced))
-                    Text(language("grouped", "그룹"))
-                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
-                }
-                .foregroundStyle(ShellPalette.text)
-                .padding(.horizontal, 11)
-                .padding(.vertical, 8)
-                .background(ShellPalette.panelRaised.opacity(0.88))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .stroke(ShellPalette.warning.opacity(0.38), lineWidth: 1)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-            }
-            .buttonStyle(.plain)
-            .position(x: size.width * 0.50, y: size.height * 0.83)
-            .accessibilityLabel(language("\(plan.hiddenAgentCount) grouped agents", "\(plan.hiddenAgentCount)명 에이전트 그룹 표시"))
-        }
+    private var planningCount: Int {
+        projection.issues.filter { issue in
+            let status = issue.status.uppercased()
+            return status.contains("PLAN") || status.contains("BACKLOG") || status.contains("TODO")
+        }.count
     }
 
-    private func zonePoint(_ zone: MeetingRoomOfficeZone, size: CGSize) -> CGPoint {
-        let point: (CGFloat, CGFloat)
-        switch zone {
-        case .agentDesk:
-            point = (0.52, 0.54)
-        case .planningBoard:
-            point = (0.50, 0.16)
-        case .reviewDesk:
-            point = (0.78, 0.40)
-        case .blockerZone:
-            point = (0.16, 0.48)
-        case .costPanel:
-            point = (0.15, 0.82)
-        case .activityWall:
-            point = (0.84, 0.18)
-        case .mergeLane:
-            point = (0.84, 0.80)
-        }
-        return CGPoint(x: size.width * point.0, y: size.height * point.1)
+    private var mergeCount: Int {
+        projection.issues.filter { issue in
+            issue.status.uppercased() == "DONE" || issue.pullRequestState?.uppercased() == "MERGED"
+        }.count
     }
 
-    private func stateTint(_ state: MeetingRoomVisualState) -> Color {
-        switch state {
-        case .idle:
-            return ShellPalette.faint
+    private func agentZIndex(_ agent: MeetingRoomSceneAgent) -> Double {
+        switch agent.projection.visualState {
         case .running:
-            return ShellPalette.success
+            return 8
         case .review:
-            return ShellPalette.warning
-        case .blocked, .failed:
-            return ShellPalette.danger
+            return 7
+        case .blocked, .failed, .costBlocked:
+            return 6
         case .done:
-            return ShellPalette.success
-        case .costBlocked:
-            return ShellPalette.warning
+            return 5
+        case .idle:
+            return 4
         }
-    }
-
-    private func inboxBoard(size: CGSize) -> some View {
-        VStack(spacing: 3) {
-            Text(language("YOUR INBOX", "받은 요청"))
-            Text("\(inboxCount)")
-                .font(.system(size: 14, weight: .heavy, design: .monospaced))
-        }
-        .font(.system(size: 10, weight: .bold, design: .monospaced))
-        .foregroundStyle(ShellPalette.text)
-        .tracking(0.6)
-        .padding(.horizontal, 18)
-        .padding(.vertical, 12)
-        .background(ShellPalette.panelRaised.opacity(0.62))
-        .overlay(
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .stroke(ShellPalette.accentWarm.opacity(0.26), lineWidth: 2)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-        .position(x: size.width * 0.52, y: size.height * 0.91)
-        .accessibilityHidden(true)
-    }
-
-    private func pixelShelf(size: CGSize, x: CGFloat, y: CGFloat) -> some View {
-        VStack(spacing: 3) {
-            ForEach(0..<2, id: \.self) { row in
-                HStack(spacing: 3) {
-                    ForEach(0..<5, id: \.self) { column in
-                        RoundedRectangle(cornerRadius: 1, style: .continuous)
-                            .fill([ShellPalette.accent, ShellPalette.accentWarm, ShellPalette.success, ShellPalette.warning, ShellPalette.faint][(row + column) % 5].opacity(0.72))
-                            .frame(width: 6, height: 16)
-                    }
-                }
-                .padding(.horizontal, 7)
-                .frame(width: min(size.width * 0.21, 112), height: 22)
-                .background(ShellPalette.panel.opacity(0.62))
-            }
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
-        .position(x: size.width * x, y: size.height * y)
-        .accessibilityHidden(true)
-    }
-
-    private func pixelDesk(size: CGSize, x: CGFloat, y: CGFloat, tint: Color) -> some View {
-        ZStack(alignment: .top) {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(tint.opacity(0.40))
-                .frame(width: 96, height: 38)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                        .stroke(ShellPalette.lineStrong.opacity(0.55), lineWidth: 1)
-                )
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(ShellPalette.panelRaised)
-                .frame(width: 30, height: 18)
-                .offset(y: -12)
-            Circle()
-                .fill(ShellPalette.accentWarm)
-                .frame(width: 9, height: 9)
-                .offset(x: 34, y: -5)
-        }
-        .frame(width: 100, height: 52)
-        .position(x: size.width * x, y: size.height * y)
-        .accessibilityHidden(true)
-    }
-
-    private func pixelPlant(size: CGSize, x: CGFloat, y: CGFloat) -> some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                Triangle().fill(ShellPalette.success).frame(width: 12, height: 18).rotationEffect(.degrees(-18))
-                Triangle().fill(ShellPalette.success.opacity(0.82)).frame(width: 13, height: 21)
-                Triangle().fill(ShellPalette.success).frame(width: 12, height: 18).rotationEffect(.degrees(18))
-            }
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(ShellPalette.accentWarm.opacity(0.62))
-                .frame(width: 23, height: 17)
-        }
-        .frame(width: 40, height: 42)
-        .position(x: size.width * x, y: size.height * y)
-        .accessibilityHidden(true)
-    }
-
-    private func roomLine(_ value: String, limit: Int) -> String {
-        let trimmed = value.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.count <= limit {
-            return trimmed
-        }
-        return String(trimmed.prefix(limit - 1)) + "…"
     }
 
     private func zoneTint(_ zone: MeetingRoomOfficeZone) -> Color {
@@ -981,253 +284,622 @@ struct MeetingRoomView: View {
             return ShellPalette.success
         }
     }
+}
 
-    private func flowTint(_ kind: MeetingRoomFlowKind) -> Color {
-        switch kind {
-        case .goalToIssue, .issueToAgent, .a2aMessage:
-            return ShellPalette.accentWarm
-        case .agentWorking, .reviewToMerge:
-            return ShellPalette.success
-        case .agentToReview, .costBlocked:
-            return ShellPalette.warning
-        case .blocked:
-            return ShellPalette.danger
+private struct PixelOfficeCanvas: View {
+    let projection: MeetingRoomProjection
+    let layout: PixelOfficeLayout
+    let language: AppLanguage
+    let inboxCount: Int
+
+    var body: some View {
+        Canvas { context, size in
+            drawRoom(context: &context, size: size)
+            drawZones(context: &context)
+            drawFurniture(context: &context)
+            drawLabels(context: &context)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func drawRoom(context: inout GraphicsContext, size: CGSize) {
+        context.fill(Path(CGRect(origin: .zero, size: size)), with: .color(Color(red: 0.07, green: 0.08, blue: 0.10)))
+
+        let wall = CGRect(x: 0, y: 0, width: size.width, height: size.height * 0.22)
+        context.fill(Path(wall), with: .color(Color(red: 0.12, green: 0.11, blue: 0.12)))
+
+        let floor = CGRect(x: 0, y: wall.maxY, width: size.width, height: size.height - wall.maxY)
+        context.fill(Path(floor), with: .color(Color(red: 0.22, green: 0.18, blue: 0.14)))
+
+        let tile: CGFloat = 32
+        var y = layout.snapped(floor.minY)
+        var row = 0
+        while y < floor.maxY {
+            var x: CGFloat = 0
+            var column = 0
+            while x < floor.maxX {
+                let rect = CGRect(x: x, y: y, width: tile, height: tile)
+                let opacity = (row + column).isMultiple(of: 2) ? 0.07 : 0.035
+                context.fill(Path(rect), with: .color(Color.white.opacity(opacity)))
+                x += tile
+                column += 1
+            }
+            y += tile
+            row += 1
+        }
+
+        for index in 0...Int(size.width / 8) {
+            let x = CGFloat(index) * 8
+            context.fill(Path(CGRect(x: x, y: floor.minY, width: 1, height: floor.height)), with: .color(Color.black.opacity(index.isMultiple(of: 4) ? 0.10 : 0.035)))
+        }
+        for index in 0...Int(size.height / 8) {
+            let y = CGFloat(index) * 8
+            context.fill(Path(CGRect(x: 0, y: y, width: size.width, height: 1)), with: .color(Color.black.opacity(index.isMultiple(of: 4) ? 0.10 : 0.035)))
+        }
+
+        context.stroke(
+            Path(roundedRect: CGRect(x: 8, y: 8, width: size.width - 16, height: size.height - 16), cornerRadius: 6),
+            with: .color(ShellPalette.lineStrong.opacity(0.65)),
+            lineWidth: 2
+        )
+    }
+
+    private func drawZones(context: inout GraphicsContext) {
+        zonePlate(.planningBoard, size: CGSize(width: 150, height: 86), tint: ShellPalette.accentWarm, context: &context)
+        zonePlate(.activityWall, size: CGSize(width: 190, height: 54), tint: ShellPalette.accent, context: &context)
+        zonePlate(.reviewDesk, size: CGSize(width: 150, height: 92), tint: ShellPalette.warning, context: &context)
+        zonePlate(.blockerZone, size: CGSize(width: 134, height: 76), tint: ShellPalette.danger, context: &context)
+        zonePlate(.mergeLane, size: CGSize(width: 150, height: 78), tint: ShellPalette.success, context: &context)
+        zonePlate(.costPanel, size: CGSize(width: 128, height: 50), tint: ShellPalette.warning, context: &context)
+    }
+
+    private func zonePlate(_ zone: MeetingRoomOfficeZone, size: CGSize, tint: Color, context: inout GraphicsContext) {
+        let point = layout.zonePoint(zone)
+        let rect = CGRect(x: point.x - size.width / 2, y: point.y - size.height / 2, width: size.width, height: size.height)
+        context.fill(Path(roundedRect: rect, cornerRadius: 4), with: .color(tint.opacity(0.12)))
+        context.stroke(Path(roundedRect: rect, cornerRadius: 4), with: .color(tint.opacity(0.50)), style: StrokeStyle(lineWidth: 1, dash: [5, 5]))
+    }
+
+    private func drawFurniture(context: inout GraphicsContext) {
+        drawPlanningBoard(context: &context)
+        drawDeskGrid(context: &context)
+        drawReviewDesk(context: &context)
+        drawBlockerCorner(context: &context)
+        drawMergeLane(context: &context)
+        drawPlants(context: &context)
+        drawInbox(context: &context)
+    }
+
+    private func drawPlanningBoard(context: inout GraphicsContext) {
+        let point = layout.zonePoint(.planningBoard)
+        let board = CGRect(x: point.x - 64, y: point.y - 32, width: 128, height: 58)
+        context.fill(Path(roundedRect: board, cornerRadius: 3), with: .color(Color(red: 0.14, green: 0.19, blue: 0.19)))
+        context.stroke(Path(roundedRect: board, cornerRadius: 3), with: .color(ShellPalette.accentWarm.opacity(0.7)), lineWidth: 2)
+        for index in 0..<9 {
+            let x = board.minX + 10 + CGFloat(index % 3) * 35
+            let y = board.minY + 10 + CGFloat(index / 3) * 15
+            context.fill(Path(CGRect(x: x, y: y, width: 25, height: 9)), with: .color(index.isMultiple(of: 2) ? ShellPalette.accentWarm.opacity(0.72) : ShellPalette.warning.opacity(0.66)))
         }
     }
 
-    private func flowIcon(_ kind: MeetingRoomFlowKind) -> String {
-        switch kind {
-        case .goalToIssue:
-            return "point.topleft.down.curvedto.point.bottomright.up"
-        case .issueToAgent:
-            return "tray.and.arrow.down.fill"
-        case .agentWorking:
+    private func drawDeskGrid(context: inout GraphicsContext) {
+        let points = [
+            CGPoint(x: layout.size.width * 0.30, y: layout.size.height * 0.60),
+            CGPoint(x: layout.size.width * 0.46, y: layout.size.height * 0.60),
+            CGPoint(x: layout.size.width * 0.62, y: layout.size.height * 0.60),
+            CGPoint(x: layout.size.width * 0.30, y: layout.size.height * 0.78),
+            CGPoint(x: layout.size.width * 0.46, y: layout.size.height * 0.78),
+            CGPoint(x: layout.size.width * 0.62, y: layout.size.height * 0.78),
+        ].map(layout.snapped)
+        for point in points {
+            drawDesk(at: point, context: &context)
+        }
+        drawConferenceTable(context: &context)
+    }
+
+    private func drawDesk(at point: CGPoint, context: inout GraphicsContext) {
+        let top = CGRect(x: point.x - 42, y: point.y - 16, width: 84, height: 26)
+        context.fill(Path(top), with: .color(Color(red: 0.30, green: 0.18, blue: 0.10)))
+        context.fill(Path(CGRect(x: top.minX + 10, y: top.minY - 9, width: 28, height: 14)), with: .color(ShellPalette.panelRaised))
+        context.fill(Path(CGRect(x: top.minX + 56, y: top.minY + 7, width: 8, height: 8)), with: .color(ShellPalette.accentWarm))
+        context.fill(Path(CGRect(x: top.minX + 8, y: top.maxY, width: 6, height: 16)), with: .color(Color.black.opacity(0.38)))
+        context.fill(Path(CGRect(x: top.maxX - 14, y: top.maxY, width: 6, height: 16)), with: .color(Color.black.opacity(0.38)))
+    }
+
+    private func drawConferenceTable(context: inout GraphicsContext) {
+        let point = CGPoint(x: layout.size.width * 0.30, y: layout.size.height * 0.40)
+        let table = CGRect(x: point.x - 62, y: point.y - 18, width: 124, height: 36)
+        context.fill(Path(roundedRect: table, cornerRadius: 4), with: .color(Color(red: 0.28, green: 0.15, blue: 0.09)))
+        context.stroke(Path(roundedRect: table, cornerRadius: 4), with: .color(ShellPalette.warning.opacity(0.34)), lineWidth: 1)
+        for index in 0..<6 {
+            let x = table.minX + 14 + CGFloat(index) * 20
+            context.fill(Path(CGRect(x: x, y: table.minY - 12, width: 14, height: 8)), with: .color(ShellPalette.panelRaised))
+            context.fill(Path(CGRect(x: x, y: table.maxY + 4, width: 14, height: 8)), with: .color(ShellPalette.panelRaised))
+        }
+    }
+
+    private func drawReviewDesk(context: inout GraphicsContext) {
+        let point = layout.zonePoint(.reviewDesk)
+        let desk = CGRect(x: point.x - 58, y: point.y - 20, width: 116, height: 40)
+        context.fill(Path(desk), with: .color(Color(red: 0.26, green: 0.21, blue: 0.12)))
+        context.stroke(Path(desk), with: .color(ShellPalette.warning.opacity(0.65)), lineWidth: 2)
+        for index in 0..<4 {
+            context.fill(
+                Path(CGRect(x: desk.minX + 14 + CGFloat(index) * 23, y: desk.minY + 10, width: 16, height: 20)),
+                with: .color(index.isMultiple(of: 2) ? ShellPalette.success.opacity(0.64) : ShellPalette.warning.opacity(0.72))
+            )
+        }
+    }
+
+    private func drawBlockerCorner(context: inout GraphicsContext) {
+        let point = layout.zonePoint(.blockerZone)
+        let rect = CGRect(x: point.x - 52, y: point.y - 26, width: 104, height: 52)
+        context.fill(Path(rect), with: .color(ShellPalette.danger.opacity(0.18)))
+        context.stroke(Path(rect), with: .color(ShellPalette.danger.opacity(0.62)), style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+        context.fill(Path(CGRect(x: rect.minX + 12, y: rect.minY + 12, width: 18, height: 18)), with: .color(ShellPalette.danger.opacity(0.72)))
+    }
+
+    private func drawMergeLane(context: inout GraphicsContext) {
+        let point = layout.zonePoint(.mergeLane)
+        let rect = CGRect(x: point.x - 62, y: point.y - 20, width: 124, height: 40)
+        context.fill(Path(rect), with: .color(ShellPalette.success.opacity(0.14)))
+        for index in 0..<5 {
+            context.fill(Path(CGRect(x: rect.minX + 10 + CGFloat(index) * 22, y: rect.midY - 5, width: 14, height: 10)), with: .color(ShellPalette.success.opacity(0.68)))
+        }
+    }
+
+    private func drawPlants(context: inout GraphicsContext) {
+        let points = [
+            CGPoint(x: layout.size.width * 0.08, y: layout.size.height * 0.30),
+            CGPoint(x: layout.size.width * 0.92, y: layout.size.height * 0.88),
+        ].map(layout.snapped)
+        for point in points {
+            context.fill(Path(CGRect(x: point.x - 7, y: point.y + 6, width: 14, height: 14)), with: .color(Color(red: 0.46, green: 0.27, blue: 0.12)))
+            context.fill(Path(CGRect(x: point.x - 14, y: point.y - 10, width: 10, height: 18)), with: .color(ShellPalette.success.opacity(0.78)))
+            context.fill(Path(CGRect(x: point.x - 2, y: point.y - 18, width: 12, height: 26)), with: .color(ShellPalette.success.opacity(0.86)))
+            context.fill(Path(CGRect(x: point.x + 9, y: point.y - 8, width: 8, height: 16)), with: .color(ShellPalette.success.opacity(0.72)))
+        }
+    }
+
+    private func drawInbox(context: inout GraphicsContext) {
+        let rect = CGRect(x: layout.size.width * 0.50 - 58, y: layout.size.height - 58, width: 116, height: 38)
+        context.fill(Path(roundedRect: rect, cornerRadius: 4), with: .color(ShellPalette.panelRaised.opacity(0.72)))
+        context.stroke(Path(roundedRect: rect, cornerRadius: 4), with: .color(ShellPalette.accentWarm.opacity(0.34)), lineWidth: 1)
+        context.draw(
+            Text("\(language("INBOX", "받은 요청")) \(inboxCount)")
+                .font(.system(size: 10, weight: .heavy, design: .monospaced))
+                .foregroundStyle(ShellPalette.text),
+            at: CGPoint(x: rect.midX, y: rect.midY),
+            anchor: .center
+        )
+    }
+
+    private func drawLabels(context: inout GraphicsContext) {
+        let labels: [(String, MeetingRoomOfficeZone, Color)] = [
+            (language("PLANNING", "기획"), .planningBoard, ShellPalette.accentWarm),
+            (language("ACTIVITY", "활동"), .activityWall, ShellPalette.accent),
+            (language("REVIEW", "리뷰"), .reviewDesk, ShellPalette.warning),
+            (language("BLOCKED", "차단"), .blockerZone, ShellPalette.danger),
+            (language("MERGE", "머지"), .mergeLane, ShellPalette.success),
+        ]
+        for (text, zone, tint) in labels {
+            let point = layout.zonePoint(zone)
+            context.draw(
+                Text(text)
+                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                    .foregroundStyle(tint),
+                at: CGPoint(x: point.x, y: point.y - 44),
+                anchor: .center
+            )
+        }
+        context.draw(
+            Text("\(projection.activeIssueCount) \(language("active", "활성")) · \(projection.blockedIssueCount) \(language("blocked", "차단"))")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundStyle(ShellPalette.muted),
+            at: CGPoint(x: layout.size.width * 0.50, y: 22),
+            anchor: .center
+        )
+    }
+}
+
+private struct PixelOfficeKeyframeView: View {
+    let keyframe: MeetingRoomSceneKeyframe
+    let language: AppLanguage
+    let time: TimeInterval
+    let animate: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Capsule()
+                    .fill(tint.opacity(0.20))
+                    .frame(width: 72, height: 18)
+                HStack(spacing: 4) {
+                    Image(systemName: icon)
+                        .font(.system(size: 8, weight: .black))
+                    Text(label)
+                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(ShellPalette.text)
+            }
+        }
+        .buttonStyle(.plain)
+        .position(keyframe.point(at: time, animate: animate && keyframe.usesScheduler))
+        .accessibilityLabel("\(label): \(keyframe.title)")
+    }
+
+    private var label: String {
+        switch keyframe.kind {
+        case .issueCreated:
+            return language("CARD", "카드")
+        case .issueAssigned:
+            return language("ASSIGN", "배정")
+        case .agentTyping:
+            return language("TYPE", "타이핑")
+        case .a2aMessage:
+            return language("MSG", "메시지")
+        case .reviewRequested:
+            return language("REVIEW", "리뷰")
+        case .mergeCompleted:
+            return language("MERGE", "머지")
+        case .blockedJump:
+            return language("BLOCK", "차단")
+        case .costPaused:
+            return language("COST", "비용")
+        }
+    }
+
+    private var icon: String {
+        switch keyframe.kind {
+        case .issueCreated:
+            return "doc.badge.plus"
+        case .issueAssigned:
+            return "arrow.right.to.line.compact"
+        case .agentTyping:
             return "keyboard.fill"
         case .a2aMessage:
-            return "bubble.left.and.bubble.right.fill"
-        case .agentToReview:
+            return "envelope.fill"
+        case .reviewRequested:
             return "checklist"
-        case .reviewToMerge:
+        case .mergeCompleted:
             return "arrow.triangle.merge"
-        case .blocked:
+        case .blockedJump:
             return "exclamationmark.triangle.fill"
-        case .costBlocked:
+        case .costPaused:
             return "pause.circle.fill"
         }
     }
 
-    private func flowLabel(_ kind: MeetingRoomFlowKind) -> String {
-        switch kind {
-        case .goalToIssue:
-            return language("goal→issue", "목표→이슈")
-        case .issueToAgent:
-            return language("dispatch", "배정")
-        case .agentWorking:
-            return language("working", "작업")
-        case .a2aMessage:
-            return language("note", "메모")
-        case .agentToReview:
-            return language("review", "리뷰")
-        case .reviewToMerge:
-            return language("merge", "머지")
-        case .blocked:
-            return language("blocked", "차단")
-        case .costBlocked:
-            return language("cost", "비용")
+    private var tint: Color {
+        switch keyframe.kind {
+        case .issueCreated, .issueAssigned, .a2aMessage:
+            return ShellPalette.accentWarm
+        case .agentTyping, .mergeCompleted:
+            return ShellPalette.success
+        case .reviewRequested, .costPaused:
+            return ShellPalette.warning
+        case .blockedJump:
+            return ShellPalette.danger
         }
     }
 }
 
-private struct Triangle: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        path.closeSubpath()
-        return path
-    }
-}
+private struct PixelIssueCardView: View {
+    let card: MeetingRoomSceneIssueCard
+    let language: AppLanguage
+    let action: () -> Void
 
-private struct MeetingRoomZoneButton {
-    let zone: MeetingRoomOfficeZone
-    let title: String
-    let count: Int
-    let point: CGPoint
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(statusLabel)
+                    .font(.system(size: 7, weight: .heavy, design: .monospaced))
+                    .foregroundStyle(tint)
+                Text(roomLine(card.title, limit: 16))
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(ShellPalette.text)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 5)
+            .frame(width: 90, alignment: .leading)
+            .background(ShellPalette.panelRaised.opacity(0.88))
+            .overlay(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .stroke(tint.opacity(0.5), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(statusLabel): \(card.title)")
+    }
+
+    private var statusLabel: String {
+        let status = card.status.uppercased()
+        if status.contains("REVIEW") {
+            return language("REVIEW", "리뷰")
+        }
+        if status.contains("PROGRESS") {
+            return language("RUN", "작업")
+        }
+        if status.contains("BLOCK") || status.contains("FAIL") {
+            return language("BLOCK", "차단")
+        }
+        if status == "DONE" || status == "MERGED" {
+            return language("DONE", "완료")
+        }
+        return language("PLAN", "계획")
+    }
+
+    private var tint: Color {
+        switch card.zone {
+        case .planningBoard:
+            return ShellPalette.accentWarm
+        case .agentDesk, .activityWall:
+            return ShellPalette.accent
+        case .reviewDesk, .costPanel:
+            return ShellPalette.warning
+        case .blockerZone:
+            return ShellPalette.danger
+        case .mergeLane:
+            return ShellPalette.success
+        }
+    }
 }
 
 private struct PixelAgentSprite: View {
-    let agent: MeetingRoomProjectionAgent
+    let sceneAgent: MeetingRoomSceneAgent
     let language: AppLanguage
     let phase: TimeInterval
-    let isAnimated: Bool
+    let animate: Bool
+    let action: () -> Void
+
+    private var agent: MeetingRoomProjectionAgent { sceneAgent.projection }
+    private var block: CGFloat { sceneAgent.isSimplified ? 3 : 4 }
 
     var body: some View {
-        VStack(spacing: 5) {
-            if showsSpeechBubble {
-                speechBubble
-                    .transition(.opacity)
-            } else {
-                Color.clear.frame(height: 18)
-            }
+        Button(action: action) {
+            VStack(spacing: 4) {
+                if showsBubble {
+                    Text(roomLine(agent.actionLine, limit: sceneAgent.isSimplified ? 12 : 18))
+                        .font(.system(size: 8, weight: .heavy, design: .monospaced))
+                        .foregroundStyle(ShellPalette.text)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(ShellPalette.panelRaised.opacity(0.94))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .stroke(stateTint.opacity(0.36), lineWidth: 1)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                } else {
+                    Color.clear.frame(height: 14)
+                }
 
-            ZStack(alignment: .topTrailing) {
-                spriteBody
-                stateBadge
-                    .offset(x: 8, y: -3)
-            }
+                ZStack(alignment: .topTrailing) {
+                    bodyPixels
+                    stateBadge
+                        .offset(x: 8, y: -4)
+                }
 
-            VStack(spacing: 2) {
-                Text(shortRole)
-                    .font(.system(size: 9, weight: .heavy, design: .monospaced))
-                    .foregroundStyle(ShellPalette.text)
-                    .lineLimit(1)
-                Text(shortStatus)
-                    .font(.system(size: 8, weight: .bold, design: .monospaced))
-                    .foregroundStyle(ShellPalette.muted)
-                    .lineLimit(1)
+                VStack(spacing: 1) {
+                    Text(shortRole)
+                        .font(.system(size: sceneAgent.isSimplified ? 8 : 9, weight: .heavy, design: .monospaced))
+                        .foregroundStyle(ShellPalette.text)
+                        .lineLimit(1)
+                    Text(shortStatus)
+                        .font(.system(size: 7, weight: .bold, design: .monospaced))
+                        .foregroundStyle(ShellPalette.muted)
+                        .lineLimit(1)
+                }
+                .frame(width: sceneAgent.isSimplified ? 54 : 70)
             }
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(agent.role), \(agent.status), \(agent.actionLine)")
     }
 
-    private var spriteBody: some View {
-        let seed = Double(abs(agent.id.hashValue % 11))
-        let bob = isAnimated ? CGFloat(sin(phase * 3.2 + seed)) * bobAmount : 0
-        let step = isAnimated ? CGFloat(sin(phase * 5.8 + seed)) : 0
-        let lean = agent.visualState == .running && isAnimated ? Double(step * 1.5) : 0
+    private var bodyPixels: some View {
+        let step = animate ? CGFloat(sin(phase * 9 + Double(abs(agent.id.hashValue % 13)))) : 0
+        let blink = animate && Int(phase * 2 + Double(abs(agent.id.hashValue % 5))).isMultiple(of: 9)
+        let typing = animate && sceneAgent.action == .typing
 
         return ZStack(alignment: .bottom) {
-            if agent.visualState == .idle || agent.visualState == .running || agent.visualState == .done {
-                miniDesk
-                    .offset(y: 21)
+            if sceneAgent.action == .sitting || sceneAgent.action == .typing {
+                pixelDesk
+                    .offset(y: block * 10)
             }
 
             VStack(spacing: 0) {
-                compactHead
-
-                ZStack {
-                    RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .fill(outfitTint)
-                        .frame(width: 24, height: 25)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                                .stroke(Color.black.opacity(0.18), lineWidth: 1)
-                        )
-                    Image(systemName: roleIcon)
-                        .font(.system(size: 8, weight: .black))
-                        .foregroundStyle(ShellPalette.text.opacity(0.86))
-                        .offset(y: 1)
-                    HStack(spacing: 21) {
-                        RoundedRectangle(cornerRadius: 2, style: .continuous)
-                            .fill(skinTint.opacity(0.96))
-                            .frame(width: 5, height: 14)
-                            .rotationEffect(.degrees(Double(step * 10)))
-                        RoundedRectangle(cornerRadius: 2, style: .continuous)
-                            .fill(skinTint.opacity(0.96))
-                            .frame(width: 5, height: 14)
-                            .rotationEffect(.degrees(Double(step * -10)))
-                    }
-                    .offset(y: 3)
-                }
-
-                HStack(spacing: 5) {
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(ShellPalette.panelDeeper)
-                        .frame(width: 7, height: 8)
-                        .offset(y: isAnimated ? max(0, step) * 2 : 0)
-                    RoundedRectangle(cornerRadius: 1, style: .continuous)
-                        .fill(ShellPalette.panelDeeper)
-                        .frame(width: 7, height: 8)
-                        .offset(y: isAnimated ? max(0, -step) * 2 : 0)
-                }
+                head(blink: blink)
+                torso(step: step)
+                legs(step: step)
             }
-            .offset(y: bob)
-            .rotationEffect(.degrees(lean))
+            .offset(y: animate && sceneAgent.action == .walking ? abs(step) * -block : 0)
 
-            if agent.visualState == .running {
-                deskKeyboard
-                    .offset(y: 16)
+            if typing {
+                keyboard
+                    .offset(y: block * 10)
             }
         }
-        .frame(width: 58, height: 68)
+        .frame(width: block * 16, height: block * 19)
     }
 
-    private var compactHead: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
+    private func head(blink: Bool) -> some View {
+        ZStack(alignment: .top) {
+            Rectangle()
                 .fill(skinTint)
-                .frame(width: 25, height: 22)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .stroke(Color.black.opacity(0.18), lineWidth: 1)
-                )
+                .frame(width: block * 7, height: block * 6)
+                .offset(y: block * 2)
 
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
+            Rectangle()
                 .fill(hairTint)
-                .frame(width: 27, height: 8)
-                .offset(y: -8)
-            HStack(spacing: 15) {
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(hairTint.opacity(0.92))
-                    .frame(width: 5, height: 10)
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(hairTint.opacity(0.92))
-                    .frame(width: 5, height: 10)
+                .frame(width: block * 8, height: block * 2)
+            HStack(spacing: block * 4) {
+                Rectangle()
+                    .fill(hairTint)
+                    .frame(width: block, height: block * 3)
+                Rectangle()
+                    .fill(hairTint)
+                    .frame(width: block, height: block * 3)
             }
-            .offset(y: -2)
+            .offset(y: block * 2)
 
-            HStack(spacing: 7) {
-                eye(left: true)
-                    .frame(width: 4, height: 4)
-                eye(left: false)
-                    .frame(width: 4, height: 4)
+            HStack(spacing: block * 2) {
+                eye(blink: blink, left: true)
+                eye(blink: blink, left: false)
             }
-            .scaleEffect(0.62)
-            .offset(y: 1)
+            .offset(y: block * 4)
 
             mouth
-                .scaleEffect(0.48)
-                .offset(y: 9)
+                .offset(y: block * 6)
 
-            HStack(spacing: 14) {
-                Rectangle().fill(Color.white.opacity(0.24)).frame(width: 3, height: 2)
-                Rectangle().fill(Color.white.opacity(0.24)).frame(width: 3, height: 2)
-            }
-            .offset(y: 7)
-
-            compactHeadwear
+            headwear
         }
-        .frame(width: 30, height: 23)
+        .frame(width: block * 10, height: block * 9)
     }
 
-    private var deskKeyboard: some View {
-        HStack(spacing: 2) {
-            ForEach(0..<5, id: \.self) { index in
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(index % 2 == 0 && agent.visualState == .running && isAnimated ? stateTint : ShellPalette.lineStrong)
-                    .frame(width: 5, height: 3)
+    private func torso(step: CGFloat) -> some View {
+        ZStack {
+            Rectangle()
+                .fill(outfitTint)
+                .frame(width: block * 7, height: block * 6)
+            Rectangle()
+                .fill(stateTint.opacity(0.75))
+                .frame(width: block * 2, height: block * 2)
+                .offset(y: block * -1)
+            HStack(spacing: block * 7) {
+                Rectangle()
+                    .fill(skinTint)
+                    .frame(width: block, height: block * 5)
+                    .offset(y: sceneAgent.action == .typing ? block * 2 : step * block)
+                Rectangle()
+                    .fill(skinTint)
+                    .frame(width: block, height: block * 5)
+                    .offset(y: sceneAgent.action == .typing ? block * 2 : -step * block)
             }
         }
-        .padding(4)
+        .frame(width: block * 11, height: block * 6)
+    }
+
+    private func legs(step: CGFloat) -> some View {
+        HStack(spacing: block * 2) {
+            Rectangle()
+                .fill(ShellPalette.panelDeeper)
+                .frame(width: block * 2, height: block * 4)
+                .offset(y: sceneAgent.action == .walking ? max(0, step) * block : 0)
+            Rectangle()
+                .fill(ShellPalette.panelDeeper)
+                .frame(width: block * 2, height: block * 4)
+                .offset(y: sceneAgent.action == .walking ? max(0, -step) * block : 0)
+        }
+        .frame(height: block * 4)
+    }
+
+    private func eye(blink: Bool, left: Bool) -> some View {
+        Group {
+            if blink {
+                Rectangle().frame(width: block, height: 1)
+            } else {
+                switch agent.expression {
+                case .focused:
+                    Rectangle().frame(width: block, height: block * 2)
+                case .talking:
+                    Rectangle().frame(width: block * 2, height: block)
+                case .happy:
+                    Rectangle()
+                        .frame(width: block * 2, height: 1)
+                        .rotationEffect(.degrees(left ? 15 : -15))
+                case .confused:
+                    Rectangle().frame(width: left ? block : block * 2, height: block)
+                case .sad:
+                    Rectangle()
+                        .frame(width: block * 2, height: 1)
+                        .rotationEffect(.degrees(left ? -12 : 12))
+                case .warning:
+                    Rectangle().frame(width: block * 2, height: block * 2)
+                case .idle:
+                    Rectangle().frame(width: block, height: block)
+                }
+            }
+        }
+        .foregroundStyle(ShellPalette.text)
+    }
+
+    @ViewBuilder
+    private var mouth: some View {
+        switch agent.expression {
+        case .happy:
+            Rectangle().fill(stateTint).frame(width: block * 3, height: block)
+        case .talking:
+            Rectangle().fill(stateTint).frame(width: block * 2, height: block * 2)
+        case .confused, .warning:
+            Rectangle().fill(stateTint).frame(width: block * 2, height: block)
+        case .sad:
+            Rectangle().fill(stateTint.opacity(0.7)).frame(width: block * 3, height: 1)
+        case .focused:
+            Rectangle().fill(stateTint).frame(width: block * 3, height: block)
+        case .idle:
+            Rectangle().fill(stateTint.opacity(0.75)).frame(width: block * 2, height: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var headwear: some View {
+        if lowerRole.contains("ceo") || lowerRole.contains("lead") {
+            HStack(spacing: 0) {
+                PixelTriangle()
+                    .fill(ShellPalette.warning)
+                    .frame(width: block * 2, height: block * 2)
+                PixelTriangle()
+                    .fill(ShellPalette.warning)
+                    .frame(width: block * 3, height: block * 3)
+                PixelTriangle()
+                    .fill(ShellPalette.warning)
+                    .frame(width: block * 2, height: block * 2)
+            }
+            .offset(y: -block)
+        } else if lowerRole.contains("builder") || lowerRole.contains("engineer") || lowerRole.contains("backend") {
+            Rectangle()
+                .fill(ShellPalette.panelRaised)
+                .frame(width: block * 6, height: block)
+                .offset(y: block)
+        } else if lowerRole.contains("ux") || lowerRole.contains("design") || lowerRole.contains("ui") || lowerRole.contains("product") {
+            Rectangle()
+                .fill(ShellPalette.accentWarm)
+                .frame(width: block * 5, height: block)
+                .rotationEffect(.degrees(-8))
+                .offset(y: block)
+        } else if lowerRole.contains("qa") || lowerRole.contains("review") {
+            Rectangle()
+                .fill(ShellPalette.warning)
+                .frame(width: block * 4, height: block)
+                .offset(y: block)
+        }
+    }
+
+    private var keyboard: some View {
+        HStack(spacing: 1) {
+            ForEach(0..<6, id: \.self) { index in
+                Rectangle()
+                    .fill(index.isMultiple(of: 2) ? stateTint : ShellPalette.lineStrong)
+                    .frame(width: block, height: block)
+            }
+        }
+        .padding(3)
         .background(ShellPalette.panelDeeper)
-        .clipShape(RoundedRectangle(cornerRadius: 1, style: .continuous))
-        .offset(y: -2)
     }
 
-    private var miniDesk: some View {
+    private var pixelDesk: some View {
         VStack(spacing: 0) {
             Rectangle()
-                .fill(Color(red: 0.45, green: 0.27, blue: 0.12))
-                .frame(width: 54, height: 15)
-                .overlay(
-                    HStack(spacing: 3) {
-                        Rectangle().fill(ShellPalette.panelRaised).frame(width: 12, height: 8)
-                        Rectangle().fill(ShellPalette.accentWarm.opacity(0.85)).frame(width: 4, height: 4)
-                    }
-                )
-            HStack(spacing: 32) {
-                Rectangle().fill(Color.black.opacity(0.42)).frame(width: 5, height: 10)
-                Rectangle().fill(Color.black.opacity(0.42)).frame(width: 5, height: 10)
+                .fill(Color(red: 0.30, green: 0.18, blue: 0.10))
+                .frame(width: block * 14, height: block * 4)
+            HStack(spacing: block * 9) {
+                Rectangle().fill(Color.black.opacity(0.42)).frame(width: block, height: block * 3)
+                Rectangle().fill(Color.black.opacity(0.42)).frame(width: block, height: block * 3)
             }
         }
         .accessibilityHidden(true)
@@ -1242,155 +914,12 @@ private struct PixelAgentSprite: View {
             .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
     }
 
-    private var speechBubble: some View {
-        Text(roomLine(agent.actionLine, limit: 18))
-            .font(.system(size: 8, weight: .heavy, design: .monospaced))
-            .foregroundStyle(ShellPalette.text)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(ShellPalette.panelRaised.opacity(0.95))
-            .overlay(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .stroke(stateTint.opacity(0.28), lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-    }
-
-    private var showsSpeechBubble: Bool {
-        switch agent.visualState {
-        case .idle:
-            return agent.messageCount > 0
-        case .done:
-            return agent.messageCount > 0
-        case .blocked, .failed, .costBlocked:
+    private var showsBubble: Bool {
+        switch sceneAgent.action {
+        case .blocked, .reviewing, .talking:
             return true
-        case .running, .review:
-            return agent.messageCount > 0
-        }
-    }
-
-    private var bobAmount: CGFloat {
-        switch agent.visualState {
-        case .idle:
-            return 1.5
-        case .running, .review:
-            return 4
-        case .blocked, .failed, .costBlocked:
-            return 2
-        case .done:
-            return 2.5
-        }
-    }
-
-    private var hair: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 5, style: .continuous)
-                .fill(hairTint)
-                .frame(width: 42, height: 13)
-            if lowerRole.contains("ceo") || lowerRole.contains("lead") {
-                Color.clear.frame(width: 42, height: 13)
-            } else {
-                HStack(spacing: 2) {
-                    ForEach(0..<3, id: \.self) { index in
-                        RoundedRectangle(cornerRadius: 1, style: .continuous)
-                            .fill(hairTint.opacity(0.92))
-                            .frame(width: 7, height: index == 1 ? 11 : 8)
-                    }
-                }
-                .offset(y: 5)
-            }
-        }
-        .offset(y: 7)
-        .zIndex(2)
-    }
-
-    private func eye(left: Bool) -> some View {
-        Group {
-            switch agent.expression {
-            case .focused:
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .frame(width: 4, height: 7)
-            case .happy:
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .frame(width: 7, height: 3)
-                    .rotationEffect(.degrees(left ? 12 : -12))
-            case .confused:
-                Circle()
-                    .frame(width: left ? 4 : 6, height: left ? 4 : 6)
-            case .sad:
-                Capsule()
-                    .frame(width: 7, height: 2)
-                    .rotationEffect(.degrees(left ? -10 : 10))
-            case .warning:
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .frame(width: 7, height: 7)
-            case .idle:
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .frame(width: 5, height: 5)
-            }
-        }
-        .foregroundStyle(ShellPalette.text)
-    }
-
-    @ViewBuilder
-    private var mouth: some View {
-        switch agent.expression {
-        case .happy:
-            Capsule().fill(stateTint).frame(width: 18, height: 5)
-        case .confused, .warning:
-            Text("o").font(.system(size: 12, weight: .bold, design: .monospaced)).foregroundStyle(stateTint)
-        case .sad:
-            Capsule().fill(stateTint.opacity(0.7)).frame(width: 14, height: 3).rotationEffect(.degrees(180))
-        case .focused:
-            RoundedRectangle(cornerRadius: 1, style: .continuous).fill(stateTint).frame(width: 14, height: 4)
-        case .idle:
-            RoundedRectangle(cornerRadius: 1, style: .continuous).fill(stateTint.opacity(0.75)).frame(width: 12, height: 3)
-        }
-    }
-
-    @ViewBuilder
-    private var headwear: some View {
-        if lowerRole.contains("ceo") || lowerRole.contains("lead") {
-            HStack(spacing: 1) {
-                Triangle().fill(ShellPalette.warning).frame(width: 7, height: 7)
-                Triangle().fill(ShellPalette.warning).frame(width: 9, height: 9)
-                Triangle().fill(ShellPalette.warning).frame(width: 7, height: 7)
-            }
-            .offset(y: -25)
-        } else if lowerRole.contains("builder") || lowerRole.contains("engineer") || lowerRole.contains("backend") {
-            RoundedRectangle(cornerRadius: 1, style: .continuous)
-                .fill(ShellPalette.panelRaised)
-                .frame(width: 24, height: 7)
-                .offset(y: -24)
-        } else if lowerRole.contains("ux") || lowerRole.contains("design") || lowerRole.contains("ui") {
-            Capsule()
-                .fill(ShellPalette.accentWarm)
-                .frame(width: 25, height: 6)
-                .rotationEffect(.degrees(-8))
-                .offset(y: -24)
-        }
-    }
-
-    @ViewBuilder
-    private var compactHeadwear: some View {
-        if lowerRole.contains("ceo") || lowerRole.contains("lead") {
-            HStack(spacing: 0) {
-                Triangle().fill(ShellPalette.warning).frame(width: 5, height: 5)
-                Triangle().fill(ShellPalette.warning).frame(width: 6, height: 6)
-                Triangle().fill(ShellPalette.warning).frame(width: 5, height: 5)
-            }
-            .offset(y: -10)
-        } else if lowerRole.contains("builder") || lowerRole.contains("engineer") || lowerRole.contains("backend") {
-            Rectangle()
-                .fill(ShellPalette.panelRaised)
-                .frame(width: 19, height: 4)
-                .offset(y: -7)
-        } else if lowerRole.contains("ux") || lowerRole.contains("design") || lowerRole.contains("ui") {
-            Rectangle()
-                .fill(ShellPalette.accentWarm)
-                .frame(width: 18, height: 4)
-                .rotationEffect(.degrees(-8))
-                .offset(y: -8)
+        case .typing, .walking, .sitting:
+            return agent.visualState == .failed || agent.visualState == .costBlocked
         }
     }
 
@@ -1408,7 +937,7 @@ private struct PixelAgentSprite: View {
         if lowerRole.contains("backend") {
             return "Backend"
         }
-        if lowerRole.contains("builder") {
+        if lowerRole.contains("builder") || lowerRole.contains("engineer") {
             return "Builder"
         }
         return String(trimmed.prefix(12))
@@ -1419,7 +948,7 @@ private struct PixelAgentSprite: View {
         case .idle:
             return language("IDLE", "대기")
         case .running:
-            return language("RUN", "작업")
+            return sceneAgent.action == .typing ? language("TYPE", "타이핑") : language("RUN", "작업")
         case .review:
             return language("REVIEW", "리뷰")
         case .blocked:
@@ -1461,7 +990,7 @@ private struct PixelAgentSprite: View {
         if lowerRole.contains("qa") || lowerRole.contains("review") {
             return Color(red: 0.82, green: 0.65, blue: 0.48)
         }
-        if lowerRole.contains("product") {
+        if lowerRole.contains("product") || lowerRole.contains("ux") {
             return Color(red: 0.95, green: 0.74, blue: 0.55)
         }
         return Color(red: 0.88, green: 0.67, blue: 0.50)
@@ -1482,7 +1011,7 @@ private struct PixelAgentSprite: View {
 
     private var outfitTint: Color {
         if lowerRole.contains("ceo") || lowerRole.contains("lead") {
-            return Color(red: 0.52, green: 0.25, blue: 0.24)
+            return Color(red: 0.34, green: 0.18, blue: 0.22)
         }
         if lowerRole.contains("product") {
             return Color(red: 0.22, green: 0.38, blue: 0.66)
@@ -1497,19 +1026,6 @@ private struct PixelAgentSprite: View {
             return Color(red: 0.35, green: 0.53, blue: 0.78)
         }
         return Color(red: 0.40, green: 0.52, blue: 0.38)
-    }
-
-    private var roleIcon: String {
-        if lowerRole.contains("ceo") || lowerRole.contains("lead") {
-            return "crown.fill"
-        }
-        if lowerRole.contains("product") {
-            return "doc.text.fill"
-        }
-        if lowerRole.contains("ux") || lowerRole.contains("design") || lowerRole.contains("ui") {
-            return "paintpalette.fill"
-        }
-        return "terminal.fill"
     }
 
     private var stateIcon: String {
@@ -1530,14 +1046,24 @@ private struct PixelAgentSprite: View {
             return "pause.circle.fill"
         }
     }
+}
 
-    private func roomLine(_ value: String, limit: Int) -> String {
-        let trimmed = value.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.count <= limit {
-            return trimmed
-        }
-        return String(trimmed.prefix(limit - 1)) + "…"
+private struct PixelTriangle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
     }
+}
+
+private struct MeetingRoomZoneButton {
+    let zone: MeetingRoomOfficeZone
+    let title: String
+    let count: Int
+    let point: CGPoint
 }
 
 private struct MeetingRoomProjectionAgentSheet: View {
@@ -1558,6 +1084,7 @@ private struct MeetingRoomProjectionAgentSheet: View {
             }
             detail(language("Current work", "현재 작업"), agent.currentIssueTitle ?? agent.detailLine)
             detail(language("Runtime state", "런타임 상태"), agent.status)
+            detail(language("Office action", "오피스 동작"), agent.actionLine)
             detail(language("Log summary", "로그 요약"), agent.detailLine)
             ProgressView(value: agent.progress)
                 .tint(ShellPalette.success)
@@ -1576,6 +1103,66 @@ private struct MeetingRoomProjectionAgentSheet: View {
                 .font(.system(size: 12, weight: .medium, design: .monospaced))
                 .foregroundStyle(ShellPalette.text)
                 .lineLimit(4)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .background(ShellPalette.panelAlt)
+        .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+    }
+}
+
+private struct MeetingRoomProjectionIssueSheet: View {
+    let issue: MeetingRoomIssueSummary
+    let language: AppLanguage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(issue.title)
+                .font(.system(size: 17, weight: .bold, design: .monospaced))
+                .foregroundStyle(ShellPalette.text)
+            HStack(spacing: 8) {
+                ShellTag(text: issue.status, tint: issue.status.uppercased().contains("BLOCK") ? ShellPalette.danger : ShellPalette.accent)
+                ShellTag(text: issue.kind, tint: ShellPalette.accentWarm)
+                if let pullRequestState = issue.pullRequestState {
+                    ShellTag(text: "PR \(pullRequestState)", tint: ShellPalette.success)
+                }
+            }
+            detail(language("Issue id", "이슈 ID"), issue.id)
+            detail(language("Assignee", "담당"), issue.assigneeProfileId ?? "-")
+            if let transitionReason = issue.transitionReason {
+                detail(language("Reason", "이유"), transitionReason)
+            }
+            if let pullRequest = pullRequestSummary {
+                detail(language("Pull request", "PR"), pullRequest)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(22)
+        .frame(width: 480, height: 340)
+        .background(ShellPalette.panel)
+    }
+
+    private var pullRequestSummary: String? {
+        guard issue.pullRequestNumber != nil || issue.pullRequestUrl != nil || issue.pullRequestState != nil else {
+            return nil
+        }
+        return [
+            issue.pullRequestNumber.map { "#\($0)" },
+            issue.pullRequestState,
+            issue.pullRequestUrl,
+        ]
+        .compactMap { $0 }
+        .joined(separator: " · ")
+    }
+
+    private func detail(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title.uppercased())
+                .font(.system(size: 9, weight: .heavy, design: .monospaced))
+                .foregroundStyle(ShellPalette.faint)
+            Text(value)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(ShellPalette.text)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(10)
@@ -1604,7 +1191,7 @@ private struct MeetingRoomProjectionFlowSheet: View {
                 }
             }
             detail(language("Issue", "이슈"), issueSummary)
-            detail(language("Movement", "이동"), "\(flow.from.rawValue) → \(flow.to.rawValue)")
+            detail(language("Movement", "이동"), "\(flow.from.rawValue) -> \(flow.to.rawValue)")
             detail(language("Detail", "상세"), flow.detail)
             if let pullRequest = pullRequestSummary {
                 detail(language("Pull request", "PR"), pullRequest)
@@ -1676,14 +1263,20 @@ private struct MeetingRoomProjectionZoneSheet: View {
                 .foregroundStyle(ShellPalette.muted)
                 .fixedSize(horizontal: false, vertical: true)
             Divider()
-            ForEach(lines, id: \.self) { line in
-                Text(line)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
-                    .foregroundStyle(ShellPalette.text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
-                    .background(ShellPalette.panelAlt)
-                    .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+            if lines.isEmpty {
+                Text(language("Nothing is pinned in this office zone yet.", "아직 이 오피스 구역에 표시할 항목이 없습니다."))
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(ShellPalette.muted)
+            } else {
+                ForEach(lines, id: \.self) { line in
+                    Text(line)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(ShellPalette.text)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(8)
+                        .background(ShellPalette.panelAlt)
+                        .clipShape(RoundedRectangle(cornerRadius: 3, style: .continuous))
+                }
             }
             Spacer(minLength: 0)
         }
@@ -1768,25 +1361,20 @@ private struct MeetingRoomProjectionZoneSheet: View {
             )
         case .activityWall:
             return ["activityCount=\(projection.activityCount)", "prStates=\(projection.pullRequestStates.joined(separator: ", "))"]
-        case .agentDesk, .planningBoard, .mergeLane:
+        case .agentDesk:
             return Array(projection.agents.map { "\($0.role): \($0.status)" }.prefix(8))
+        case .planningBoard:
+            return Array(projection.issues.filter { $0.status.uppercased().contains("PLAN") }.map { $0.title }.prefix(8))
+        case .mergeLane:
+            return Array(projection.issues.filter { $0.status.uppercased() == "DONE" || $0.pullRequestState?.uppercased() == "MERGED" }.map { $0.title }.prefix(8))
         }
     }
 }
 
-private extension MeetingRoomVisualState {
-    var renderPriority: Int {
-        switch self {
-        case .running:
-            return 700
-        case .review:
-            return 600
-        case .blocked, .failed, .costBlocked:
-            return 500
-        case .done:
-            return 300
-        case .idle:
-            return 100
-        }
+private func roomLine(_ value: String, limit: Int) -> String {
+    let trimmed = value.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.count <= limit {
+        return trimmed
     }
+    return String(trimmed.prefix(max(1, limit - 1))) + "..."
 }

--- a/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Testing
 @testable import CotorDesktopApp
 
@@ -416,6 +417,170 @@ struct MeetingRoomProjectionTests {
         #expect(activePlan.shouldAnimate)
         #expect(activePlan.frameInterval == 1.0 / 15.0)
     }
+
+    @Test
+    func sceneReducerMapsRunningAgentToTypingSprite() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "builder", title: "Builder")],
+            issues: [issue(id: "issue-active", title: "Active work", status: "IN_PROGRESS", assigneeProfileId: "Builder")],
+            runningSessions: [session(agentId: "builder", agentName: "opencode", issueId: "issue-active", status: "RUNNING")],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: []
+        )
+        let state = sceneState(projection)
+        let builder = try #require(state.agents.first)
+
+        #expect(builder.projection.expression == .focused)
+        #expect(builder.action == .typing)
+        #expect(builder.targetPoint == state.layout.deskPoint(for: builder.projection, index: 0, count: 1))
+        #expect(state.keyframes.contains { $0.kind == .agentTyping })
+    }
+
+    @Test
+    func sceneReducerCreatesA2AKeyframeBetweenSenderAndReceiver() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [
+                agent(id: "builder", title: "Builder"),
+                agent(id: "qa", title: "QA"),
+            ],
+            issues: [issue(id: "issue-1", title: "Coordinate work", status: "IN_PROGRESS", assigneeProfileId: "builder")],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: [
+                message(id: "msg-1", from: "Builder", to: "QA", issueId: "issue-1", body: "Please review.")
+            ]
+        )
+        let state = sceneState(projection)
+        let message = try #require(state.keyframes.first { $0.kind == .a2aMessage })
+
+        #expect(message.fromAgentId == "builder")
+        #expect(message.toAgentId == "qa")
+        #expect(message.usesScheduler)
+        #expect(state.agents.first { $0.id == "builder" }?.projection.expression == .talking)
+    }
+
+    @Test
+    func sceneReducerMapsIssueStatusesToOfficeZones() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "builder", title: "Builder")],
+            issues: [
+                issue(id: "planned", title: "Planned work", status: "PLANNED", assigneeProfileId: "builder"),
+                issue(id: "progress", title: "Running work", status: "IN_PROGRESS", assigneeProfileId: "builder"),
+                issue(id: "review", title: "Review work", status: "IN_REVIEW", assigneeProfileId: "builder", pullRequestState: "OPEN"),
+                issue(id: "blocked", title: "Blocked work", status: "BLOCKED", assigneeProfileId: "builder"),
+                issue(id: "done", title: "Done work", status: "DONE", assigneeProfileId: "builder", pullRequestState: "MERGED", mergeResult: "MERGED"),
+            ],
+            runningSessions: [],
+            reviewQueue: [review(issueId: "review", status: "READY_FOR_QA", pullRequestState: "OPEN")],
+            runtime: runtime(),
+            activity: [],
+            messages: []
+        )
+        let state = sceneState(projection)
+        let cards = Dictionary(uniqueKeysWithValues: state.issueCards.map { ($0.id, $0.zone) })
+
+        #expect(cards["planned"] == .planningBoard)
+        #expect(cards["progress"] == .agentDesk)
+        #expect(cards["review"] == .reviewDesk)
+        #expect(cards["blocked"] == .blockerZone)
+        #expect(cards["done"] == .mergeLane)
+    }
+
+    @Test
+    func sceneReducerDisablesSchedulerForReducedMotionBackgroundAndLowResource() {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [agent(id: "active-builder", title: "Builder")],
+            issues: [issue(id: "issue-active", title: "Active work", status: "IN_PROGRESS", assigneeProfileId: "Builder")],
+            runningSessions: [session(agentId: "active-builder", agentName: "opencode", issueId: "issue-active", status: "RUNNING")],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: []
+        )
+        let active = sceneState(projection)
+        let reduced = sceneState(projection, reduceMotion: true)
+        let low = sceneState(projection, lowResourceMode: true)
+        let background = sceneState(projection, isSceneActive: false)
+
+        #expect(active.shouldAnimate)
+        #expect(active.frameInterval == 1.0 / 15.0)
+        #expect(!reduced.shouldAnimate)
+        #expect(!low.shouldAnimate)
+        #expect(!background.shouldAnimate)
+        #expect(reduced.frameInterval == 1.0)
+        #expect(low.frameInterval == 1.0)
+        #expect(background.frameInterval == 1.0)
+    }
+
+    @Test
+    func renderPlanUsesSimplifiedAtTwentyAndGroupedAtFiftyAgents() {
+        let twentyProjection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: (0..<20).map { agent(id: "agent-\($0)", title: "Agent \($0)") },
+            issues: [],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(),
+            activity: [],
+            messages: []
+        )
+        let fiftyProjection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: (0..<50).map { agent(id: "agent-\($0)", title: "Agent \($0)") },
+            issues: [],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(),
+            activity: [],
+            messages: []
+        )
+
+        let twenty = sceneState(twentyProjection)
+        let fifty = sceneState(fiftyProjection)
+
+        #expect(twenty.renderPlan.mode == .simplified)
+        #expect(twenty.renderPlan.visibleAgents.count == 20)
+        #expect(!twenty.shouldAnimate)
+        #expect(fifty.renderPlan.mode == .grouped)
+        #expect(fifty.renderPlan.visibleAgents.count == 12)
+        #expect(fifty.renderPlan.hiddenAgentCount == 38)
+        #expect(!fifty.shouldAnimate)
+    }
+}
+
+private func sceneState(
+    _ projection: MeetingRoomProjection,
+    isCompact: Bool = false,
+    reduceMotion: Bool = false,
+    lowResourceMode: Bool = false,
+    isSceneActive: Bool = true
+) -> MeetingRoomSceneState {
+    let plan = MeetingRoomRenderPlan.build(
+        projection: projection,
+        isCompact: isCompact,
+        reduceMotion: reduceMotion,
+        lowResourceMode: lowResourceMode,
+        isSceneActive: isSceneActive
+    )
+    let layout = PixelOfficeLayout(size: CGSize(width: 1000, height: 640), isCompact: isCompact, mode: plan.mode)
+    return MeetingRoomSceneReducer.reduce(
+        previous: nil,
+        projection: projection,
+        layout: layout,
+        isCompact: isCompact,
+        reduceMotion: reduceMotion,
+        lowResourceMode: lowResourceMode,
+        isSceneActive: isSceneActive,
+        now: 100
+    )
 }
 
 private func agent(id: String, title: String) -> CompanyAgentDefinitionRecord {

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -699,6 +699,7 @@ class LocalModelPlugin : AgentPlugin {
 
     companion object {
         private val ollamaServerLock = Any()
+
         @Volatile
         private var managedOllamaProcess: Process? = null
     }


### PR DESCRIPTION
## Summary
- Rebuild the desktop Meeting Room as a projection-driven 2D pixel office scene.
- Add a Swift scene reducer and layout layer for agent positions, issue card zones, sprite actions, render modes, and keyframes.
- Replace the old card/map-style room renderer with a Canvas background, sprite/keyframe layer, and minimal SwiftUI hit targets.
- Make Live Office the default meeting-room surface and move activity/review detail into a drawer.
- Add reducer tests for typing agents, A2A messages, issue status zoning, scheduler policy, and 20/50-agent render modes.
- Include a Spotless-only Kotlin whitespace fix required by the PR CI format gate.

## Why
The previous Meeting Room was connected to real runtime projection data, but it read like overlapping state cards. This change keeps the existing backend/dashboard snapshot contract and makes the runtime projection visible as a small working office: agents at desks, review and blocker zones, message movement, and event-driven animation only when the projection has active work.

## Validation
- `swift build --package-path macos`
- `swift test --package-path macos --filter MeetingRoomProjectionTests`
- `swift test --package-path macos`
- `./gradlew --no-daemon formatCheck`

## Notes
- Built and committed from a clean worktree at `/Users/Projects/bssm-oss/cotor-organization/cotor-pixel-office-pr` so unrelated dirty workspace changes were excluded.
- `graphify update .` was attempted after code edits, but graphify refused to overwrite because the isolated worktree graph had 3886 nodes while the existing graph had 3928 nodes. No graphify output files are included in this PR.
- Live desktop smoke and 5-minute idle CPU validation were not run in this PR flow.
