### PR TITLE
[codex] Render Meeting Room as a live runtime office

### DIFF
--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -5707,6 +5707,7 @@ private struct CenterPaneView: View {
             companyId: companyId,
             agents: store.dashboard.companyAgentDefinitions,
             goals: store.dashboard.goals,
+            goalDecisions: store.dashboard.goalDecisions,
             orgProfiles: store.dashboard.orgProfiles,
             issues: store.dashboard.issues,
             runningSessions: store.dashboard.runningAgentSessions,

--- a/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
@@ -71,6 +71,49 @@ struct MeetingRoomFlowItem: Identifiable, Hashable {
     let progress: Double
 }
 
+enum MeetingRoomInteractionKind: String, Hashable {
+    case issueAssigned
+    case workStarted
+    case handoff
+    case meeting
+    case qaReviewRequested
+    case ceoApprovalRequested
+    case approvalGranted
+    case changesRequested
+    case blockedEscalation
+    case mergeCompleted
+    case costPaused
+
+    var usesScheduler: Bool {
+        switch self {
+        case .issueAssigned, .workStarted, .handoff, .meeting, .qaReviewRequested, .ceoApprovalRequested, .changesRequested, .blockedEscalation:
+            return true
+        case .approvalGranted, .mergeCompleted, .costPaused:
+            return false
+        }
+    }
+}
+
+struct MeetingRoomInteractionEvent: Identifiable, Hashable {
+    let id: String
+    let kind: MeetingRoomInteractionKind
+    let title: String
+    let detail: String
+    let speechText: String
+    let fromAgentId: String?
+    let toAgentId: String?
+    let participantAgentIds: [String]
+    let issueId: String?
+    let reviewId: String?
+    let messageId: String?
+    let occurredAt: Int64
+    let priority: Int
+
+    var agentIds: [String] {
+        Array(([fromAgentId, toAgentId].compactMap { $0 } + participantAgentIds).deduplicated())
+    }
+}
+
 struct MeetingRoomIssueSummary: Identifiable, Hashable {
     let id: String
     let title: String
@@ -104,6 +147,7 @@ struct MeetingRoomProjection: Hashable {
     let companyId: String?
     let agents: [MeetingRoomProjectionAgent]
     let flows: [MeetingRoomFlowItem]
+    let interactions: [MeetingRoomInteractionEvent]
     let issues: [MeetingRoomIssueSummary]
     let reviews: [MeetingRoomReviewSummary]
     let runtimeStatus: String
@@ -129,6 +173,7 @@ struct MeetingRoomProjection: Hashable {
         companyId: String?,
         agents allAgents: [CompanyAgentDefinitionRecord],
         goals allGoals: [GoalRecord] = [],
+        goalDecisions allGoalDecisions: [GoalOrchestrationDecisionRecord] = [],
         orgProfiles allOrgProfiles: [OrgAgentProfileRecord] = [],
         issues allIssues: [IssueRecord],
         runningSessions allRunningSessions: [RunningAgentSessionRecord],
@@ -140,6 +185,7 @@ struct MeetingRoomProjection: Hashable {
         let scopedAgents = scoped(allAgents, companyId: companyId)
             .sorted { $0.displayOrder < $1.displayOrder }
         let scopedGoals = scoped(allGoals, companyId: companyId)
+        let scopedGoalDecisions = scoped(allGoalDecisions, companyId: companyId)
         let scopedProfiles = scoped(allOrgProfiles, companyId: companyId)
         let scopedIssues = scoped(allIssues, companyId: companyId)
         let scopedSessions = scoped(allRunningSessions, companyId: companyId)
@@ -216,6 +262,17 @@ struct MeetingRoomProjection: Hashable {
             )
         }
 
+        let interactions = buildInteractions(
+            goals: scopedGoals,
+            goalDecisions: scopedGoalDecisions,
+            agents: projectedAgents,
+            orgProfiles: scopedProfiles,
+            issues: scopedIssues,
+            runningSessions: scopedSessions,
+            reviewQueue: scopedReviews,
+            messages: scopedMessages,
+            runtime: runtime
+        )
         let flows = buildFlows(
             goals: scopedGoals,
             issues: scopedIssues,
@@ -237,6 +294,7 @@ struct MeetingRoomProjection: Hashable {
             companyId: companyId,
             agents: projectedAgents,
             flows: flows,
+            interactions: interactions,
             issues: issueSummaries,
             reviews: reviewSummaries,
             runtimeStatus: runtime.status,
@@ -274,6 +332,8 @@ struct MeetingRoomProjection: Hashable {
                 return agent.companyId == companyId
             case let goal as GoalRecord:
                 return goal.companyId == companyId
+            case let decision as GoalOrchestrationDecisionRecord:
+                return decision.companyId == companyId
             case let profile as OrgAgentProfileRecord:
                 return profile.companyId == companyId
             case let issue as IssueRecord:
@@ -592,6 +652,409 @@ struct MeetingRoomProjection: Hashable {
 
         return Array(flows.prefix(10))
     }
+
+    private static func buildInteractions(
+        goals: [GoalRecord],
+        goalDecisions: [GoalOrchestrationDecisionRecord],
+        agents: [MeetingRoomProjectionAgent],
+        orgProfiles: [OrgAgentProfileRecord],
+        issues: [IssueRecord],
+        runningSessions: [RunningAgentSessionRecord],
+        reviewQueue: [ReviewQueueItemRecord],
+        messages: [AgentMessageRecord],
+        runtime: CompanyRuntimeSnapshotRecord
+    ) -> [MeetingRoomInteractionEvent] {
+        let resolver = MeetingRoomAgentResolver(agents: agents, orgProfiles: orgProfiles)
+        let issuesById = Dictionary(uniqueKeysWithValues: issues.map { ($0.id, $0) })
+        var events: [MeetingRoomInteractionEvent] = []
+
+        for session in runningSessions.sorted(by: { $0.updatedAt > $1.updatedAt }).prefix(6) {
+            let agentId = resolver.agentId(for: session.agentId)
+                ?? resolver.agentId(for: session.roleName)
+                ?? resolver.agentId(for: session.agentName)
+            let issue = session.issueId.flatMap { issuesById[$0] }
+            events.append(
+                MeetingRoomInteractionEvent(
+                    id: "work-\(session.runId)",
+                    kind: .workStarted,
+                    title: issue?.title ?? session.agentName,
+                    detail: session.outputSnippet ?? session.status,
+                    speechText: "Working on it",
+                    fromAgentId: agentId,
+                    toAgentId: nil,
+                    participantAgentIds: [agentId].compactMap { $0 },
+                    issueId: session.issueId,
+                    reviewId: nil,
+                    messageId: nil,
+                    occurredAt: session.updatedAt,
+                    priority: 760
+                )
+            )
+        }
+
+        for review in reviewQueue.sorted(by: { $0.updatedAt > $1.updatedAt }).prefix(8) {
+            let issue = issuesById[review.issueId]
+            let owner = issue.flatMap { resolver.agentId(forIssue: $0) } ?? resolver.builderAgentId()
+            let qa = resolver.qaAgentId()
+            let ceo = resolver.ceoAgentId()
+            let status = review.status.uppercased()
+            let merged = review.pullRequestState?.uppercased() == "MERGED" || review.mergedAt != nil
+
+            if merged || status == "MERGED" {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "merge-\(review.id)",
+                        kind: .mergeCompleted,
+                        title: issue?.title ?? review.issueId,
+                        detail: review.pullRequestUrl ?? review.branchName ?? "Merged work",
+                        speechText: "Merged",
+                        fromAgentId: ceo ?? qa ?? owner,
+                        toAgentId: nil,
+                        participantAgentIds: [owner, qa, ceo].compactMap { $0 },
+                        issueId: review.issueId,
+                        reviewId: review.id,
+                        messageId: nil,
+                        occurredAt: review.mergedAt ?? review.updatedAt,
+                        priority: 520
+                    )
+                )
+            } else if status == "READY_FOR_CEO" || review.approvalIssueId != nil {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "ceo-approval-\(review.id)",
+                        kind: .ceoApprovalRequested,
+                        title: issue?.title ?? review.issueId,
+                        detail: review.pullRequestUrl ?? review.branchName ?? review.status,
+                        speechText: "Approval requested",
+                        fromAgentId: owner,
+                        toAgentId: ceo,
+                        participantAgentIds: [owner, ceo].compactMap { $0 },
+                        issueId: review.issueId,
+                        reviewId: review.id,
+                        messageId: nil,
+                        occurredAt: review.updatedAt,
+                        priority: 930
+                    )
+                )
+            } else if status == "CHANGES_REQUESTED" || status == "FAILED_CHECKS" {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "changes-\(review.id)",
+                        kind: .changesRequested,
+                        title: issue?.title ?? review.issueId,
+                        detail: review.qaFeedback ?? review.ceoFeedback ?? review.checksSummary ?? review.status,
+                        speechText: "Changes requested",
+                        fromAgentId: qa ?? ceo,
+                        toAgentId: owner,
+                        participantAgentIds: [owner, qa, ceo].compactMap { $0 },
+                        issueId: review.issueId,
+                        reviewId: review.id,
+                        messageId: nil,
+                        occurredAt: review.updatedAt,
+                        priority: 880
+                    )
+                )
+            } else if status.contains("QA") || status.contains("REVIEW") || status == "AWAITING_QA" {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "qa-review-\(review.id)",
+                        kind: .qaReviewRequested,
+                        title: issue?.title ?? review.issueId,
+                        detail: review.pullRequestUrl ?? review.branchName ?? review.status,
+                        speechText: "Please review",
+                        fromAgentId: owner,
+                        toAgentId: qa,
+                        participantAgentIds: [owner, qa].compactMap { $0 },
+                        issueId: review.issueId,
+                        reviewId: review.id,
+                        messageId: nil,
+                        occurredAt: review.updatedAt,
+                        priority: 900
+                    )
+                )
+            } else if status == "READY_TO_MERGE" || review.ceoVerdict?.uppercased().contains("PASS") == true {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "approval-granted-\(review.id)",
+                        kind: .approvalGranted,
+                        title: issue?.title ?? review.issueId,
+                        detail: review.ceoFeedback ?? review.status,
+                        speechText: "Approved",
+                        fromAgentId: ceo,
+                        toAgentId: owner,
+                        participantAgentIds: [owner, ceo].compactMap { $0 },
+                        issueId: review.issueId,
+                        reviewId: review.id,
+                        messageId: nil,
+                        occurredAt: review.ceoReviewedAt ?? review.updatedAt,
+                        priority: 700
+                    )
+                )
+            }
+        }
+
+        for message in messages.sorted(by: { $0.createdAt > $1.createdAt }).prefix(8) {
+            let from = resolver.agentId(for: message.fromAgentName)
+            let to = message.toAgentName.flatMap { resolver.agentId(for: $0) }
+            let kind = message.kind.lowercased()
+            let eventKind: MeetingRoomInteractionKind
+            let speech: String
+            let fallbackTarget: String?
+
+            if kind.contains("escalation") {
+                eventKind = .blockedEscalation
+                speech = "Need help"
+                fallbackTarget = resolver.ceoAgentId() ?? resolver.qaAgentId()
+            } else if kind.contains("feedback") {
+                eventKind = .meeting
+                speech = "Feedback sync"
+                fallbackTarget = nil
+            } else if kind.contains("review.request") {
+                eventKind = .qaReviewRequested
+                speech = "Please review"
+                fallbackTarget = resolver.qaAgentId()
+            } else if kind.contains("approval") {
+                eventKind = .ceoApprovalRequested
+                speech = "Approval requested"
+                fallbackTarget = resolver.ceoAgentId()
+            } else {
+                eventKind = .handoff
+                speech = "Handoff update"
+                fallbackTarget = nil
+            }
+
+            let target = to ?? fallbackTarget
+            events.append(
+                MeetingRoomInteractionEvent(
+                    id: "message-\(message.id)",
+                    kind: eventKind,
+                    title: message.subject,
+                    detail: message.body,
+                    speechText: speech,
+                    fromAgentId: from,
+                    toAgentId: target,
+                    participantAgentIds: [from, target].compactMap { $0 },
+                    issueId: message.issueId,
+                    reviewId: nil,
+                    messageId: message.id,
+                    occurredAt: message.createdAt,
+                    priority: eventKind == .blockedEscalation ? 910 : 780
+                )
+            )
+        }
+
+        for issue in issues.sorted(by: { $0.updatedAt > $1.updatedAt }).prefix(8) {
+            let status = issue.status.uppercased()
+            let assignee = resolver.agentId(forIssue: issue)
+            if runtime.isBudgetPaused {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "cost-\(issue.id)",
+                        kind: .costPaused,
+                        title: issue.title,
+                        detail: "Cost guardrail paused runtime.",
+                        speechText: "Cost pause",
+                        fromAgentId: resolver.ceoAgentId(),
+                        toAgentId: assignee,
+                        participantAgentIds: [resolver.ceoAgentId(), assignee].compactMap { $0 },
+                        issueId: issue.id,
+                        reviewId: nil,
+                        messageId: nil,
+                        occurredAt: issue.updatedAt,
+                        priority: 860
+                    )
+                )
+            } else if status == "READY_FOR_CEO" || issue.kind.lowercased() == "approval" {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "issue-approval-\(issue.id)",
+                        kind: .ceoApprovalRequested,
+                        title: issue.title,
+                        detail: issue.transitionReason ?? issue.pullRequestUrl ?? issue.status,
+                        speechText: "Approval requested",
+                        fromAgentId: assignee ?? resolver.builderAgentId(),
+                        toAgentId: resolver.ceoAgentId(),
+                        participantAgentIds: [assignee, resolver.ceoAgentId()].compactMap { $0 },
+                        issueId: issue.id,
+                        reviewId: nil,
+                        messageId: nil,
+                        occurredAt: issue.updatedAt,
+                        priority: 890
+                    )
+                )
+            } else if status.contains("BLOCK") || status.contains("FAIL") {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "blocked-\(issue.id)",
+                        kind: .blockedEscalation,
+                        title: issue.title,
+                        detail: issue.transitionReason ?? issue.providerBlockReasonFallback,
+                        speechText: "Need help",
+                        fromAgentId: assignee,
+                        toAgentId: resolver.ceoAgentId() ?? resolver.qaAgentId(),
+                        participantAgentIds: [assignee, resolver.ceoAgentId(), resolver.qaAgentId()].compactMap { $0 },
+                        issueId: issue.id,
+                        reviewId: nil,
+                        messageId: nil,
+                        occurredAt: issue.updatedAt,
+                        priority: 850
+                    )
+                )
+            } else if status.contains("PLAN") || status == "DELEGATED" || status.contains("BACKLOG") {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "assign-\(issue.id)",
+                        kind: .issueAssigned,
+                        title: issue.title,
+                        detail: issue.transitionReason ?? "Issue is ready to dispatch.",
+                        speechText: "Taking this",
+                        fromAgentId: resolver.planningAgentId(),
+                        toAgentId: assignee,
+                        participantAgentIds: [resolver.planningAgentId(), assignee].compactMap { $0 },
+                        issueId: issue.id,
+                        reviewId: nil,
+                        messageId: nil,
+                        occurredAt: issue.updatedAt,
+                        priority: 620
+                    )
+                )
+            }
+        }
+
+        for decision in goalDecisions.sorted(by: { $0.createdAt > $1.createdAt }).prefix(4) {
+            let participants = decision.assignments
+                .compactMap { assignmentTarget(from: $0) }
+                .compactMap { resolver.agentId(for: $0) }
+            let lead = resolver.ceoAgentId() ?? resolver.planningAgentId()
+            if !participants.isEmpty {
+                events.append(
+                    MeetingRoomInteractionEvent(
+                        id: "meeting-\(decision.id)",
+                        kind: .meeting,
+                        title: decision.title,
+                        detail: decision.summary,
+                        speechText: "Plan sync",
+                        fromAgentId: lead,
+                        toAgentId: nil,
+                        participantAgentIds: Array(([lead].compactMap { $0 } + participants).deduplicated()),
+                        issueId: decision.issueId,
+                        reviewId: nil,
+                        messageId: nil,
+                        occurredAt: decision.createdAt,
+                        priority: 740
+                    )
+                )
+            }
+        }
+
+        let goalTitles = Dictionary(uniqueKeysWithValues: goals.map { ($0.id, $0.title) })
+        return Array(events
+            .sorted {
+                if $0.priority != $1.priority {
+                    return $0.priority > $1.priority
+                }
+                return $0.occurredAt > $1.occurredAt
+            }
+            .map { event in
+                guard event.title.isEmpty, let issueId = event.issueId, let issue = issuesById[issueId] else {
+                    return event
+                }
+                return MeetingRoomInteractionEvent(
+                    id: event.id,
+                    kind: event.kind,
+                    title: issue.title,
+                    detail: goalTitles[issue.goalId] ?? event.detail,
+                    speechText: event.speechText,
+                    fromAgentId: event.fromAgentId,
+                    toAgentId: event.toAgentId,
+                    participantAgentIds: event.participantAgentIds,
+                    issueId: event.issueId,
+                    reviewId: event.reviewId,
+                    messageId: event.messageId,
+                    occurredAt: event.occurredAt,
+                    priority: event.priority
+                )
+            }
+            .deduplicatedById()
+            .prefix(14))
+    }
+
+    private static func assignmentTarget(from assignment: String) -> String? {
+        let separators = ["->", "→", ":"]
+        for separator in separators where assignment.contains(separator) {
+            return assignment.components(separatedBy: separator).last?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return assignment.trimmingCharacters(in: .whitespacesAndNewlines).nilIfBlank
+    }
+}
+
+private struct MeetingRoomAgentResolver {
+    private let agents: [MeetingRoomProjectionAgent]
+    private let idByKey: [String: String]
+
+    init(agents: [MeetingRoomProjectionAgent], orgProfiles: [OrgAgentProfileRecord]) {
+        self.agents = agents
+        var map: [String: String] = [:]
+        for agent in agents {
+            [agent.id, agent.companyAgentId, agent.name, agent.role, agent.cli].forEach { value in
+                map[value.normalizedMeetingRoomKey] = agent.id
+            }
+        }
+        for profile in orgProfiles {
+            let matched = agents.first {
+                $0.role.normalizedMeetingRoomKey == profile.roleName.normalizedMeetingRoomKey ||
+                    $0.cli.normalizedMeetingRoomKey == profile.executionAgentName.normalizedMeetingRoomKey ||
+                    $0.id.normalizedMeetingRoomKey == profile.id.normalizedMeetingRoomKey
+            }
+            if let matched {
+                [profile.id, profile.roleName, profile.executionAgentName].forEach { value in
+                    map[value.normalizedMeetingRoomKey] = matched.id
+                }
+            }
+        }
+        idByKey = map
+    }
+
+    func agentId(for value: String?) -> String? {
+        guard let key = value?.normalizedMeetingRoomKey, !key.isEmpty else { return nil }
+        return idByKey[key] ?? agents.first { agent in
+            agent.role.normalizedMeetingRoomKey.contains(key) ||
+                key.contains(agent.role.normalizedMeetingRoomKey) ||
+                agent.cli.normalizedMeetingRoomKey.contains(key)
+        }?.id
+    }
+
+    func agentId(forIssue issue: IssueRecord) -> String? {
+        agentId(for: issue.assigneeProfileId)
+    }
+
+    func ceoAgentId() -> String? {
+        agents.first { agent in
+            let role = agent.role.lowercased()
+            return role.contains("ceo") || role.contains("lead") || role.contains("approval")
+        }?.id ?? agents.first?.id
+    }
+
+    func qaAgentId() -> String? {
+        agents.first { agent in
+            let role = agent.role.lowercased()
+            return role.contains("qa") || role.contains("review") || role.contains("test")
+        }?.id
+    }
+
+    func builderAgentId() -> String? {
+        agents.first { agent in
+            let role = agent.role.lowercased()
+            return role.contains("builder") || role.contains("engineer") || role.contains("backend")
+        }?.id
+    }
+
+    func planningAgentId() -> String? {
+        agents.first { agent in
+            let role = agent.role.lowercased()
+            return role.contains("product") || role.contains("ux") || role.contains("planner") || role.contains("ceo")
+        }?.id ?? ceoAgentId()
+    }
 }
 
 private extension MeetingRoomIssueSummary {
@@ -632,10 +1095,32 @@ private extension String {
     var normalizedMeetingRoomKey: String {
         trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
+
+    var nilIfBlank: String? {
+        isEmpty ? nil : self
+    }
 }
 
 private extension IssueRecord {
     var providerBlockReasonFallback: String {
         transitionReason ?? pullRequestState ?? "Blocked issue"
+    }
+}
+
+private extension Array where Element == String {
+    func deduplicated() -> [String] {
+        var seen: Set<String> = []
+        return filter { value in
+            seen.insert(value).inserted
+        }
+    }
+}
+
+private extension Array where Element == MeetingRoomInteractionEvent {
+    func deduplicatedById() -> [MeetingRoomInteractionEvent] {
+        var seen: Set<String> = []
+        return filter { event in
+            seen.insert(event.id).inserted
+        }
     }
 }

--- a/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
@@ -7,7 +7,10 @@ enum MeetingRoomSpriteAction: String, Hashable {
     case walking
     case reviewing
     case talking
+    case listening
+    case approving
     case blocked
+    case celebrating
 }
 
 enum MeetingRoomSceneKeyframeKind: String, Hashable {
@@ -22,9 +25,9 @@ enum MeetingRoomSceneKeyframeKind: String, Hashable {
 
     var usesScheduler: Bool {
         switch self {
-        case .issueCreated, .issueAssigned, .agentTyping, .a2aMessage, .reviewRequested:
+        case .issueCreated, .issueAssigned, .agentTyping, .reviewRequested:
             return true
-        case .mergeCompleted, .blockedJump, .costPaused:
+        case .a2aMessage, .mergeCompleted, .blockedJump, .costPaused:
             return false
         }
     }
@@ -52,6 +55,7 @@ struct MeetingRoomRenderPlan: Hashable {
     let visibleAgents: [MeetingRoomProjectionAgent]
     let hiddenAgentCount: Int
     let visibleFlows: [MeetingRoomFlowItem]
+    let visibleInteractions: [MeetingRoomInteractionEvent]
     let shouldAnimate: Bool
     let frameInterval: TimeInterval
 
@@ -59,6 +63,7 @@ struct MeetingRoomRenderPlan: Hashable {
         [
             mode.rawValue,
             visibleAgents.map { "\($0.id):\($0.visualState.rawValue):\($0.currentIssueId ?? "-")" }.joined(separator: "|"),
+            visibleInteractions.map { "\($0.id):\($0.kind.rawValue):\($0.occurredAt)" }.joined(separator: "|"),
             visibleFlows.map { "\($0.id):\($0.kind.rawValue):\($0.progress)" }.joined(separator: "|"),
         ].joined(separator: "::")
     }
@@ -68,7 +73,8 @@ struct MeetingRoomRenderPlan: Hashable {
         isCompact: Bool,
         reduceMotion: Bool,
         lowResourceMode: Bool,
-        isSceneActive: Bool
+        isSceneActive: Bool,
+        seenEventIds: Set<String> = []
     ) -> MeetingRoomRenderPlan {
         let agentCount = projection.agents.count
         let mode: Mode
@@ -82,55 +88,69 @@ struct MeetingRoomRenderPlan: Hashable {
 
         let maxAgents: Int
         let maxFlows: Int
+        let maxInteractions: Int
         switch mode {
         case .full:
             maxAgents = agentCount
-            maxFlows = 8
+            maxFlows = 5
+            maxInteractions = 8
         case .simplified:
             maxAgents = min(agentCount, isCompact ? 10 : 20)
-            maxFlows = 6
+            maxFlows = 4
+            maxInteractions = 5
         case .grouped:
             maxAgents = min(agentCount, 12)
-            maxFlows = 6
+            maxFlows = 3
+            maxInteractions = 4
         }
 
+        let visibleInteractions = Array(projection.interactions.prefix(maxInteractions))
+        let interactionAgentIds = Set(visibleInteractions.flatMap(\.agentIds))
+        let priorityByAgentId = visibleInteractions.reduce(into: [String: Int]()) { result, event in
+            for agentId in event.agentIds {
+                result[agentId] = max(result[agentId] ?? 0, event.priority)
+            }
+        }
         let prioritizedAgents = projection.agents.sorted { lhs, rhs in
+            let lhsEventPriority = priorityByAgentId[lhs.id] ?? 0
+            let rhsEventPriority = priorityByAgentId[rhs.id] ?? 0
+            if lhsEventPriority != rhsEventPriority {
+                return lhsEventPriority > rhsEventPriority
+            }
+            if interactionAgentIds.contains(lhs.id) != interactionAgentIds.contains(rhs.id) {
+                return interactionAgentIds.contains(lhs.id)
+            }
             if lhs.visualState.renderPriority != rhs.visualState.renderPriority {
                 return lhs.visualState.renderPriority > rhs.visualState.renderPriority
             }
             return lhs.id < rhs.id
         }
         let visibleAgents = Array(prioritizedAgents.prefix(maxAgents))
-        let visibleFlows = Array(projection.flows.prefix(maxFlows))
-        let hasLiveMotion = visibleAgents.contains { agent in
-            switch agent.visualState {
-            case .running, .review:
-                return true
-            case .idle, .blocked, .failed, .done, .costBlocked:
-                return false
-            }
+        let visibleAgentIds = Set(visibleAgents.map(\.id))
+        let filteredInteractions = visibleInteractions.filter { event in
+            event.agentIds.isEmpty || !Set(event.agentIds).isDisjoint(with: visibleAgentIds)
         }
-        let hasActiveFlow = visibleFlows.contains { flow in
-            switch flow.kind {
-            case .goalToIssue, .issueToAgent, .agentWorking, .a2aMessage, .agentToReview:
-                return true
-            case .reviewToMerge, .blocked, .costBlocked:
-                return false
-            }
+        let visibleFlows = Array(
+            projection.flows
+                .filter { $0.kind != .a2aMessage && $0.kind != .agentToReview }
+                .prefix(maxFlows)
+        )
+        let hasFreshInteraction = filteredInteractions.contains { event in
+            event.drivesSceneScheduler && !seenEventIds.contains(event.id)
         }
-        let hasActiveMotion = hasLiveMotion || hasActiveFlow
         let shouldAnimate = isSceneActive &&
             !reduceMotion &&
             !lowResourceMode &&
             mode == .full &&
             agentCount < 20 &&
-            hasActiveMotion
+            hasFreshInteraction
 
         return MeetingRoomRenderPlan(
             mode: mode,
             visibleAgents: visibleAgents,
             hiddenAgentCount: max(0, agentCount - visibleAgents.count),
             visibleFlows: visibleFlows,
+            visibleInteractions: filteredInteractions,
             shouldAnimate: shouldAnimate,
             frameInterval: shouldAnimate ? (1.0 / 15.0) : 1.0
         )
@@ -158,7 +178,7 @@ struct PixelOfficeLayout: Hashable {
         case .agentDesk:
             point = (0.52, 0.62)
         case .planningBoard:
-            point = (0.24, 0.23)
+            point = (0.22, 0.22)
         case .reviewDesk:
             point = (0.78, 0.34)
         case .blockerZone:
@@ -173,16 +193,21 @@ struct PixelOfficeLayout: Hashable {
         return snapped(CGPoint(x: size.width * point.0, y: size.height * point.1))
     }
 
+    func centerTablePoint(index: Int = 0, count: Int = 1) -> CGPoint {
+        let offsets = huddleOffsets(index: index, count: count, radius: isCompact ? 30 : 48)
+        return snapped(CGPoint(x: size.width * 0.50 + offsets.x, y: size.height * 0.43 + offsets.y))
+    }
+
     func deskPoint(for agent: MeetingRoomProjectionAgent, index: Int, count: Int) -> CGPoint {
         let role = agent.role.lowercased()
         if role.contains("ceo") || role.contains("lead") {
-            return snapped(CGPoint(x: size.width * 0.30, y: size.height * 0.40))
+            return snapped(CGPoint(x: size.width * 0.30, y: size.height * 0.39))
         }
         if role.contains("qa") || role.contains("review") {
-            return snapped(CGPoint(x: size.width * 0.70, y: size.height * 0.48))
+            return snapped(CGPoint(x: size.width * 0.71, y: size.height * 0.49))
         }
         if role.contains("ux") || role.contains("ui") || role.contains("design") || role.contains("product") {
-            return snapped(CGPoint(x: size.width * 0.38, y: size.height * 0.48))
+            return snapped(CGPoint(x: size.width * 0.38, y: size.height * 0.49))
         }
 
         let columns = max(2, min(isCompact ? 3 : 4, Int(ceil(sqrt(Double(max(1, count)))))))
@@ -206,6 +231,44 @@ struct PixelOfficeLayout: Hashable {
             return zonePoint(agent.zone)
         }
     }
+
+    func talkPoint(near point: CGPoint, index: Int = 0) -> CGPoint {
+        let offsets = [
+            CGPoint(x: -48, y: 36),
+            CGPoint(x: 48, y: 36),
+            CGPoint(x: -48, y: -34),
+            CGPoint(x: 48, y: -34),
+        ]
+        let offset = offsets[index % offsets.count]
+        return snapped(CGPoint(x: point.x + offset.x, y: point.y + offset.y))
+    }
+
+    func cardPoint(for event: MeetingRoomInteractionEvent, fallbackZone: MeetingRoomOfficeZone) -> CGPoint {
+        switch event.kind {
+        case .ceoApprovalRequested, .approvalGranted:
+            return snapped(CGPoint(x: zonePoint(.agentDesk).x - size.width * 0.20, y: zonePoint(.agentDesk).y - size.height * 0.22))
+        case .qaReviewRequested, .changesRequested:
+            return zonePoint(.reviewDesk)
+        case .blockedEscalation:
+            return zonePoint(.blockerZone)
+        case .mergeCompleted:
+            return zonePoint(.mergeLane)
+        case .costPaused:
+            return zonePoint(.costPanel)
+        case .meeting:
+            return centerTablePoint()
+        case .issueAssigned:
+            return zonePoint(.planningBoard)
+        case .workStarted, .handoff:
+            return zonePoint(fallbackZone)
+        }
+    }
+
+    private func huddleOffsets(index: Int, count: Int, radius: CGFloat) -> CGPoint {
+        guard count > 1 else { return CGPoint(x: 0, y: radius * 0.55) }
+        let angle = (Double(index) / Double(max(1, count))) * Double.pi * 2.0 + Double.pi / 2.0
+        return CGPoint(x: cos(angle) * radius, y: sin(angle) * radius * 0.62)
+    }
 }
 
 struct MeetingRoomSceneAgent: Identifiable, Hashable {
@@ -217,6 +280,9 @@ struct MeetingRoomSceneAgent: Identifiable, Hashable {
     let movementStartedAt: TimeInterval
     let movementDuration: TimeInterval
     let isSimplified: Bool
+    let speechText: String?
+    let focusEvent: MeetingRoomInteractionEvent?
+    let isFreshInteraction: Bool
 
     func point(at time: TimeInterval, animate: Bool) -> CGPoint {
         guard animate, action == .walking, movementDuration > 0 else {
@@ -237,8 +303,41 @@ struct MeetingRoomSceneIssueCard: Identifiable, Hashable {
     let title: String
     let status: String
     let zone: MeetingRoomOfficeZone
-    let point: CGPoint
+    let fromPoint: CGPoint
+    let targetPoint: CGPoint
+    let movementStartedAt: TimeInterval
+    let movementDuration: TimeInterval
     let flow: MeetingRoomFlowItem?
+    let interaction: MeetingRoomInteractionEvent?
+
+    var point: CGPoint { targetPoint }
+
+    func point(at time: TimeInterval, animate: Bool) -> CGPoint {
+        guard animate, movementDuration > 0 else {
+            return targetPoint
+        }
+        let raw = CGFloat((time - movementStartedAt) / movementDuration)
+        let progress = min(1, max(0, raw))
+        let eased = progress * progress * (3 - 2 * progress)
+        return CGPoint(
+            x: fromPoint.x + (targetPoint.x - fromPoint.x) * eased,
+            y: fromPoint.y + (targetPoint.y - fromPoint.y) * eased
+        )
+    }
+}
+
+struct MeetingRoomSceneInteraction: Identifiable, Hashable {
+    let id: String
+    let event: MeetingRoomInteractionEvent
+    let fromPoint: CGPoint
+    let toPoint: CGPoint
+    let startedAt: TimeInterval
+    let duration: TimeInterval
+    let isFresh: Bool
+
+    var usesScheduler: Bool {
+        isFresh && event.drivesSceneScheduler
+    }
 }
 
 struct MeetingRoomSceneKeyframe: Identifiable, Hashable {
@@ -275,17 +374,53 @@ struct MeetingRoomSceneKeyframe: Identifiable, Hashable {
     }
 }
 
+struct MeetingRoomSceneLedger: Hashable {
+    var seenEventIds: Set<String> = []
+    var settledAgentPositions: [String: CGPoint] = [:]
+    var lastProjectionFingerprint: Int?
+
+    static let empty = MeetingRoomSceneLedger()
+
+    func recording(events: [MeetingRoomInteractionEvent], agents: [MeetingRoomSceneAgent], projectionIdentity: Int) -> MeetingRoomSceneLedger {
+        var next = self
+        next.seenEventIds.formUnion(events.map(\.id))
+        next.settledAgentPositions = Dictionary(uniqueKeysWithValues: agents.map { ($0.id, $0.targetPoint) })
+        next.lastProjectionFingerprint = projectionIdentity
+        return next
+    }
+}
+
+@MainActor
+enum MeetingRoomSceneMemoryStore {
+    private static var ledgers: [String: MeetingRoomSceneLedger] = [:]
+
+    static func ledger(for key: String) -> MeetingRoomSceneLedger {
+        ledgers[key] ?? .empty
+    }
+
+    static func remember(_ ledger: MeetingRoomSceneLedger, for key: String) {
+        ledgers[key] = ledger
+    }
+
+    static func reset(for key: String) {
+        ledgers[key] = nil
+    }
+}
+
 struct MeetingRoomSceneState: Hashable {
     let projectionIdentity: Int
     let layout: PixelOfficeLayout
     let renderPlan: MeetingRoomRenderPlan
     let agents: [MeetingRoomSceneAgent]
     let issueCards: [MeetingRoomSceneIssueCard]
+    let interactions: [MeetingRoomSceneInteraction]
     let keyframes: [MeetingRoomSceneKeyframe]
+    let freshInteractionIds: Set<String>
+    let nextLedger: MeetingRoomSceneLedger
     let startedAt: TimeInterval
 
     var shouldAnimate: Bool {
-        renderPlan.shouldAnimate && keyframes.contains { $0.usesScheduler }
+        renderPlan.shouldAnimate && !freshInteractionIds.isEmpty
     }
 
     var frameInterval: TimeInterval {
@@ -298,6 +433,7 @@ struct MeetingRoomSceneState: Hashable {
             "\(Int(layout.size.width))x\(Int(layout.size.height))",
             layout.mode.rawValue,
             renderPlan.animationKey,
+            freshInteractionIds.sorted().joined(separator: "|"),
         ].joined(separator: "::")
     }
 }
@@ -311,6 +447,7 @@ enum MeetingRoomSceneReducer {
         reduceMotion: Bool,
         lowResourceMode: Bool,
         isSceneActive: Bool,
+        ledger: MeetingRoomSceneLedger = .empty,
         now: TimeInterval = Date().timeIntervalSinceReferenceDate
     ) -> MeetingRoomSceneState {
         let plan = MeetingRoomRenderPlan.build(
@@ -318,69 +455,218 @@ enum MeetingRoomSceneReducer {
             isCompact: isCompact,
             reduceMotion: reduceMotion,
             lowResourceMode: lowResourceMode,
-            isSceneActive: isSceneActive
+            isSceneActive: isSceneActive,
+            seenEventIds: ledger.seenEventIds
         )
+        let freshInteractionIds = Set(plan.visibleInteractions.filter { event in
+            event.drivesSceneScheduler && !ledger.seenEventIds.contains(event.id)
+        }.map(\.id))
         let previousAgentsById = Dictionary(uniqueKeysWithValues: (previous?.agents ?? []).map { ($0.id, $0) })
+        let basePointByAgentId = Dictionary(uniqueKeysWithValues: plan.visibleAgents.enumerated().map { index, agent in
+            (agent.id, layout.targetPoint(for: agent, index: index, count: plan.visibleAgents.count))
+        })
+        let interactionByAgentId = focusedInteractionByAgentId(plan.visibleInteractions, freshInteractionIds: freshInteractionIds)
+
         let sceneAgents = plan.visibleAgents.enumerated().map { index, agent in
-            let target = layout.targetPoint(for: agent, index: index, count: plan.visibleAgents.count)
-            let previousAgent = previousAgentsById[agent.id]
-            let from = previousAgent?.targetPoint ?? layout.deskPoint(for: agent, index: index, count: plan.visibleAgents.count)
-            let moved = distance(from, target) > 4
-            let action = spriteAction(for: agent, moved: moved && !reduceMotion && !lowResourceMode)
+            let baseTarget = basePointByAgentId[agent.id] ?? layout.targetPoint(for: agent, index: index, count: plan.visibleAgents.count)
+            let focusEvent = interactionByAgentId[agent.id]
+            let target = focusEvent.map {
+                interactionTargetPoint(for: agent, event: $0, basePointByAgentId: basePointByAgentId, layout: layout)
+            } ?? baseTarget
+            let existing = previousAgentsById[agent.id]
+            let from = existing?.targetPoint ?? ledger.settledAgentPositions[agent.id] ?? baseTarget
+            let isFresh = focusEvent.map { freshInteractionIds.contains($0.id) } ?? false
+            let shouldMove = isFresh && !reduceMotion && !lowResourceMode && distance(from, target) > 4
+            let action = spriteAction(for: agent, focusEvent: focusEvent, isFresh: isFresh, moved: shouldMove)
             return MeetingRoomSceneAgent(
                 id: agent.id,
                 projection: agent,
                 action: action,
-                fromPoint: from,
+                fromPoint: shouldMove ? from : target,
                 targetPoint: target,
-                movementStartedAt: moved ? now : (previousAgent?.movementStartedAt ?? now),
-                movementDuration: moved ? 1.25 : 0,
-                isSimplified: plan.mode != .full
+                movementStartedAt: shouldMove ? now : (existing?.movementStartedAt ?? now),
+                movementDuration: shouldMove ? movementDuration(for: focusEvent?.kind) : 0,
+                isSimplified: plan.mode != .full,
+                speechText: speechText(for: agent.id, event: focusEvent),
+                focusEvent: focusEvent,
+                isFreshInteraction: isFresh
             )
         }
-        let agentsByRole = Dictionary(sceneAgents.map { ($0.projection.role.normalizedSceneKey, $0) }, uniquingKeysWith: { first, _ in first })
-        let agentsByCli = Dictionary(sceneAgents.map { ($0.projection.cli.normalizedSceneKey, $0) }, uniquingKeysWith: { first, _ in first })
-        let keyframes = plan.visibleFlows.map { flow in
-            keyframe(
-                for: flow,
-                agentsByRole: agentsByRole,
-                agentsByCli: agentsByCli,
-                layout: layout,
-                previous: previous,
-                now: now
+
+        let sceneAgentsById = Dictionary(uniqueKeysWithValues: sceneAgents.map { ($0.id, $0) })
+        let interactions = plan.visibleInteractions.map { event in
+            let fromPoint = event.fromAgentId.flatMap { sceneAgentsById[$0]?.targetPoint } ?? event.agentIds.first.flatMap { sceneAgentsById[$0]?.targetPoint } ?? layout.zonePoint(.activityWall)
+            let toPoint = event.toAgentId.flatMap { sceneAgentsById[$0]?.targetPoint } ?? event.agentIds.dropFirst().first.flatMap { sceneAgentsById[$0]?.targetPoint } ?? layout.cardPoint(for: event, fallbackZone: .activityWall)
+            return MeetingRoomSceneInteraction(
+                id: event.id,
+                event: event,
+                fromPoint: fromPoint,
+                toPoint: toPoint,
+                startedAt: previous?.interactions.first { $0.id == event.id }?.startedAt ?? now,
+                duration: movementDuration(for: event.kind),
+                isFresh: freshInteractionIds.contains(event.id)
             )
+        }
+
+        let keyframes = plan.visibleFlows.map { flow in
+            keyframe(for: flow, layout: layout, previous: previous, now: now)
         }
         let flowByIssueId = Dictionary(plan.visibleFlows.compactMap { flow in
             flow.issueId.map { ($0, flow) }
         }, uniquingKeysWith: { first, _ in first })
+        let interactionByIssueId = Dictionary(plan.visibleInteractions.compactMap { event in
+            event.issueId.map { ($0, event) }
+        }, uniquingKeysWith: { first, _ in first })
+        let previousCardsById = Dictionary(uniqueKeysWithValues: (previous?.issueCards ?? []).map { ($0.id, $0) })
         let issueCards = projection.issues.prefix(plan.mode == .full ? 14 : 8).enumerated().map { index, issue in
             let zone = issueZone(for: issue)
             let base = layout.zonePoint(zone)
             let offset = cardOffset(index: index, mode: plan.mode)
+            let staticPoint = layout.snapped(CGPoint(x: base.x + offset.x, y: base.y + offset.y))
+            let event = interactionByIssueId[issue.id]
+            let target = event.map { layout.cardPoint(for: $0, fallbackZone: zone) } ?? staticPoint
+            let previousCard = previousCardsById[issue.id]
+            let isFresh = event.map { freshInteractionIds.contains($0.id) } ?? false
+            let from = previousCard?.targetPoint ?? staticPoint
             return MeetingRoomSceneIssueCard(
                 id: issue.id,
                 title: issue.title,
                 status: issue.status,
                 zone: zone,
-                point: layout.snapped(CGPoint(x: base.x + offset.x, y: base.y + offset.y)),
-                flow: flowByIssueId[issue.id]
+                fromPoint: isFresh ? from : target,
+                targetPoint: target,
+                movementStartedAt: isFresh ? now : (previousCard?.movementStartedAt ?? now),
+                movementDuration: isFresh ? 1.1 : 0,
+                flow: flowByIssueId[issue.id],
+                interaction: event
             )
         }
+
+        let nextLedger = ledger.recording(
+            events: plan.visibleInteractions,
+            agents: sceneAgents,
+            projectionIdentity: projection.hashValue
+        )
         return MeetingRoomSceneState(
             projectionIdentity: projection.hashValue,
             layout: layout,
             renderPlan: plan,
             agents: sceneAgents,
             issueCards: issueCards,
+            interactions: interactions,
             keyframes: keyframes,
+            freshInteractionIds: freshInteractionIds,
+            nextLedger: nextLedger,
             startedAt: previous?.startedAt ?? now
         )
     }
 
-    private static func spriteAction(for agent: MeetingRoomProjectionAgent, moved: Bool) -> MeetingRoomSpriteAction {
+    private static func focusedInteractionByAgentId(
+        _ interactions: [MeetingRoomInteractionEvent],
+        freshInteractionIds: Set<String>
+    ) -> [String: MeetingRoomInteractionEvent] {
+        var result: [String: MeetingRoomInteractionEvent] = [:]
+        for event in interactions.sorted(by: { lhs, rhs in
+            let lhsFresh = freshInteractionIds.contains(lhs.id)
+            let rhsFresh = freshInteractionIds.contains(rhs.id)
+            if lhsFresh != rhsFresh {
+                return lhsFresh
+            }
+            if lhs.priority != rhs.priority {
+                return lhs.priority > rhs.priority
+            }
+            return lhs.occurredAt > rhs.occurredAt
+        }) {
+            for agentId in event.agentIds where result[agentId] == nil {
+                result[agentId] = event
+            }
+        }
+        return result
+    }
+
+    private static func interactionTargetPoint(
+        for agent: MeetingRoomProjectionAgent,
+        event: MeetingRoomInteractionEvent,
+        basePointByAgentId: [String: CGPoint],
+        layout: PixelOfficeLayout
+    ) -> CGPoint {
+        switch event.kind {
+        case .ceoApprovalRequested, .approvalGranted:
+            if event.toAgentId == agent.id {
+                return basePointByAgentId[agent.id] ?? layout.zonePoint(.agentDesk)
+            }
+            let ceoPoint = event.toAgentId.flatMap { basePointByAgentId[$0] } ?? layout.zonePoint(.agentDesk)
+            return layout.talkPoint(near: ceoPoint, index: 0)
+        case .qaReviewRequested, .changesRequested:
+            if event.toAgentId == agent.id {
+                return basePointByAgentId[agent.id] ?? layout.zonePoint(.reviewDesk)
+            }
+            let qaPoint = event.toAgentId.flatMap { basePointByAgentId[$0] } ?? layout.zonePoint(.reviewDesk)
+            return layout.talkPoint(near: qaPoint, index: 1)
+        case .handoff:
+            if event.toAgentId == agent.id {
+                return basePointByAgentId[agent.id] ?? layout.centerTablePoint()
+            }
+            let targetPoint = event.toAgentId.flatMap { basePointByAgentId[$0] } ?? layout.centerTablePoint()
+            return layout.talkPoint(near: targetPoint, index: 0)
+        case .meeting:
+            let ids = event.agentIds
+            let index = ids.firstIndex(of: agent.id) ?? 0
+            return layout.centerTablePoint(index: index, count: max(1, ids.count))
+        case .blockedEscalation:
+            if event.fromAgentId == agent.id {
+                return layout.zonePoint(.blockerZone)
+            }
+            return layout.talkPoint(near: layout.zonePoint(.blockerZone), index: 1)
+        case .issueAssigned:
+            if event.toAgentId == agent.id {
+                return layout.talkPoint(near: layout.zonePoint(.planningBoard), index: 1)
+            }
+            return layout.talkPoint(near: layout.zonePoint(.planningBoard), index: 0)
+        case .workStarted:
+            return basePointByAgentId[agent.id] ?? layout.zonePoint(.agentDesk)
+        case .mergeCompleted:
+            return event.fromAgentId == agent.id ? layout.talkPoint(near: layout.zonePoint(.mergeLane), index: 0) : layout.zonePoint(.mergeLane)
+        case .costPaused:
+            return event.fromAgentId == agent.id ? layout.talkPoint(near: layout.zonePoint(.costPanel), index: 0) : layout.zonePoint(.costPanel)
+        }
+    }
+
+    private static func spriteAction(
+        for agent: MeetingRoomProjectionAgent,
+        focusEvent: MeetingRoomInteractionEvent?,
+        isFresh: Bool,
+        moved: Bool
+    ) -> MeetingRoomSpriteAction {
         if moved {
             return .walking
         }
+        guard let focusEvent else {
+            return baseSpriteAction(for: agent)
+        }
+        switch focusEvent.kind {
+        case .workStarted:
+            return .typing
+        case .ceoApprovalRequested:
+            return focusEvent.toAgentId == agent.id ? .approving : .talking
+        case .approvalGranted:
+            return .celebrating
+        case .qaReviewRequested, .changesRequested:
+            return focusEvent.toAgentId == agent.id ? .reviewing : .talking
+        case .handoff:
+            return focusEvent.fromAgentId == agent.id ? .talking : .listening
+        case .meeting:
+            return focusEvent.fromAgentId == agent.id ? .talking : .listening
+        case .blockedEscalation, .costPaused:
+            return focusEvent.fromAgentId == agent.id ? .blocked : .listening
+        case .issueAssigned:
+            return focusEvent.toAgentId == agent.id ? .talking : .listening
+        case .mergeCompleted:
+            return isFresh ? .walking : .celebrating
+        }
+    }
+
+    private static func baseSpriteAction(for agent: MeetingRoomProjectionAgent) -> MeetingRoomSpriteAction {
         if agent.messageCount > 0 {
             return .talking
         }
@@ -396,19 +682,53 @@ enum MeetingRoomSceneReducer {
         }
     }
 
+    private static func speechText(for agentId: String, event: MeetingRoomInteractionEvent?) -> String? {
+        guard let event else { return nil }
+        if event.fromAgentId == agentId {
+            return event.speechText
+        }
+        if event.toAgentId == agentId {
+            switch event.kind {
+            case .ceoApprovalRequested:
+                return "Reviewing approval"
+            case .qaReviewRequested:
+                return "Reviewing now"
+            case .changesRequested:
+                return "Please revise"
+            case .handoff:
+                return "Received"
+            case .blockedEscalation:
+                return "Checking blocker"
+            case .issueAssigned:
+                return "Assigned"
+            case .approvalGranted:
+                return "Approved"
+            case .meeting:
+                return "Syncing"
+            case .workStarted:
+                return "Working on it"
+            case .mergeCompleted:
+                return "Merged"
+            case .costPaused:
+                return "Paused"
+            }
+        }
+        if event.kind == .meeting {
+            return "Syncing"
+        }
+        return nil
+    }
+
     private static func keyframe(
         for flow: MeetingRoomFlowItem,
-        agentsByRole: [String: MeetingRoomSceneAgent],
-        agentsByCli: [String: MeetingRoomSceneAgent],
         layout: PixelOfficeLayout,
         previous: MeetingRoomSceneState?,
         now: TimeInterval
     ) -> MeetingRoomSceneKeyframe {
         let kind = keyframeKind(for: flow.kind)
         let existing = previous?.keyframes.first { $0.id == flow.id }
-        let agentEndpoints = a2aEndpoints(for: flow, agentsByRole: agentsByRole, agentsByCli: agentsByCli)
-        let fromPoint = agentEndpoints?.from.targetPoint ?? layout.zonePoint(flow.from)
-        let toPoint = agentEndpoints?.to.targetPoint ?? layout.zonePoint(flow.to)
+        let fromPoint = layout.zonePoint(flow.from)
+        let toPoint = layout.zonePoint(flow.to)
         return MeetingRoomSceneKeyframe(
             id: flow.id,
             kind: kind,
@@ -420,8 +740,8 @@ enum MeetingRoomSceneReducer {
             toZone: flow.to,
             fromPoint: fromPoint,
             toPoint: toPoint,
-            fromAgentId: agentEndpoints?.from.id,
-            toAgentId: agentEndpoints?.to.id,
+            fromAgentId: nil,
+            toAgentId: nil,
             startedAt: existing?.startedAt ?? now,
             duration: keyframeDuration(for: kind)
         )
@@ -450,35 +770,26 @@ enum MeetingRoomSceneReducer {
 
     private static func keyframeDuration(for kind: MeetingRoomSceneKeyframeKind) -> TimeInterval {
         switch kind {
-        case .a2aMessage:
-            return 1.4
         case .issueCreated, .issueAssigned, .reviewRequested:
             return 1.2
         case .agentTyping:
             return 0.8
-        case .mergeCompleted, .blockedJump, .costPaused:
+        case .a2aMessage, .mergeCompleted, .blockedJump, .costPaused:
             return 0
         }
     }
 
-    private static func a2aEndpoints(
-        for flow: MeetingRoomFlowItem,
-        agentsByRole: [String: MeetingRoomSceneAgent],
-        agentsByCli: [String: MeetingRoomSceneAgent]
-    ) -> (from: MeetingRoomSceneAgent, to: MeetingRoomSceneAgent)? {
-        guard flow.kind == .a2aMessage else {
-            return nil
+    private static func movementDuration(for kind: MeetingRoomInteractionKind?) -> TimeInterval {
+        switch kind {
+        case .meeting:
+            return 1.4
+        case .ceoApprovalRequested, .qaReviewRequested, .blockedEscalation, .handoff, .changesRequested:
+            return 1.25
+        case .issueAssigned, .workStarted:
+            return 1.0
+        case .approvalGranted, .mergeCompleted, .costPaused, nil:
+            return 0
         }
-        let parts = flow.title.components(separatedBy: "→").map { $0.normalizedSceneKey }
-        guard parts.count == 2 else {
-            return nil
-        }
-        let from = agentsByRole[parts[0]] ?? agentsByCli[parts[0]]
-        let to = agentsByRole[parts[1]] ?? agentsByCli[parts[1]]
-        guard let from, let to else {
-            return nil
-        }
-        return (from, to)
     }
 
     private static func issueZone(for issue: MeetingRoomIssueSummary) -> MeetingRoomOfficeZone {
@@ -486,7 +797,7 @@ enum MeetingRoomSceneReducer {
         if status.contains("BLOCK") || status.contains("FAIL") {
             return .blockerZone
         }
-        if status.contains("REVIEW") || issue.pullRequestState?.uppercased() == "OPEN" {
+        if status == "READY_FOR_CEO" || status.contains("REVIEW") || issue.pullRequestState?.uppercased() == "OPEN" {
             return .reviewDesk
         }
         if status == "DONE" || status == "MERGED" || issue.pullRequestState?.uppercased() == "MERGED" {
@@ -524,6 +835,18 @@ private extension MeetingRoomVisualState {
         case .idle:
             return 100
         }
+    }
+}
+
+private extension MeetingRoomInteractionEvent {
+    var drivesSceneScheduler: Bool {
+        guard kind.usesScheduler else {
+            return false
+        }
+        if kind == .blockedEscalation && messageId == nil && reviewId == nil {
+            return false
+        }
+        return true
     }
 }
 

--- a/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
@@ -19,6 +19,10 @@ struct MeetingRoomView: View {
     @State private var selectedFlow: MeetingRoomFlowItem?
     @State private var selectedZone: MeetingRoomOfficeZone?
 
+    private var sceneMemoryKey: String {
+        projection.companyId ?? "all-companies"
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             header
@@ -32,6 +36,7 @@ struct MeetingRoomView: View {
                     isSceneActive: scenePhase == .active
                 )
                 let layout = PixelOfficeLayout(size: geometry.size, isCompact: isCompact, mode: plan.mode)
+                let ledger = MeetingRoomSceneMemoryStore.ledger(for: sceneMemoryKey)
                 let state = MeetingRoomSceneReducer.reduce(
                     previous: sceneState,
                     projection: projection,
@@ -39,15 +44,18 @@ struct MeetingRoomView: View {
                     isCompact: isCompact,
                     reduceMotion: reduceMotion,
                     lowResourceMode: lowResourceMode,
-                    isSceneActive: scenePhase == .active
+                    isSceneActive: scenePhase == .active,
+                    ledger: ledger
                 )
 
                 officeStage(state: state)
                     .onAppear {
                         sceneState = state
+                        MeetingRoomSceneMemoryStore.remember(state.nextLedger, for: sceneMemoryKey)
                     }
                     .onChange(of: state.cacheKey) { _, _ in
                         sceneState = state
+                        MeetingRoomSceneMemoryStore.remember(state.nextLedger, for: sceneMemoryKey)
                     }
             }
             .frame(height: isCompact ? 380 : 560)
@@ -137,6 +145,12 @@ struct MeetingRoomView: View {
 
     private func spriteLayer(state: MeetingRoomSceneState, time: TimeInterval) -> some View {
         ZStack {
+            ForEach(state.interactions) { interaction in
+                PixelOfficeInteractionRouteView(interaction: interaction)
+                    .frame(width: state.layout.size.width, height: state.layout.size.height)
+                    .zIndex(1)
+            }
+
             ForEach(state.keyframes) { keyframe in
                 PixelOfficeKeyframeView(
                     keyframe: keyframe,
@@ -154,7 +168,7 @@ struct MeetingRoomView: View {
                 PixelIssueCardView(card: card, language: language) {
                     selectedIssue = projection.issues.first { $0.id == card.id }
                 }
-                .position(card.point)
+                .position(card.point(at: time, animate: state.shouldAnimate && card.interaction != nil))
                 .zIndex(2)
             }
 
@@ -502,6 +516,47 @@ private struct PixelOfficeCanvas: View {
     }
 }
 
+private struct PixelOfficeInteractionRouteView: View {
+    let interaction: MeetingRoomSceneInteraction
+
+    var body: some View {
+        Canvas { context, _ in
+            var path = Path()
+            path.move(to: interaction.fromPoint)
+            let mid = CGPoint(
+                x: (interaction.fromPoint.x + interaction.toPoint.x) / 2,
+                y: min(interaction.fromPoint.y, interaction.toPoint.y) - 24
+            )
+            path.addQuadCurve(to: interaction.toPoint, control: mid)
+            context.stroke(
+                path,
+                with: .color(tint.opacity(interaction.isFresh ? 0.64 : 0.24)),
+                style: StrokeStyle(lineWidth: interaction.isFresh ? 2 : 1, lineCap: .round, dash: interaction.isFresh ? [7, 4] : [3, 5])
+            )
+            if interaction.isFresh {
+                context.fill(Path(ellipseIn: CGRect(x: interaction.toPoint.x - 4, y: interaction.toPoint.y - 4, width: 8, height: 8)), with: .color(tint.opacity(0.8)))
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private var tint: Color {
+        switch interaction.event.kind {
+        case .ceoApprovalRequested, .approvalGranted, .costPaused:
+            return ShellPalette.warning
+        case .qaReviewRequested, .changesRequested:
+            return ShellPalette.accentWarm
+        case .blockedEscalation:
+            return ShellPalette.danger
+        case .mergeCompleted:
+            return ShellPalette.success
+        case .issueAssigned, .handoff, .meeting, .workStarted:
+            return ShellPalette.accent
+        }
+    }
+}
+
 private struct PixelOfficeKeyframeView: View {
     let keyframe: MeetingRoomSceneKeyframe
     let language: AppLanguage
@@ -663,7 +718,7 @@ private struct PixelAgentSprite: View {
         Button(action: action) {
             VStack(spacing: 4) {
                 if showsBubble {
-                    Text(roomLine(agent.actionLine, limit: sceneAgent.isSimplified ? 12 : 18))
+                    Text(roomLine(bubbleText, limit: sceneAgent.isSimplified ? 12 : 18))
                         .font(.system(size: 8, weight: .heavy, design: .monospaced))
                         .foregroundStyle(ShellPalette.text)
                         .padding(.horizontal, 5)
@@ -702,9 +757,9 @@ private struct PixelAgentSprite: View {
     }
 
     private var bodyPixels: some View {
-        let step = animate ? CGFloat(sin(phase * 9 + Double(abs(agent.id.hashValue % 13)))) : 0
+        let step = animate ? keyframeStep : 0
         let blink = animate && Int(phase * 2 + Double(abs(agent.id.hashValue % 5))).isMultiple(of: 9)
-        let typing = animate && sceneAgent.action == .typing
+        let typing = sceneAgent.action == .typing
 
         return ZStack(alignment: .bottom) {
             if sceneAgent.action == .sitting || sceneAgent.action == .typing {
@@ -915,11 +970,80 @@ private struct PixelAgentSprite: View {
     }
 
     private var showsBubble: Bool {
+        if sceneAgent.speechText != nil {
+            return true
+        }
         switch sceneAgent.action {
-        case .blocked, .reviewing, .talking:
+        case .blocked, .reviewing, .talking, .listening, .approving, .celebrating:
             return true
         case .typing, .walking, .sitting:
             return agent.visualState == .failed || agent.visualState == .costBlocked
+        }
+    }
+
+    private var bubbleText: String {
+        guard let speech = sceneAgent.speechText else {
+            return agent.actionLine
+        }
+        switch speech {
+        case "Approval requested":
+            return language("Approval requested", "승인 요청합니다")
+        case "Reviewing approval":
+            return language("Reviewing approval", "승인 검토 중")
+        case "Please review":
+            return language("Please review", "검토 부탁합니다")
+        case "Reviewing now":
+            return language("Reviewing now", "검토합니다")
+        case "Changes requested":
+            return language("Changes requested", "수정 요청합니다")
+        case "Please revise":
+            return language("Please revise", "수정해 주세요")
+        case "Need help":
+            return language("Need help", "도움이 필요합니다")
+        case "Checking blocker":
+            return language("Checking blocker", "막힘 확인 중")
+        case "Handoff update":
+            return language("Handoff update", "인수인계합니다")
+        case "Received":
+            return language("Received", "확인했습니다")
+        case "Feedback sync":
+            return language("Feedback sync", "피드백 공유")
+        case "Plan sync":
+            return language("Plan sync", "계획 회의")
+        case "Syncing":
+            return language("Syncing", "회의 중")
+        case "Taking this":
+            return language("Taking this", "맡겠습니다")
+        case "Assigned":
+            return language("Assigned", "배정됨")
+        case "Working on it":
+            return language("Working on it", "작업 중")
+        case "Approved":
+            return language("Approved", "승인했습니다")
+        case "Merged":
+            return language("Merged", "머지 완료")
+        case "Cost pause":
+            return language("Cost pause", "비용 일시정지")
+        case "Paused":
+            return language("Paused", "일시정지")
+        default:
+            return speech
+        }
+    }
+
+    private var keyframeStep: CGFloat {
+        switch sceneAgent.action {
+        case .walking:
+            guard sceneAgent.movementDuration > 0 else { return 0 }
+            let raw = CGFloat((phase - sceneAgent.movementStartedAt) / sceneAgent.movementDuration)
+            let progress = min(1, max(0, raw))
+            return progress < 0.5 ? progress * 2 : (1 - progress) * -2
+        case .typing:
+            return Int(phase * 6).isMultiple(of: 2) ? 1 : -1
+        case .talking, .listening, .approving, .reviewing:
+            return Int(phase * 3).isMultiple(of: 2) ? 0.5 : 0
+        case .sitting, .blocked, .celebrating:
+            return 0
         }
     }
 
@@ -950,7 +1074,7 @@ private struct PixelAgentSprite: View {
         case .running:
             return sceneAgent.action == .typing ? language("TYPE", "타이핑") : language("RUN", "작업")
         case .review:
-            return language("REVIEW", "리뷰")
+            return sceneAgent.action == .approving ? language("APPROVE", "승인") : language("REVIEW", "리뷰")
         case .blocked:
             return language("BLOCK", "차단")
         case .failed:

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -818,6 +818,8 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
     let budgetPausedAt: Int64?
     let budgetResetDate: String?
     let waitingApprovalCount: Int
+    let pendingApprovalRunIds: [String]
+    let reviewQueueAttentionIds: [String]
 
     private enum CodingKeys: String, CodingKey {
         case companyId
@@ -843,6 +845,8 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
         case budgetPausedAt
         case budgetResetDate
         case waitingApprovalCount
+        case pendingApprovalRunIds
+        case reviewQueueAttentionIds
     }
 
     init(
@@ -868,7 +872,9 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
         monthSpentCents: Int = 0,
         budgetPausedAt: Int64? = nil,
         budgetResetDate: String? = nil,
-        waitingApprovalCount: Int = 0
+        waitingApprovalCount: Int = 0,
+        pendingApprovalRunIds: [String] = [],
+        reviewQueueAttentionIds: [String] = []
     ) {
         self.companyId = companyId
         self.status = status
@@ -893,6 +899,8 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
         self.budgetPausedAt = budgetPausedAt
         self.budgetResetDate = budgetResetDate
         self.waitingApprovalCount = waitingApprovalCount
+        self.pendingApprovalRunIds = pendingApprovalRunIds
+        self.reviewQueueAttentionIds = reviewQueueAttentionIds
     }
 
     init(from decoder: Decoder) throws {
@@ -920,6 +928,8 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
         budgetPausedAt = try container.decodeIfPresent(Int64.self, forKey: .budgetPausedAt)
         budgetResetDate = try container.decodeIfPresent(String.self, forKey: .budgetResetDate)
         waitingApprovalCount = try container.decodeValue(Int.self, forKey: .waitingApprovalCount, default: 0)
+        pendingApprovalRunIds = try container.decodeValue([String].self, forKey: .pendingApprovalRunIds, default: [])
+        reviewQueueAttentionIds = try container.decodeValue([String].self, forKey: .reviewQueueAttentionIds, default: [])
     }
 
     var isManuallyStopped: Bool {

--- a/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
@@ -440,7 +440,7 @@ struct MeetingRoomProjectionTests {
     }
 
     @Test
-    func sceneReducerCreatesA2AKeyframeBetweenSenderAndReceiver() throws {
+    func sceneReducerMovesSenderForA2AInteractionInsteadOfEnvelopeKeyframe() throws {
         let projection = MeetingRoomProjection.build(
             companyId: "company",
             agents: [
@@ -457,12 +457,14 @@ struct MeetingRoomProjectionTests {
             ]
         )
         let state = sceneState(projection)
-        let message = try #require(state.keyframes.first { $0.kind == .a2aMessage })
+        let message = try #require(state.interactions.first { $0.event.kind == .handoff })
 
-        #expect(message.fromAgentId == "builder")
-        #expect(message.toAgentId == "qa")
+        #expect(message.event.fromAgentId == "builder")
+        #expect(message.event.toAgentId == "qa")
         #expect(message.usesScheduler)
-        #expect(state.agents.first { $0.id == "builder" }?.projection.expression == .talking)
+        #expect(state.keyframes.allSatisfy { $0.kind != .a2aMessage })
+        #expect(state.agents.first { $0.id == "builder" }?.action == .walking)
+        #expect(state.agents.first { $0.id == "builder" }?.speechText == "Handoff update")
     }
 
     @Test
@@ -521,6 +523,123 @@ struct MeetingRoomProjectionTests {
     }
 
     @Test
+    func readyForCeoReviewCreatesApprovalInteractionAndMovesRequesterToCeo() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [
+                agent(id: "ceo", title: "CEO"),
+                agent(id: "builder", title: "Builder"),
+            ],
+            issues: [
+                issue(id: "issue-approval", title: "Approve PR", status: "READY_FOR_CEO", assigneeProfileId: "builder", pullRequestState: "OPEN")
+            ],
+            runningSessions: [],
+            reviewQueue: [
+                review(issueId: "issue-approval", status: "READY_FOR_CEO", pullRequestState: "OPEN", approvalIssueId: "approval-issue")
+            ],
+            runtime: runtime(),
+            activity: [],
+            messages: []
+        )
+        let approval = try #require(projection.interactions.first { $0.kind == .ceoApprovalRequested })
+        let state = sceneState(projection)
+        let builder = try #require(state.agents.first { $0.id == "builder" })
+        let ceo = try #require(state.agents.first { $0.id == "ceo" })
+
+        #expect(approval.fromAgentId == "builder")
+        #expect(approval.toAgentId == "ceo")
+        #expect(approval.speechText == "Approval requested")
+        #expect(builder.action == .walking)
+        #expect(builder.speechText == "Approval requested")
+        #expect(ceo.speechText == "Reviewing approval")
+        #expect(state.issueCards.first { $0.id == "issue-approval" }?.interaction?.kind == .ceoApprovalRequested)
+    }
+
+    @Test
+    func messageKindsMapToRuntimeFloorInteractions() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [
+                agent(id: "ceo", title: "CEO"),
+                agent(id: "builder", title: "Builder"),
+                agent(id: "qa", title: "QA"),
+            ],
+            issues: [issue(id: "issue-1", title: "Coordinate work", status: "IN_PROGRESS", assigneeProfileId: "builder")],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: [
+                message(id: "handoff", from: "Builder", to: "QA", issueId: "issue-1", body: "handoff", kind: "handoff"),
+                message(id: "escalation", from: "Builder", to: nil, issueId: "issue-1", body: "blocked", kind: "escalation"),
+                message(id: "feedback", from: "QA", to: "Builder", issueId: "issue-1", body: "feedback", kind: "feedback"),
+                message(id: "review-request", from: "Builder", to: "QA", issueId: "issue-1", body: "review", kind: "review.request"),
+            ]
+        )
+
+        #expect(projection.interactions.contains { $0.kind == .handoff && $0.messageId == "handoff" })
+        #expect(projection.interactions.contains { $0.kind == .blockedEscalation && $0.messageId == "escalation" })
+        #expect(projection.interactions.contains { $0.kind == .meeting && $0.messageId == "feedback" })
+        #expect(projection.interactions.contains { $0.kind == .qaReviewRequested && $0.messageId == "review-request" })
+    }
+
+    @Test
+    func goalDecisionAssignmentsCreatePlanningMeetingInteraction() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [
+                agent(id: "ceo", title: "CEO"),
+                agent(id: "builder", title: "Builder"),
+                agent(id: "ux", title: "UX"),
+            ],
+            goals: [goal(id: "goal", title: "Ship feature")],
+            goalDecisions: [
+                decision(id: "decision-1", assignments: ["Build API -> Builder", "Sketch flow -> UX"], issueId: "issue-1")
+            ],
+            issues: [issue(id: "issue-1", title: "Build API", status: "PLANNED", assigneeProfileId: "builder")],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: []
+        )
+        let meeting = try #require(projection.interactions.first { $0.kind == .meeting && $0.id == "meeting-decision-1" })
+        let state = sceneState(projection)
+
+        #expect(meeting.participantAgentIds.contains("ceo"))
+        #expect(meeting.participantAgentIds.contains("builder"))
+        #expect(meeting.participantAgentIds.contains("ux"))
+        #expect(state.agents.filter { $0.focusEvent?.id == "meeting-decision-1" }.count == 3)
+    }
+
+    @Test
+    func seenInteractionDoesNotReplayOnSceneReentry() throws {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: [
+                agent(id: "builder", title: "Builder"),
+                agent(id: "qa", title: "QA"),
+            ],
+            issues: [issue(id: "issue-1", title: "Coordinate work", status: "IN_PROGRESS", assigneeProfileId: "builder")],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: [
+                message(id: "msg-1", from: "Builder", to: "QA", issueId: "issue-1", body: "Please review.")
+            ]
+        )
+        let firstEntry = sceneState(projection)
+        let secondEntry = sceneState(projection, ledger: firstEntry.nextLedger)
+
+        #expect(firstEntry.shouldAnimate)
+        #expect(firstEntry.agents.first { $0.id == "builder" }?.action == .walking)
+        #expect(!secondEntry.shouldAnimate)
+        #expect(secondEntry.agents.first { $0.id == "builder" }?.action != .walking)
+        #expect(secondEntry.frameInterval == 1.0)
+    }
+
+    @Test
     func renderPlanUsesSimplifiedAtTwentyAndGroupedAtFiftyAgents() {
         let twentyProjection = MeetingRoomProjection.build(
             companyId: "company",
@@ -554,6 +673,28 @@ struct MeetingRoomProjectionTests {
         #expect(fifty.renderPlan.hiddenAgentCount == 38)
         #expect(!fifty.shouldAnimate)
     }
+
+    @Test
+    func groupedModeKeepsActiveInteractionParticipantsVisible() {
+        let projection = MeetingRoomProjection.build(
+            companyId: "company",
+            agents: (0..<50).map { agent(id: "agent-\($0)", title: "Agent \($0)") },
+            issues: [],
+            runningSessions: [],
+            reviewQueue: [],
+            runtime: runtime(status: "RUNNING"),
+            activity: [],
+            messages: [
+                message(id: "late-handoff", from: "Agent 49", to: "Agent 48", issueId: nil, body: "Need a sync.")
+            ]
+        )
+        let state = sceneState(projection)
+
+        #expect(state.renderPlan.mode == .grouped)
+        #expect(state.agents.contains { $0.id == "agent-49" })
+        #expect(state.agents.contains { $0.id == "agent-48" })
+        #expect(!state.shouldAnimate)
+    }
 }
 
 private func sceneState(
@@ -561,14 +702,16 @@ private func sceneState(
     isCompact: Bool = false,
     reduceMotion: Bool = false,
     lowResourceMode: Bool = false,
-    isSceneActive: Bool = true
+    isSceneActive: Bool = true,
+    ledger: MeetingRoomSceneLedger = .empty
 ) -> MeetingRoomSceneState {
     let plan = MeetingRoomRenderPlan.build(
         projection: projection,
         isCompact: isCompact,
         reduceMotion: reduceMotion,
         lowResourceMode: lowResourceMode,
-        isSceneActive: isSceneActive
+        isSceneActive: isSceneActive,
+        seenEventIds: ledger.seenEventIds
     )
     let layout = PixelOfficeLayout(size: CGSize(width: 1000, height: 640), isCompact: isCompact, mode: plan.mode)
     return MeetingRoomSceneReducer.reduce(
@@ -579,6 +722,7 @@ private func sceneState(
         reduceMotion: reduceMotion,
         lowResourceMode: lowResourceMode,
         isSceneActive: isSceneActive,
+        ledger: ledger,
         now: 100
     )
 }
@@ -617,6 +761,21 @@ private func goal(id: String, title: String) -> GoalRecord {
         autonomyEnabled: true,
         createdAt: 0,
         updatedAt: 1
+    )
+}
+
+private func decision(id: String, assignments: [String], issueId: String? = nil) -> GoalOrchestrationDecisionRecord {
+    GoalOrchestrationDecisionRecord(
+        id: id,
+        companyId: "company",
+        goalId: "goal",
+        issueId: issueId,
+        title: "Planning sync",
+        summary: "CEO planned assigned work.",
+        createdIssues: [],
+        assignments: assignments,
+        escalations: [],
+        createdAt: 20
     )
 }
 
@@ -709,7 +868,8 @@ private func review(
     checksSummary: String? = nil,
     mergeability: String? = nil,
     qaVerdict: String? = nil,
-    ceoVerdict: String? = nil
+    ceoVerdict: String? = nil,
+    approvalIssueId: String? = nil
 ) -> ReviewQueueItemRecord {
     ReviewQueueItemRecord(
         id: "review-\(issueId)",
@@ -733,7 +893,7 @@ private func review(
         ceoVerdict: ceoVerdict,
         ceoFeedback: nil,
         ceoReviewedAt: nil,
-        approvalIssueId: nil,
+        approvalIssueId: approvalIssueId,
         mergeCommitSha: nil,
         mergedAt: nil,
         createdAt: 0,
@@ -741,7 +901,7 @@ private func review(
     )
 }
 
-private func message(id: String, from: String, to: String?, issueId: String?, body: String) -> AgentMessageRecord {
+private func message(id: String, from: String, to: String?, issueId: String?, body: String, kind: String = "handoff") -> AgentMessageRecord {
     AgentMessageRecord(
         id: id,
         companyId: "company",
@@ -749,7 +909,7 @@ private func message(id: String, from: String, to: String?, issueId: String?, bo
         toAgentName: to,
         issueId: issueId,
         goalId: "goal",
-        kind: "handoff",
+        kind: kind,
         subject: "A2A handoff",
         body: body,
         status: "SENT",


### PR DESCRIPTION
## Summary

- Reworks the Meeting Room projection around explicit `MeetingRoomInteractionEvent` records instead of making moving flow capsules/envelopes the primary animation surface.
- Maps existing dashboard snapshot data into semantic live-office events: work start, handoff, feedback meeting, QA review, CEO approval, changes requested, blocker escalation, merge completion, cost pause, and planning assignment meetings.
- Updates the Swift scene reducer and pixel office renderer so agents walk, talk, listen, review, approve, type, or gather around meeting zones while issue cards move to the relevant desk/inbox.
- Adds per-company scene ledger memory so already-seen runtime events settle and do not replay from the beginning when the Meeting Room view is reopened.
- Keeps old `flows` available for detail/legacy support while demoting envelope/capsule motion to subtle secondary route traces.

## Why

The previous Meeting Room looked like runtime state was represented by floating message capsules rather than by agents actually working together. This change keeps the cute pixel office direction but makes the runtime floor read as live operational behavior: agents move to each other, speech bubbles explain the action, and issue cards land at the right desk or queue.

## Impact

- No new backend API is required; the implementation interprets existing snapshot fields in Swift.
- `CompanyRuntimeSnapshotRecord` additively decodes `pendingApprovalRunIds` and `reviewQueueAttentionIds` for more accurate approval/review mapping.
- Reduced-motion, low-resource, background, and seen-event states avoid scheduler-driven movement.
- 20/50 agent modes prioritize active event participants so the important actors remain visible.

## Validation

- `swift test --package-path macos --filter MeetingRoomProjectionTests`
- `swift test --package-path macos`
- `swift build --package-path macos`
- `./gradlew test`
- `git diff --check`
- `graphify update .` was run, but the tool refused to overwrite `graphify-out/graph.json` because the rebuilt AST graph had fewer nodes than the existing graph and the installed CLI exposes no working force flag. No graphify output files were changed.

## Manual validation

Desktop GUI smoke validation was not run in this session.