### PR TITLE
fix(ui): clean up agent skill card status display — replace raw enum chips with Korean summary labels

### DIFF
--- a/macos/Sources/CotorDesktopApp/AgentSkillCards.swift
+++ b/macos/Sources/CotorDesktopApp/AgentSkillCards.swift
@@ -46,6 +46,15 @@ enum AgentSkillPolicy: String, CaseIterable, Identifiable, Hashable {
     case disabled = "DISABLED"
 
     var id: String { rawValue }
+
+    func label(_ language: AppLanguage) -> String {
+        switch self {
+        case .auto: return language("Auto", "자동 실행")
+        case .approvalRequired: return language("Approval Required", "확인 후 실행")
+        case .readOnly: return language("Read Only", "읽기 전용")
+        case .disabled: return language("Disabled", "비활성")
+        }
+    }
 }
 
 struct AgentSkillCardRecord: Identifiable, Hashable {
@@ -59,6 +68,7 @@ struct AgentSkillCardRecord: Identifiable, Hashable {
     let selectedSkills: [AgentSkillChipRecord]
     let capabilityScopes: [AgentSkillScope]
     let policyChips: [AgentSkillPolicy]
+    let hasDisabledCapabilities: Bool
 
     init(
         agent: CompanyAgentDefinitionRecord,
@@ -113,19 +123,20 @@ struct AgentSkillCardRecord: Identifiable, Hashable {
         capabilityScopes = scopes
 
         var policies = Set<AgentSkillPolicy>()
-        if !agent.enabled {
-            policies.insert(.disabled)
-        }
+        var disabledCapabilitiesFound = false
         if let skillRun = settings["SKILL_RUN"] {
-            policies.insert(Self.policy(for: skillRun))
+            let p = Self.policy(for: skillRun)
+            if p == .disabled { disabledCapabilitiesFound = true } else { policies.insert(p) }
         }
         for (capability, setting) in settings {
             let normalized = Self.normalizedCapability(capability)
             guard activeCapabilityKeys.contains(normalized), !["SKILL_RUN"].contains(normalized) else { continue }
             guard !Self.scopes(forCapability: normalized).isEmpty else { continue }
-            policies.insert(Self.policy(for: setting))
+            let p = Self.policy(for: setting)
+            if p == .disabled { disabledCapabilitiesFound = true } else { policies.insert(p) }
         }
         policyChips = AgentSkillPolicy.allCases.filter { policies.contains($0) }
+        hasDisabledCapabilities = agent.enabled && disabledCapabilitiesFound
     }
 
     private static func selectedSkillIDs(

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -3883,7 +3883,11 @@ private struct AgentSkillCardView: View {
     }
 
     private var policyTags: [(String, Color)] {
-        card.policyChips.map { ($0.rawValue, policyTint($0)) }
+        var tags = card.policyChips.map { ($0.label(language), policyTint($0)) }
+        if card.hasDisabledCapabilities {
+            tags.append((language("Some off", "일부 권한 꺼짐"), ShellPalette.muted))
+        }
+        return tags
     }
 
     private func compactTags(_ tags: [(String, Color)]) -> some View {

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -1069,8 +1069,33 @@ struct DesktopStoreTests {
         let card = AgentSkillCardRecord(agent: agent, profile: profile, skillCatalog: [])
 
         #expect(!card.enabled)
-        #expect(card.policyChips.contains(.disabled))
+        #expect(!card.policyChips.contains(.disabled))
+        #expect(!card.hasDisabledCapabilities)
         #expect(card.capabilityScopes.contains(.qaReview))
+    }
+
+    @Test
+    func agentSkillCardShowsHasDisabledCapabilitiesForEnabledAgentWithRestrictedCapability() {
+        let agent = agentDefinition(id: "agent-restricted", title: "Restricted", roleSummary: "marketing")
+        let profile = capabilityProfile(agentId: agent.id, settings: [
+            "SKILL_RUN": AgentCapabilitySettingRecord(
+                enabled: true,
+                mode: "AUTO",
+                skillAllowlist: ["marketing-operator"]
+            ),
+            "WEB_PUBLISH": AgentCapabilitySettingRecord(enabled: true, mode: "DISABLED"),
+        ])
+        let card = AgentSkillCardRecord(
+            agent: agent,
+            profile: profile,
+            skillCatalog: [
+                skillEntry(name: "marketing-operator", displayName: "Marketing Operator", requiredCapabilities: ["WEB_PUBLISH"])
+            ]
+        )
+
+        #expect(card.enabled)
+        #expect(!card.policyChips.contains(.disabled))
+        #expect(card.hasDisabledCapabilities)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Raw policy enum strings removed** from the agent skill card default view — `DISABLED`, `AUTO`, `APPROVAL_REQUIRED`, `READ_ONLY` no longer appear as chips
- **User-facing Korean labels** introduced via `AgentSkillPolicy.label(_:)`: `자동 실행`, `확인 후 실행`, `읽기 전용`
- **`일부 권한 꺼짐` neutral chip** (ShellPalette.muted, not red) surfaces when an *enabled* agent has one or more capability-level DISABLED restrictions — clearly distinct from the agent being `비활성`
- **`hasDisabledCapabilities: Bool`** added to `AgentSkillCardRecord`; `false` when the agent itself is disabled so a redundant chip doesn't appear alongside the warning border
- Agent-level `enabled=false` state is already rendered via the dot indicator and border colour on the card; `.disabled` no longer pollutes `policyChips`

## Test plan

- [x] `swift build --package-path macos` — clean build, no warnings
- [x] `swift test --package-path macos` — 83/83 tests pass
- [x] `agentSkillCardMarksDisabledAgent` updated: asserts `!policyChips.contains(.disabled)` and `!hasDisabledCapabilities`
- [x] New test `agentSkillCardShowsHasDisabledCapabilitiesForEnabledAgentWithRestrictedCapability`: enabled agent with DISABLED capability → `hasDisabledCapabilities = true`, no raw `.disabled` in chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)