### PR TITLE
[codex] Add grounded operator chat and fix CEO planning retries

### DIFF
--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -232,6 +232,24 @@ struct DesktopAPI {
         )
     }
 
+    func runOperatorChat(
+        companyId: String,
+        message: String,
+        automationMode: String? = nil,
+        confirmFullAuto: Bool = false,
+        confirmStaffing: Bool = false
+    ) async throws -> OperatorChatResponsePayload {
+        try await post(
+            path: "api/app/companies/\(companyId)/operator/chat",
+            body: OperatorCommandRequestPayload(
+                message: message,
+                automationMode: automationMode,
+                confirmFullAuto: confirmFullAuto,
+                confirmStaffing: confirmStaffing
+            )
+        )
+    }
+
     func skills() async throws -> [SkillCatalogEntryRecord] {
         try await get(path: "api/app/skills")
     }

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -3131,6 +3131,37 @@ final class DesktopStore: ObservableObject {
         }
     }
 
+    func runCompanyOperatorChat(
+        message: String,
+        automationMode: String? = nil,
+        confirmFullAuto: Bool = false,
+        confirmStaffing: Bool = false
+    ) async -> OperatorChatResponsePayload? {
+        guard let company = selectedCompany else { return nil }
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        do {
+            actionErrorMessage = nil
+            errorMessage = nil
+            let response = try await runWithEmbeddedBackendRecovery {
+                try await api.runOperatorChat(
+                    companyId: company.id,
+                    message: trimmed,
+                    automationMode: automationMode,
+                    confirmFullAuto: confirmFullAuto,
+                    confirmStaffing: confirmStaffing
+                )
+            }
+            await refreshDashboard(restartEventStream: false)
+            await loadSelectedCompanyMemorySnapshot()
+            return response
+        } catch {
+            actionErrorMessage = error.localizedDescription
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
     func setSelectedCompanyOperatorAutomationMode(_ mode: String, confirmFullAuto: Bool = false) async {
         guard let company = selectedCompany else { return }
         let response = await runCompanyOperatorCommand(
@@ -3434,7 +3465,7 @@ final class DesktopStore: ObservableObject {
             return companyLinearStatusMessage ?? language("Saved Linear settings.", "Linear 설정을 저장했습니다.")
         }
 
-        return await runOperatorCommandAsChatReply(message: message)
+        return await runOperatorChatAsChatReply(message: message)
     }
 
     private func runOperatorCommandAsChatReply(
@@ -3454,7 +3485,33 @@ final class DesktopStore: ObservableObject {
         return operatorAssistantText(for: response)
     }
 
+    private func runOperatorChatAsChatReply(message: String) async -> String {
+        guard let response = await runCompanyOperatorChat(message: message) else {
+            if let commandResponse = await runCompanyOperatorCommand(message: message) {
+                return operatorAssistantText(for: commandResponse)
+            }
+            return operatorFailureFallback()
+        }
+        return operatorAssistantText(for: response)
+    }
+
     private func operatorAssistantText(for response: OperatorCommandResponsePayload) -> String {
+        let blocked = response.blockedActions.map { operatorActionText($0) }
+        if !blocked.isEmpty {
+            return blocked.joined(separator: "\n")
+        }
+        let pending = response.pendingApprovals.map { operatorActionText($0) }
+        if !pending.isEmpty {
+            return language("Sent this to internal approval.", "내부 승인으로 보냈습니다.") + "\n" + pending.joined(separator: "\n")
+        }
+        let actions = response.actions.map { operatorActionText($0) }
+        if !actions.isEmpty {
+            return actions.joined(separator: "\n")
+        }
+        return sanitizeOperatorUserText(response.message, language: language)
+    }
+
+    private func operatorAssistantText(for response: OperatorChatResponsePayload) -> String {
         let blocked = response.blockedActions.map { operatorActionText($0) }
         if !blocked.isEmpty {
             return blocked.joined(separator: "\n")

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -575,6 +575,27 @@ struct OperatorCommandResponsePayload: Codable, Hashable, Identifiable {
     let summary: OperatorCompanySummaryPayload?
 }
 
+struct OperatorAnswerSourcePayload: Codable, Hashable, Identifiable {
+    var id: String { "\(type)-\(title)-\(refId ?? "")-\(detail ?? "")" }
+
+    let type: String
+    let title: String
+    let detail: String?
+    let refId: String?
+}
+
+struct OperatorChatResponsePayload: Codable, Hashable, Identifiable {
+    var id: String { "\(message)-\(automationMode)-\(actions.count)-\(pendingApprovals.count)-\(blockedActions.count)-\(answerSources.count)" }
+
+    let message: String
+    let automationMode: String
+    let actions: [OperatorCommandActionPayload]
+    let pendingApprovals: [OperatorCommandActionPayload]
+    let blockedActions: [OperatorCommandActionPayload]
+    let summary: OperatorCompanySummaryPayload?
+    let answerSources: [OperatorAnswerSourcePayload]
+}
+
 /// User-authored task record shown in the center pane.
 struct TaskRecord: Codable, Identifiable, Hashable {
     let id: String

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -318,14 +318,14 @@ struct DesktopStoreTests {
                 availableAgents: ["opencode", "codex"],
                 availableCliAgents: ["opencode", "codex", "gemma4", "ollama", "lmstudio"],
                 availableAgentModels: [
-                    "opencode": ["opencode/big-pickle", "opencode-go/deepseek-v4-flash"],
+                    "opencode": ["opencode/big-pickle", "opencode/nemotron-3-super-free"],
                     "codex": ["openai/gpt-5.5"],
                     "gemma4": ["gemma4:e2b"],
                     "ollama": ["gemma4:e2b"],
                     "lmstudio": ["gemma4:e2b"]
                 ],
                 defaultAgentModels: [
-                    "opencode": "opencode-go/deepseek-v4-flash",
+                    "opencode": "opencode/nemotron-3-super-free",
                     "codex": "openai/gpt-5.5",
                     "gemma4": "gemma4:e2b",
                     "ollama": "gemma4:e2b",
@@ -360,7 +360,7 @@ struct DesktopStoreTests {
         )
 
         store.selectNewCompanyAgentCli("opencode")
-        #expect(store.newCompanyAgentModel == "opencode-go/deepseek-v4-flash")
+        #expect(store.newCompanyAgentModel == "opencode/nemotron-3-super-free")
 
         store.selectNewCompanyAgentCli("codex")
         #expect(store.newCompanyAgentModel == "openai/gpt-5.5")
@@ -386,10 +386,10 @@ struct DesktopStoreTests {
                 availableAgents: ["opencode"],
                 availableCliAgents: ["opencode"],
                 availableAgentModels: [
-                    "opencode": ["opencode-go/deepseek-v4-flash"]
+                    "opencode": ["opencode/nemotron-3-super-free"]
                 ],
                 defaultAgentModels: [
-                    "opencode": "opencode-go/deepseek-v4-flash"
+                    "opencode": "opencode/nemotron-3-super-free"
                 ],
                 recentCompanies: baseSettings.recentCompanies,
                 defaultLaunchMode: baseSettings.defaultLaunchMode,
@@ -422,7 +422,7 @@ struct DesktopStoreTests {
         store.newCompanyAgentCli = ""
 
         #expect(store.resolvedNewCompanyAgentCli == "opencode")
-        #expect(store.newCompanyAgentModelOptions == ["opencode-go/deepseek-v4-flash"])
+        #expect(store.newCompanyAgentModelOptions == ["opencode/nemotron-3-super-free"])
     }
 
     @Test
@@ -626,13 +626,13 @@ struct DesktopStoreTests {
     func batchEditPayloadKeepsExplicitModelAndCapabilities() {
         let payload = OrgProfileBatchEditPayloadDraft.build(
             batchAgent: "opencode",
-            batchModel: " opencode-go/deepseek-v4-flash ",
+            batchModel: " opencode/nemotron-3-super-free ",
             batchCapabilities: "qa, review, , deploy",
             batchEnabled: false
         )
 
         #expect(payload.agentCli == "opencode")
-        #expect(payload.model == "opencode-go/deepseek-v4-flash")
+        #expect(payload.model == "opencode/nemotron-3-super-free")
         #expect(payload.specialties == ["qa", "review", "deploy"])
         #expect(payload.enabled == false)
     }

--- a/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
@@ -328,6 +328,43 @@ struct ModelsTests {
     }
 
     @Test
+    func operatorChatResponseDecodesAnswerSources() throws {
+        let json = """
+        {
+          "message": "Builder가 현재 가장 좋은 에이전트입니다.",
+          "automationMode": "AGENT_APPROVED",
+          "actions": [],
+          "pendingApprovals": [],
+          "blockedActions": [],
+          "summary": {
+            "runtimeStatus": "STOPPED",
+            "backendHealth": "healthy",
+            "activeAgentCount": 0,
+            "blockedIssueCount": 0,
+            "reviewQueueCount": 0,
+            "pendingApprovalCount": 0,
+            "budgetPaused": false
+          },
+          "answerSources": [
+            {
+              "type": "agent-performance",
+              "title": "Builder · Builder",
+              "detail": "score=91",
+              "refId": "agent-builder"
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(OperatorChatResponsePayload.self, from: json)
+
+        #expect(response.message.contains("Builder"))
+        #expect(response.summary?.runtimeStatus == "STOPPED")
+        #expect(response.answerSources.first?.type == "agent-performance")
+        #expect(response.answerSources.first?.refId == "agent-builder")
+    }
+
+    @Test
     func batchUpdatePayloadEncodesSelectedFields() throws {
         let payload = BatchUpdateCompanyAgentsPayload(
             agentIds: ["agent-1", "agent-2"],

--- a/src/main/kotlin/com/cotor/app/AppApiModels.kt
+++ b/src/main/kotlin/com/cotor/app/AppApiModels.kt
@@ -136,6 +136,25 @@ data class OperatorCommandResponse(
 )
 
 @Serializable
+data class OperatorAnswerSource(
+    val type: String,
+    val title: String,
+    val detail: String? = null,
+    val refId: String? = null
+)
+
+@Serializable
+data class OperatorChatResponse(
+    val message: String,
+    val automationMode: OperatorAutomationMode,
+    val actions: List<OperatorCommandAction> = emptyList(),
+    val pendingApprovals: List<OperatorCommandAction> = emptyList(),
+    val blockedActions: List<OperatorCommandAction> = emptyList(),
+    val summary: OperatorCompanySummary? = null,
+    val answerSources: List<OperatorAnswerSource> = emptyList()
+)
+
+@Serializable
 data class UpdateGoalRequest(
     val title: String? = null,
     val description: String? = null,

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -1596,6 +1596,24 @@ internal fun Application.cotorAppModule(
                     }
                 }
 
+                route("/{companyId}/operator/chat") {
+                    post {
+                        if (!requireToken(token)) return@post
+                        val companyId = call.parameters["companyId"]
+                            ?: return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
+                        val request = call.receive<OperatorCommandRequest>()
+                        respondDesktopRequest {
+                            desktopService.runOperatorChat(
+                                companyId = companyId,
+                                message = request.message,
+                                automationMode = request.automationMode,
+                                confirmFullAuto = request.confirmFullAuto,
+                                confirmStaffing = request.confirmStaffing
+                            )
+                        }
+                    }
+                }
+
                 route("/{companyId}/issues") {
                     get {
                         if (!requireToken(token)) return@get

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -4826,6 +4826,292 @@ class DesktopAppService(
         return response
     }
 
+    suspend fun runOperatorChat(
+        companyId: String,
+        message: String,
+        automationMode: OperatorAutomationMode? = null,
+        confirmFullAuto: Boolean = false,
+        confirmStaffing: Boolean = false
+    ): OperatorChatResponse {
+        val trimmedMessage = message.trim()
+        require(trimmedMessage.isNotBlank()) { "message is required" }
+        val normalized = trimmedMessage.lowercase()
+
+        detectHardGateOperatorAction(normalized)?.let { blocked ->
+            val response = OperatorChatResponse(
+                message = blocked.detail,
+                automationMode = currentOperatorAutomationMode(companyId),
+                blockedActions = listOf(blocked),
+                summary = buildOperatorCompanySummary(companyId),
+                answerSources = listOf(
+                    OperatorAnswerSource(
+                        type = "safety-policy",
+                        title = "Operator hard gate",
+                        detail = blocked.title
+                    )
+                )
+            )
+            recordOperatorChatConversation(companyId, trimmedMessage, response)
+            return response
+        }
+
+        if (
+            automationMode != null ||
+            confirmFullAuto ||
+            confirmStaffing ||
+            looksLikeDeterministicOperatorCommand(normalized)
+        ) {
+            return runOperatorCommand(
+                companyId = companyId,
+                message = trimmedMessage,
+                automationMode = automationMode,
+                confirmFullAuto = confirmFullAuto,
+                confirmStaffing = confirmStaffing
+            ).toOperatorChatResponse()
+        }
+
+        val answer = buildGroundedOperatorChatAnswer(companyId, trimmedMessage, normalized)
+        val response = OperatorChatResponse(
+            message = answer.message,
+            automationMode = currentOperatorAutomationMode(companyId),
+            summary = buildOperatorCompanySummary(companyId),
+            answerSources = answer.sources
+        )
+        recordOperatorChatConversation(companyId, trimmedMessage, response)
+        return response
+    }
+
+    private data class GroundedOperatorAnswer(
+        val message: String,
+        val sources: List<OperatorAnswerSource> = emptyList()
+    )
+
+    private fun OperatorCommandResponse.toOperatorChatResponse(
+        answerSources: List<OperatorAnswerSource> = emptyList()
+    ): OperatorChatResponse = OperatorChatResponse(
+        message = message,
+        automationMode = automationMode,
+        actions = actions,
+        pendingApprovals = pendingApprovals,
+        blockedActions = blockedActions,
+        summary = summary,
+        answerSources = answerSources
+    )
+
+    private suspend fun buildGroundedOperatorChatAnswer(
+        companyId: String,
+        message: String,
+        normalized: String
+    ): GroundedOperatorAnswer {
+        val state = stateStore.load().withDerivedMetrics()
+        val company = state.companies.firstOrNull { it.id == companyId }
+            ?: throw IllegalArgumentException("Company not found: $companyId")
+        val orgProfiles = ensureOrgProfiles(state.orgProfiles, state.companyAgentDefinitions, state.companies)
+        val performance = computeAgentPerformance(state, companyId, orgProfiles)
+        val companyIssues = state.issues.filter { it.companyId == companyId }
+        val companyIssueIds = companyIssues.mapTo(linkedSetOf()) { it.id }
+        val companyTasks = state.tasks.filter { task -> task.issueId == null || task.issueId in companyIssueIds }
+        val companyTaskIds = companyTasks.mapTo(linkedSetOf()) { it.id }
+        val companyRuns = state.runs.filter { it.taskId in companyTaskIds }
+        val companyReviews = state.reviewQueue.filter { it.companyId == companyId || it.issueId in companyIssueIds }
+        val companyActivity = state.companyActivity.filter { it.companyId == companyId }
+        val summary = buildOperatorCompanySummary(companyId)
+        val korean = prefersKoreanOperatorAnswer(message)
+
+        return when {
+            looksLikePerformanceQuestion(normalized) ->
+                buildOperatorPerformanceAnswer(performance, companyIssues, companyRuns, companyReviews, korean)
+            looksLikeBlockedQuestion(normalized) ->
+                buildOperatorBlockedAnswer(companyIssues, companyActivity, korean)
+            looksLikeApprovalOrReviewQuestion(normalized) ->
+                buildOperatorReviewAnswer(companyReviews, companyIssues, korean)
+            looksLikeRuntimeQuestion(normalized) ->
+                buildOperatorRuntimeAnswer(summary, companyRuns, korean)
+            else ->
+                buildOperatorGeneralAnswer(company, summary, performance, companyIssues, companyActivity, korean)
+        }
+    }
+
+    private fun buildOperatorPerformanceAnswer(
+        performance: List<AgentPerformanceSnapshot>,
+        issues: List<CompanyIssue>,
+        runs: List<AgentRun>,
+        reviews: List<ReviewQueueItem>,
+        korean: Boolean
+    ): GroundedOperatorAnswer {
+        val ranked = performance.sortedWith(
+            compareByDescending<AgentPerformanceSnapshot> { it.score ?: -1 }
+                .thenByDescending { it.completedIssues }
+                .thenBy { it.blockedIssues }
+                .thenBy { it.retryCount }
+        )
+        val best = ranked.firstOrNull()
+            ?: return GroundedOperatorAnswer(
+                message = if (korean) {
+                    "아직 인사평가에 쓸 에이전트 실행 데이터가 없습니다. 이슈 실행, 리뷰, QA 결과가 쌓이면 성과 순위를 답할 수 있습니다."
+                } else {
+                    "There is not enough agent performance data yet. Once issues, runs, and review outcomes exist, I can rank the team."
+                },
+                sources = listOf(
+                    OperatorAnswerSource(
+                        type = "agent-performance",
+                        title = "No scoreable agent performance",
+                        detail = "issues=${issues.size}, runs=${runs.size}, reviews=${reviews.size}"
+                    )
+                )
+            )
+
+        val scoreText = best.score?.let { "${it}점" } ?: if (korean) "점수 산정 전" else "not scored yet"
+        val successText = best.runSuccessRate?.let { "${(it * 100).toInt()}%" } ?: if (korean) "데이터 부족" else "insufficient data"
+        val qaText = best.qaPassRate?.let { "${(it * 100).toInt()}%" } ?: if (korean) "데이터 부족" else "insufficient data"
+        val message = if (korean) {
+            buildString {
+                append("${best.agentName}(${best.roleName})가 현재 가장 좋은 에이전트입니다. ")
+                append("성과 점수는 $scoreText, 완료 이슈 ${best.completedIssues}개, 실행 성공률 $successText, QA 통과율 ${qaText}입니다.")
+                if (best.blockedIssues > 0) append(" 다만 막힌 이슈 ${best.blockedIssues}개가 있어 다음 평가에서 감점 요인이 됩니다.")
+                if (best.retryCount > 0) append(" 재시도는 ${best.retryCount}회 기록됐습니다.")
+            }
+        } else {
+            buildString {
+                append("${best.agentName} (${best.roleName}) is currently the strongest agent. ")
+                append("Score: ${best.score ?: "not scored"}, completed issues: ${best.completedIssues}, run success: $successText, QA pass: $qaText.")
+                if (best.blockedIssues > 0) append(" ${best.blockedIssues} blocked issue(s) still weigh against that score.")
+                if (best.retryCount > 0) append(" Retry count: ${best.retryCount}.")
+            }
+        }
+        val sources = ranked.take(3).map { snapshot ->
+            OperatorAnswerSource(
+                type = "agent-performance",
+                title = "${snapshot.agentName} · ${snapshot.roleName}",
+                detail = "score=${snapshot.score ?: "n/a"}, completed=${snapshot.completedIssues}, active=${snapshot.activeIssues}, blocked=${snapshot.blockedIssues}, runSuccess=${snapshot.runSuccessRate ?: "n/a"}, qaPass=${snapshot.qaPassRate ?: "n/a"}",
+                refId = snapshot.agentId
+            )
+        } + OperatorAnswerSource(
+            type = "runtime-scope",
+            title = "Performance evidence scope",
+            detail = "issues=${issues.size}, runs=${runs.size}, reviews=${reviews.size}"
+        )
+        return GroundedOperatorAnswer(message = message, sources = sources)
+    }
+
+    private fun buildOperatorBlockedAnswer(
+        issues: List<CompanyIssue>,
+        activity: List<CompanyActivityItem>,
+        korean: Boolean
+    ): GroundedOperatorAnswer {
+        val blocked = issues.filter { it.status == IssueStatus.BLOCKED }.sortedByDescending { it.updatedAt }
+        if (blocked.isEmpty()) {
+            return GroundedOperatorAnswer(
+                message = if (korean) {
+                    "현재 막힌 이슈는 없습니다. 최근 활동 기준으로 차단 상태가 새로 쌓이지 않았습니다."
+                } else {
+                    "There are no blocked issues right now."
+                },
+                sources = activity.take(3).map {
+                    OperatorAnswerSource("activity", it.title, it.detail, it.id)
+                }
+            )
+        }
+        val lead = blocked.first()
+        val reason = humanizeOperatorBlockReason(lead.transitionReason ?: lead.providerBlockReason)
+        val message = if (korean) {
+            "현재 ${blocked.size}개 이슈가 막혀 있습니다. 가장 최근 항목은 \"${lead.title}\"이고, 원인은 $reason 입니다."
+        } else {
+            "${blocked.size} issue(s) are blocked. The most recent is \"${lead.title}\"; reason: $reason."
+        }
+        val sources = blocked.take(5).map { issue ->
+            OperatorAnswerSource(
+                type = "issue",
+                title = issue.title,
+                detail = humanizeOperatorBlockReason(issue.transitionReason ?: issue.providerBlockReason),
+                refId = issue.id
+            )
+        } + activity.filter { it.title.contains("blocked", ignoreCase = true) || it.severity == "error" }
+            .take(3)
+            .map { OperatorAnswerSource("activity", it.title, humanizeOperatorBlockReason(it.detail), it.id) }
+        return GroundedOperatorAnswer(message = message, sources = sources)
+    }
+
+    private fun buildOperatorReviewAnswer(
+        reviews: List<ReviewQueueItem>,
+        issues: List<CompanyIssue>,
+        korean: Boolean
+    ): GroundedOperatorAnswer {
+        val attention = reviews.filter { it.status != ReviewQueueStatus.MERGED }.sortedByDescending { it.updatedAt }
+        val ceoReady = attention.count { it.status == ReviewQueueStatus.READY_FOR_CEO || it.status == ReviewQueueStatus.READY_TO_MERGE }
+        val qaReady = attention.count { it.status == ReviewQueueStatus.AWAITING_QA || it.status == ReviewQueueStatus.CHANGES_REQUESTED }
+        val message = if (korean) {
+            "리뷰 큐에는 처리할 항목 ${attention.size}개가 있습니다. CEO 승인 대기 ${ceoReady}개, QA/수정 확인 ${qaReady}개입니다."
+        } else {
+            "The review queue has ${attention.size} active item(s): $ceoReady waiting on CEO/merge approval and $qaReady in QA or changes-requested review."
+        }
+        val issueById = issues.associateBy { it.id }
+        val sources = attention.take(5).map { item ->
+            OperatorAnswerSource(
+                type = "review",
+                title = issueById[item.issueId]?.title ?: "Review ${item.id}",
+                detail = item.status.name,
+                refId = item.id
+            )
+        }
+        return GroundedOperatorAnswer(message = message, sources = sources)
+    }
+
+    private fun buildOperatorRuntimeAnswer(
+        summary: OperatorCompanySummary,
+        runs: List<AgentRun>,
+        korean: Boolean
+    ): GroundedOperatorAnswer {
+        val activeRuns = runs.filter { it.status == AgentRunStatus.RUNNING || it.status == AgentRunStatus.QUEUED }
+        val message = if (korean) {
+            "런타임은 ${summary.runtimeStatus} 상태입니다. 활성 에이전트 ${summary.activeAgentCount}개, 막힌 이슈 ${summary.blockedIssueCount}개, 승인 대기 ${summary.pendingApprovalCount}개입니다."
+        } else {
+            "Runtime status is ${summary.runtimeStatus}. Active agents: ${summary.activeAgentCount}, blocked issues: ${summary.blockedIssueCount}, pending approvals: ${summary.pendingApprovalCount}."
+        }
+        val sources = activeRuns.take(5).map { run ->
+            OperatorAnswerSource(
+                type = "run",
+                title = "${run.agentName} · ${run.status.name}",
+                detail = run.output?.take(180) ?: run.error?.take(180),
+                refId = run.id
+            )
+        }
+        return GroundedOperatorAnswer(message = message, sources = sources)
+    }
+
+    private fun buildOperatorGeneralAnswer(
+        company: Company,
+        summary: OperatorCompanySummary,
+        performance: List<AgentPerformanceSnapshot>,
+        issues: List<CompanyIssue>,
+        activity: List<CompanyActivityItem>,
+        korean: Boolean
+    ): GroundedOperatorAnswer {
+        val best = performance.firstOrNull { it.score != null }
+        val activeIssues = issues.count { it.status in setOf(IssueStatus.PLANNED, IssueStatus.DELEGATED, IssueStatus.IN_PROGRESS, IssueStatus.IN_REVIEW) }
+        val message = if (korean) {
+            buildString {
+                append("${company.name} 상태를 기준으로 답하면, 런타임은 ${summary.runtimeStatus}이고 활성 이슈는 ${activeIssues}개입니다. ")
+                append("막힌 이슈 ${summary.blockedIssueCount}개, 리뷰 ${summary.reviewQueueCount}개, 승인 대기 ${summary.pendingApprovalCount}개가 보입니다.")
+                best?.let { append(" 현재 성과 상위 에이전트는 ${it.agentName}(${it.roleName})입니다.") }
+            }
+        } else {
+            buildString {
+                append("${company.name} is ${summary.runtimeStatus}; active issues: $activeIssues. ")
+                append("Blocked issues: ${summary.blockedIssueCount}, review items: ${summary.reviewQueueCount}, pending approvals: ${summary.pendingApprovalCount}.")
+                best?.let { append(" Current top performer: ${it.agentName} (${it.roleName}).") }
+            }
+        }
+        val sources = buildList {
+            add(OperatorAnswerSource("company-summary", company.name, "runtime=${summary.runtimeStatus}, activeIssues=$activeIssues", company.id))
+            best?.let {
+                add(OperatorAnswerSource("agent-performance", "${it.agentName} · ${it.roleName}", "score=${it.score}", it.agentId))
+            }
+            activity.take(3).forEach { add(OperatorAnswerSource("activity", it.title, it.detail, it.id)) }
+        }
+        return GroundedOperatorAnswer(message = message, sources = sources)
+    }
+
     private data class OperatorModeUpdate(
         val mode: OperatorAutomationMode,
         val actions: List<OperatorCommandAction> = emptyList(),
@@ -5568,6 +5854,31 @@ class DesktopAppService(
         }
     }
 
+    private suspend fun recordOperatorChatConversation(
+        companyId: String,
+        request: String,
+        response: OperatorChatResponse
+    ) {
+        runCatching {
+            sendMessage(
+                companyId = companyId,
+                fromAgentName = "User",
+                toAgentName = "Company Operator",
+                kind = "operator-chat",
+                subject = "Operator question",
+                body = request
+            )
+            sendMessage(
+                companyId = companyId,
+                fromAgentName = "Company Operator",
+                toAgentName = null,
+                kind = "operator-answer",
+                subject = "Operator answer",
+                body = response.message
+            )
+        }
+    }
+
     private fun requestsFullAutoMode(text: String): Boolean =
         containsAny(text, "full_auto", "full auto", "풀오토", "완전 자동")
 
@@ -5601,6 +5912,57 @@ class DesktopAppService(
 
     private fun containsAny(text: String, vararg needles: String): Boolean =
         needles.any { text.contains(it) }
+
+    private fun looksLikeDeterministicOperatorCommand(text: String): Boolean =
+        requestsFullAutoMode(text) ||
+            looksLikeDeepSeekModelUpdate(text) ||
+            looksLikeHrStaffingRequest(text) ||
+            looksLikeRuntimeStart(text) ||
+            looksLikeRuntimeStop(text) ||
+            looksLikeBlockedIssueRetry(text) ||
+            looksLikeGitHubSync(text) ||
+            looksLikeLinearSync(text)
+
+    private fun looksLikePerformanceQuestion(text: String): Boolean =
+        containsAny(text, "인사평가", "성과", "performance", "평가", "제일 잘", "가장 좋", "최고", "best agent", "top agent")
+
+    private fun looksLikeBlockedQuestion(text: String): Boolean =
+        containsAny(text, "왜 막", "왜 blocked", "why blocked", "blocked", "블록", "막혔", "차단", "실패 원인")
+
+    private fun looksLikeApprovalOrReviewQuestion(text: String): Boolean =
+        containsAny(text, "review", "리뷰", "qa", "승인", "approval", "merge", "머지")
+
+    private fun looksLikeRuntimeQuestion(text: String): Boolean =
+        containsAny(text, "runtime", "런타임", "실행 중", "가동", "active agent", "활성 에이전트")
+
+    private fun prefersKoreanOperatorAnswer(message: String): Boolean =
+        message.any { ch -> ch in '\uAC00'..'\uD7A3' }
+
+    private fun humanizeOperatorBlockReason(reason: String?): String {
+        val text = reason?.trim().orEmpty()
+        if (text.isBlank()) {
+            return "No detailed reason was recorded."
+        }
+        val lower = text.lowercase()
+        return when {
+            isOpenCodeInterruptedBeforePlanningText(text) ->
+                "OpenCode was interrupted before producing planning text"
+            lower.contains(CEO_PLANNING_INVALID_OUTPUT.lowercase()) ->
+                "CEO planning did not produce a valid execution graph"
+            lower.contains("github publishing") ->
+                text.lineSequence().firstOrNull { it.isNotBlank() }?.take(240)
+                    ?: "GitHub publishing is not ready"
+            lower.contains("capability") && lower.contains("requires approval") ->
+                "A required execution capability is waiting for approval"
+            else -> text
+                .lineSequence()
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .take(3)
+                .joinToString(" ")
+                .take(300)
+        }
+    }
 
     private fun detectHardGateOperatorAction(text: String): OperatorCommandAction? {
         val title = when {
@@ -9415,6 +9777,19 @@ class DesktopAppService(
                     message.contains("invalid argument: [object object]")
                 )
 
+    private fun isOpenCodeInterruptedBeforePlanningText(message: String): Boolean {
+        val lower = message.lowercase()
+        val exit143 = lower.contains("exit=143") ||
+            lower.contains("exit 143") ||
+            lower.contains("exit code 143")
+        if (!exit143) {
+            return false
+        }
+        val stepStarted = lower.contains("step_start") || lower.contains("step-start")
+        val hasPlanningJson = lower.contains("```json") || lower.contains("\"issues\"")
+        return stepStarted && !hasPlanningJson
+    }
+
     private fun extractGitHubPublishReadinessFailureReason(
         task: AgentTask,
         issue: CompanyIssue,
@@ -9463,6 +9838,7 @@ class DesktopAppService(
                 message.contains(INTERRUPTED_RUN_ERROR.lowercase()) ||
                 (message.contains("pull request create failed") && isTransientGitHubPublishFailure(message)) ||
                 message.contains("submitted too quickly") ||
+                isOpenCodeInterruptedBeforePlanningText(message) ||
                 isRecoverableCodexExecutionConfigFailure(message) ||
                 isRecoverableCodexMcpBootstrapFailure(message) ||
                 isRecoverableOpenCodeCliFailure(message)
@@ -9475,6 +9851,7 @@ class DesktopAppService(
         }
         return failureSignals(task, run).any { message ->
             message.contains(INTERRUPTED_RUN_ERROR, ignoreCase = true) ||
+                isOpenCodeInterruptedBeforePlanningText(message) ||
                 CodexDefaults.isRetiredModelAliasFailure(message) ||
                 isOpenCodePromptFileArgumentOrderFailure(message)
         }
@@ -9599,7 +9976,7 @@ class DesktopAppService(
                     val recoverableRetryPending =
                         issue.status in setOf(IssueStatus.PLANNED, IssueStatus.BACKLOG, IssueStatus.DELEGATED) &&
                             retryDecision.canAutoRetry
-                    if (recoverableRetryPending) {
+                    if (recoverableRetryPending && !issue.kind.equals("planning", ignoreCase = true)) {
                         informationalTraceEvents += buildCompanyAutomationTraceEvent(
                             issue = issue,
                             goal = state.goals.firstOrNull { it.id == issue.goalId },
@@ -16363,6 +16740,22 @@ class DesktopAppService(
         return "$CEO_PLANNING_INVALID_OUTPUT: CEO planning task ${task.id} run $runRef ended with ${finalStatus.name} but did not produce a valid planning JSON block. Output summary: $summary"
     }
 
+    private fun isRetryableCeoPlanningInterruption(
+        task: AgentTask,
+        run: AgentRun?,
+        finalStatus: DesktopTaskStatus
+    ): Boolean =
+        finalStatus != DesktopTaskStatus.COMPLETED &&
+            failureSignals(task, run).any(::isOpenCodeInterruptedBeforePlanningText)
+
+    private fun ceoPlanningInterruptedReason(
+        task: AgentTask,
+        run: AgentRun?
+    ): String {
+        val runRef = run?.id ?: "none"
+        return "OpenCode was interrupted before producing planning text for CEO planning task ${task.id} run $runRef."
+    }
+
     private fun ceoPlanningRunOutputSummary(run: AgentRun?): String =
         listOfNotNull(run?.output, run?.error, run?.publish?.error)
             .joinToString("\n")
@@ -16484,6 +16877,133 @@ class DesktopAppService(
 
             val parsedPlan = if (finalStatus == DesktopTaskStatus.COMPLETED) parseCeoPlanningPayload(primaryRun?.output) else null
             if (parsedPlan == null) {
+                val retryableInterruption = isRetryableCeoPlanningInterruption(task, primaryRun, finalStatus)
+                if (retryableInterruption) {
+                    val latestRunsByTaskId = state.runs
+                        .filter { run -> state.tasks.any { it.issueId == currentIssue.id && it.id == run.taskId } }
+                        .groupBy { it.taskId }
+                        .mapValues { (_, runs) -> runs.maxByOrNull { it.updatedAt }!! }
+                    val retryDecision = resolveRecoverableRetryDecision(
+                        issueTasks = state.tasks.filter { it.issueId == currentIssue.id },
+                        latestRunsByTaskId = latestRunsByTaskId,
+                        now = now
+                    )
+                    val interruptionReason = ceoPlanningInterruptedReason(task, primaryRun)
+                    if (retryDecision.mode != RecoverableRetryMode.EXHAUSTED) {
+                        val retryReason = if (retryDecision.mode == RecoverableRetryMode.WAITING && retryDecision.retryAt != null) {
+                            "$interruptionReason Cotor will retry CEO planning after the provider cooldown."
+                        } else {
+                            "$interruptionReason Cotor will retry CEO planning instead of treating this as invalid CEO JSON."
+                        }
+                        val retryablePlanningIssue = currentIssue.copy(
+                            status = IssueStatus.PLANNED,
+                            transitionReason = retryReason,
+                            providerBlockReason = null,
+                            blockedBy = emptyList(),
+                            updatedAt = if (
+                                currentIssue.status == IssueStatus.PLANNED &&
+                                currentIssue.transitionReason == retryReason &&
+                                currentIssue.providerBlockReason == null
+                            ) {
+                                currentIssue.updatedAt
+                            } else {
+                                now
+                            }
+                        )
+                        traceEvents += buildCompanyAutomationTraceEvent(
+                            issue = currentIssue,
+                            goal = goal,
+                            oldStatus = currentIssue.status,
+                            newStatus = retryablePlanningIssue.status,
+                            source = "syncPlanningIssueFromTask",
+                            reason = retryReason,
+                            latestTask = task,
+                            latestRun = primaryRun,
+                            retryEligible = true
+                        )
+                        val nextState = state.copy(
+                            issues = state.issues.map { existing -> if (existing.id == currentIssue.id) retryablePlanningIssue else existing }
+                        ).recordCompanyActivity(
+                            companyId = company.id,
+                            projectContextId = currentIssue.projectContextId,
+                            goalId = goal.id,
+                            issueId = currentIssue.id,
+                            source = "ceo-planning",
+                            title = "CEO planning retry pending",
+                            detail = retryReason,
+                            severity = "warning"
+                        ).withDerivedMetrics()
+                        stateStore.save(nextState)
+                        runtimeContinuationCompanyId = currentIssue.companyId
+                        return@withLock
+                    }
+                    val exhaustedReason =
+                        "$interruptionReason Automatic retry budget was exhausted after ${retryDecision.consecutiveFailures} recoverable interruption(s)."
+                    val blockedTransition = "$exhaustedReason Downstream execution issues were not created."
+                    val blockedPlanningIssue = currentIssue.copy(
+                        status = IssueStatus.BLOCKED,
+                        transitionReason = blockedTransition,
+                        providerBlockReason = exhaustedReason,
+                        updatedAt = if (
+                            currentIssue.status == IssueStatus.BLOCKED &&
+                            currentIssue.transitionReason == blockedTransition &&
+                            currentIssue.providerBlockReason == exhaustedReason
+                        ) {
+                            currentIssue.updatedAt
+                        } else {
+                            now
+                        }
+                    )
+                    val decisionExists = state.goalDecisions.any { decision ->
+                        decision.companyId == company.id &&
+                            decision.goalId == goal.id &&
+                            decision.issueId == currentIssue.id &&
+                            decision.title == "CEO planning blocked" &&
+                            decision.escalations.contains(exhaustedReason)
+                    }
+                    val nextDecisions = if (decisionExists) {
+                        state.goalDecisions
+                    } else {
+                        state.goalDecisions + GoalOrchestrationDecision(
+                            id = UUID.randomUUID().toString(),
+                            companyId = company.id,
+                            goalId = goal.id,
+                            issueId = currentIssue.id,
+                            title = "CEO planning blocked",
+                            summary = "CEO planning for \"${goal.title}\" was interrupted before producing an execution graph.",
+                            createdIssues = emptyList(),
+                            assignments = emptyList(),
+                            escalations = listOf(exhaustedReason),
+                            createdAt = now
+                        )
+                    }
+                    traceEvents += buildCompanyAutomationTraceEvent(
+                        issue = currentIssue,
+                        goal = goal,
+                        oldStatus = currentIssue.status,
+                        newStatus = blockedPlanningIssue.status,
+                        source = "syncPlanningIssueFromTask",
+                        reason = blockedTransition,
+                        latestTask = task,
+                        latestRun = primaryRun,
+                        retryEligible = false
+                    )
+                    val nextState = state.copy(
+                        issues = state.issues.map { existing -> if (existing.id == currentIssue.id) blockedPlanningIssue else existing },
+                        goalDecisions = nextDecisions
+                    ).recordCompanyActivity(
+                        companyId = company.id,
+                        projectContextId = currentIssue.projectContextId,
+                        goalId = goal.id,
+                        issueId = currentIssue.id,
+                        source = "ceo-planning",
+                        title = "CEO planning blocked",
+                        detail = blockedTransition,
+                        severity = "error"
+                    ).withDerivedMetrics()
+                    stateStore.save(nextState)
+                    return@withLock
+                }
                 val invalidPlanningReason = ceoPlanningInvalidOutputReason(task, primaryRun, finalStatus)
                 val repairAttempts = state.tasks.count { candidate ->
                     candidate.issueId == currentIssue.id &&
@@ -16531,11 +17051,16 @@ class DesktopAppService(
                     runtimeContinuationCompanyId = currentIssue.companyId
                     return@withLock
                 }
+                val blockedTransition = "$invalidPlanningReason Downstream execution issues were not created."
+                val unchangedBlockedIssue =
+                    currentIssue.status == IssueStatus.BLOCKED &&
+                        currentIssue.transitionReason == blockedTransition &&
+                        currentIssue.providerBlockReason == invalidPlanningReason
                 val blockedPlanningIssue = currentIssue.copy(
                     status = IssueStatus.BLOCKED,
-                    transitionReason = "$invalidPlanningReason Downstream execution issues were not created.",
+                    transitionReason = blockedTransition,
                     providerBlockReason = invalidPlanningReason,
-                    updatedAt = now
+                    updatedAt = if (unchangedBlockedIssue) currentIssue.updatedAt else now
                 )
                 traceEvents += buildCompanyAutomationTraceEvent(
                     issue = currentIssue,
@@ -16548,9 +17073,17 @@ class DesktopAppService(
                     latestRun = primaryRun,
                     retryEligible = false
                 )
-                val nextState = state.copy(
-                    issues = state.issues.map { existing -> if (existing.id == currentIssue.id) blockedPlanningIssue else existing },
-                    goalDecisions = state.goalDecisions + GoalOrchestrationDecision(
+                val decisionExists = state.goalDecisions.any { decision ->
+                    decision.companyId == company.id &&
+                        decision.goalId == goal.id &&
+                        decision.issueId == currentIssue.id &&
+                        decision.title == "CEO planning blocked" &&
+                        decision.escalations.contains(invalidPlanningReason)
+                }
+                val nextDecisions = if (decisionExists) {
+                    state.goalDecisions
+                } else {
+                    state.goalDecisions + GoalOrchestrationDecision(
                         id = UUID.randomUUID().toString(),
                         companyId = company.id,
                         goalId = goal.id,
@@ -16562,6 +17095,10 @@ class DesktopAppService(
                         escalations = listOf(invalidPlanningReason),
                         createdAt = now
                     )
+                }
+                val nextState = state.copy(
+                    issues = state.issues.map { existing -> if (existing.id == currentIssue.id) blockedPlanningIssue else existing },
+                    goalDecisions = nextDecisions
                 ).recordCompanyActivity(
                     companyId = company.id,
                     projectContextId = currentIssue.projectContextId,
@@ -18653,6 +19190,19 @@ class DesktopAppService(
         goalId: String? = null,
         issueId: String? = null
     ): DesktopAppState {
+        val now = System.currentTimeMillis()
+        val cutoff = now - COMPANY_TRACE_DEDUP_WINDOW_MS
+        val duplicate = companyActivity.any { activity ->
+            activity.companyId == companyId &&
+                activity.issueId == issueId &&
+                activity.source == source &&
+                activity.title == title &&
+                activity.detail == detail &&
+                activity.createdAt >= cutoff
+        }
+        if (duplicate) {
+            return this
+        }
         val item = CompanyActivityItem(
             id = UUID.randomUUID().toString(),
             companyId = companyId,
@@ -18663,7 +19213,7 @@ class DesktopAppService(
             title = title,
             detail = detail,
             severity = severity,
-            createdAt = System.currentTimeMillis()
+            createdAt = now
         )
         return copy(companyActivity = (listOf(item) + companyActivity).take(200))
     }

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -5954,13 +5954,14 @@ class DesktopAppService(
                     ?: "GitHub publishing is not ready"
             lower.contains("capability") && lower.contains("requires approval") ->
                 "A required execution capability is waiting for approval"
-            else -> text
-                .lineSequence()
-                .map { it.trim() }
-                .filter { it.isNotBlank() }
-                .take(3)
-                .joinToString(" ")
-                .take(300)
+            else ->
+                text
+                    .lineSequence()
+                    .map { it.trim() }
+                    .filter { it.isNotBlank() }
+                    .take(3)
+                    .joinToString(" ")
+                    .take(300)
         }
     }
 

--- a/src/main/kotlin/com/cotor/model/OpenCodeDefaults.kt
+++ b/src/main/kotlin/com/cotor/model/OpenCodeDefaults.kt
@@ -7,7 +7,7 @@ package com.cotor.model
  * company-created agents so execution costs stay predictable.
  */
 object OpenCodeDefaults {
-    const val DEFAULT_MODEL = "opencode-go/deepseek-v4-flash"
+    const val DEFAULT_MODEL = "opencode/nemotron-3-super-free"
     const val LOCAL_OLLAMA_GEMMA_MODEL = "ollama/gemma3:4b"
     const val LOCAL_OLLAMA_EXECUTION_MODE = "local-ollama-opencode"
     const val LOCAL_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1"

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -496,6 +496,123 @@ class DesktopAppServiceTest : FunSpec({
         persisted.all { it.model == com.cotor.model.OpenCodeDefaults.DEFAULT_MODEL } shouldBe true
     }
 
+    test("operator chat answers agent performance questions from company evidence") {
+        val now = System.currentTimeMillis()
+        val appHome = Files.createTempDirectory("operator-chat-performance-home")
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true)
+        )
+        val company = service.createCompany(name = "Operator Chat Performance", rootPath = appHome.toString())
+        val seeded = stateStore.load()
+        val project = seeded.projectContexts.first { it.companyId == company.id }
+        val workspace = seeded.workspaces.first { it.repositoryId == company.repositoryId }
+        val builder = seeded.companyAgentDefinitions.first { it.companyId == company.id && it.title == "Builder" }
+        val qa = seeded.companyAgentDefinitions.first { it.companyId == company.id && it.title == "QA" }
+        val goal = CompanyGoal(
+            id = "goal-operator-performance",
+            companyId = company.id,
+            projectContextId = project.id,
+            title = "Ship performance evidence",
+            description = "Seed enough evidence for operator chat.",
+            status = GoalStatus.ACTIVE,
+            createdAt = now,
+            updatedAt = now
+        )
+        val builderIssue = CompanyIssue(
+            id = "issue-builder-performance",
+            companyId = company.id,
+            projectContextId = project.id,
+            goalId = goal.id,
+            workspaceId = workspace.id,
+            title = "Builder delivered slice",
+            description = "Completed implementation work.",
+            status = IssueStatus.DONE,
+            kind = "execution",
+            assigneeProfileId = builder.id,
+            createdAt = now - 5_000,
+            updatedAt = now - 1_000
+        )
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-performance",
+            companyId = company.id,
+            projectContextId = project.id,
+            goalId = goal.id,
+            workspaceId = workspace.id,
+            title = "QA blocked slice",
+            description = "Still blocked.",
+            status = IssueStatus.BLOCKED,
+            kind = "execution",
+            assigneeProfileId = qa.id,
+            createdAt = now - 4_000,
+            updatedAt = now - 2_000
+        )
+        val task = AgentTask(
+            id = "task-builder-performance",
+            workspaceId = workspace.id,
+            issueId = builderIssue.id,
+            title = builderIssue.title,
+            prompt = builderIssue.description,
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.COMPLETED,
+            createdAt = now - 4_000,
+            updatedAt = now - 1_000
+        )
+        val run = AgentRun(
+            id = "run-builder-performance",
+            taskId = task.id,
+            workspaceId = workspace.id,
+            repositoryId = company.repositoryId,
+            agentId = builder.id,
+            agentName = builder.title,
+            branchName = "codex/test",
+            worktreePath = appHome.toString(),
+            status = AgentRunStatus.COMPLETED,
+            output = "Implemented and verified.",
+            durationMs = 90_000,
+            estimatedCostCents = 12,
+            createdAt = now - 3_000,
+            updatedAt = now - 1_000
+        )
+        stateStore.save(
+            seeded.copy(
+                goals = seeded.goals + goal,
+                issues = seeded.issues + builderIssue + qaIssue,
+                tasks = seeded.tasks + task,
+                runs = seeded.runs + run
+            )
+        )
+
+        val response = service.runOperatorChat(company.id, "팀 인사평가에서 가장 좋은 에이전트는 뭐야?")
+
+        response.message shouldContain "Builder"
+        response.answerSources.any { it.type == "agent-performance" && it.refId == builder.id } shouldBe true
+        response.actions.shouldBeEmpty()
+        response.blockedActions.shouldBeEmpty()
+        stateStore.load().agentMessages.any { it.kind == "operator-answer" && it.body.contains("Builder") } shouldBe true
+    }
+
+    test("operator chat hard gates destructive policy changes") {
+        val appHome = Files.createTempDirectory("operator-chat-hard-gate-home")
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true)
+        )
+        val company = service.createCompany(name = "Operator Chat Safety", rootPath = appHome.toString())
+
+        val response = service.runOperatorChat(company.id, "merge policy 해제하고 바로 머지해")
+
+        response.blockedActions.shouldNotBeEmpty()
+        response.blockedActions.single().type shouldBe "hard-gate"
+        response.actions.shouldBeEmpty()
+    }
+
     test("new companies seed HR Manager and mentor assignments") {
         val appHome = Files.createTempDirectory("hr-seed-home")
         val stateStore = DesktopStateStore { appHome }
@@ -3438,6 +3555,60 @@ class DesktopAppServiceTest : FunSpec({
         state.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
         state.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE
         state.goalDecisions.last { it.goalId == goal.id }.title shouldBe "CEO planned execution graph"
+    }
+
+    test("interrupted OpenCode CEO planning remains retryable instead of invalid JSON blocked") {
+        val appHome = Files.createTempDirectory("desktop-ceo-interrupted-plan-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-interrupted-plan-test").resolve("repo"))
+        val worktreeRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-interrupted-plan-worktree").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val gitWorkspaceService = mockk<GitWorkspaceService>()
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { gitWorkspaceService.resolveRepositoryRoot(any()) } returns repoRoot
+        coEvery { gitWorkspaceService.detectDefaultBranch(any()) } returns "master"
+        coEvery { gitWorkspaceService.detectRemoteUrl(any()) } returns null
+        coEvery { gitWorkspaceService.ensureWorktree(any(), any(), any(), any(), any()) } returns WorktreeBinding(
+            branchName = "codex/cotor/ceo-interrupted-plan/opencode",
+            worktreePath = worktreeRoot
+        )
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } returns AgentResult(
+            agentName = "opencode",
+            isSuccess = false,
+            output = """{"type":"step_start","timestamp":1778128131724,"sessionID":"ses_1ff4df14affeEb414G1doOHnl8","part":{"id":"prt_e00b21686001aYMfThX3ibFRHJ","messageID":"msg_e00b20ef6001e5wxJOGHKwx9eJ","sessionID":"ses_1ff4df14affeEb414G1doOHnl8","snapshot":"bd97a7460fae5ba7ad0f53fe8c854a4791e3c501","type":"step-start"}}""",
+            error = """OpenCode execution failed (exit=143): {"type":"step_start","timestamp":1778128131724}""",
+            duration = 100,
+            metadata = emptyMap()
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            agentExecutor = agentExecutor
+        )
+        val company = service.createCompany(
+            name = "CEO Interrupted Plan Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Plan after provider interruption",
+            description = "The CEO planning provider is interrupted before producing content.",
+            autonomyEnabled = true,
+            startRuntimeIfNeeded = false
+        )
+        val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
+
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
+
+        val state = stateStore.load()
+        val latestIssue = state.issues.single { it.id == planningIssue.id }
+        latestIssue.status shouldBe IssueStatus.PLANNED
+        latestIssue.providerBlockReason.shouldBeNull()
+        latestIssue.transitionReason.orEmpty() shouldNotContain "CEO_PLANNING_INVALID_OUTPUT"
+        state.goalDecisions.filter { it.goalId == goal.id && it.title == "CEO planning blocked" }.shouldBeEmpty()
+        state.companyActivity.filter { it.issueId == planningIssue.id && it.title == "CEO planning blocked" }.shouldBeEmpty()
     }
 
     test("autonomous CEO planning blocks after repeated invalid output without creating fallback issues") {

--- a/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
@@ -148,7 +148,7 @@ class AgentCommandTest : FunSpec({
         val added = root.resolve(".cotor/agents/opencode.yaml")
         added.exists() shouldBe true
         added.readText() shouldContain "pluginClass: com.cotor.data.plugin.OpenCodePlugin"
-        added.readText() shouldContain "model: \"opencode-go/deepseek-v4-flash\""
+        added.readText() shouldContain "model: \"opencode/nemotron-3-super-free\""
     }
 
     test("agent add gemma4 writes local model provider defaults") {


### PR DESCRIPTION
## Summary
- Add a grounded operator chat endpoint for company Q&A while preserving the existing deterministic command path for runtime controls.
- Route macOS operator chat through the new endpoint, including answer sources and existing action/approval rendering.
- Reclassify OpenCode exit 143 + step-start-only CEO planning output as a retryable provider interruption instead of invalid JSON, and dedupe repeated planning block activity.
- Align default OpenCode execution model expectations with `opencode/nemotron-3-super-free`.

## Root Cause
- Operator chat was mostly keyword/command routing, so general questions like agent performance evaluation did not have a grounded answer path.
- CEO planning repair runs interrupted before producing text were treated as invalid planning JSON and then repeatedly recorded as blocked activity on runtime ticks.

## Validation
- `./gradlew testClasses`
- `swift build --package-path macos`
- `swift test --package-path macos --filter ModelsTests/operatorChatResponseDecodesAnswerSources`
- `./gradlew test --tests com.cotor.app.DesktopAppServiceTest -Dkotest.filter.tests="operator chat answers agent performance questions from company evidence"`
- `./gradlew test --rerun-tasks --tests com.cotor.app.DesktopAppServiceTest -Dkotest.filter.tests="operator chat hard gates destructive policy changes"`
- `./gradlew test --rerun-tasks --tests com.cotor.app.DesktopAppServiceTest -Dkotest.filter.tests="interrupted OpenCode CEO planning remains retryable instead of invalid JSON blocked"`
- `./gradlew test --rerun-tasks --tests com.cotor.app.DesktopAppServiceTest -Dkotest.filter.tests="autonomous CEO planning blocks after repeated invalid output without creating fallback issues"`
- `swift test --package-path macos`
- `./gradlew test`
- `git diff --check origin/master..HEAD`

## Notes
- `graphify update .` was attempted, but it refused to overwrite because the new graph had fewer nodes than the existing graph output. No graph artifacts were changed.