### PR TITLE
fix(plugin): fix OpenCode CEO planning blank output (prompt file relocation + silent exit detection)

### DIFF
--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -784,6 +784,14 @@ class OpenCodePlugin : AgentPlugin {
                 stderr = result.stderr.ifBlank { finalError ?: result.stderr }
             )
         }
+        if (result.stdout.isBlank()) {
+            throw ProcessExecutionException(
+                message = "OpenCode execution failed",
+                exitCode = result.exitCode,
+                stdout = "opencode run exit 0 but stdout and stderr were both empty",
+                stderr = "opencode run exit 0 but stdout and stderr were both empty"
+            )
+        }
 
         val parsedText = parseOpenCodeJsonOutput(result.stdout)
         return PluginExecutionOutput(parsedText, result.processId)
@@ -802,7 +810,11 @@ class OpenCodePlugin : AgentPlugin {
         // Keep the full task prompt out of process arguments; it may contain repo
         // context or user text that should not be visible via `ps`.
         val promptFile = withContext(Dispatchers.IO) {
-            Files.createTempFile("cotor-opencode-prompt-", ".md").also { path ->
+            val promptDir = context.workingDirectory
+                ?.resolve(".cotor/runtime/opencode-prompts")
+                ?.also { Files.createDirectories(it) }
+                ?: Path.of(System.getProperty("java.io.tmpdir"))
+            Files.createTempFile(promptDir, "opencode-prompt-", ".md").also { path ->
                 runCatching {
                     Files.setPosixFilePermissions(
                         path,

--- a/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
@@ -56,7 +56,7 @@ class OpenCodePluginTest : FunSpec({
                         assertOpenCodeRunCommand(command, "opencode/qwen3.6-plus-free", "hello")
                         ProcessResult(
                             exitCode = 0,
-                            stdout = "",
+                            stdout = """{"type":"text","text":"ok"}""",
                             stderr = "",
                             isSuccess = true
                         )
@@ -553,6 +553,102 @@ class OpenCodePluginTest : FunSpec({
             runInvoked shouldBe false
         } finally {
             server.stop(0)
+        }
+    }
+
+    test("exit 0 with blank stdout and stderr throws ProcessExecutionException") {
+        val plugin = OpenCodePlugin()
+        val processManager = object : ProcessManager {
+            override suspend fun executeProcess(
+                command: List<String>,
+                input: String?,
+                environment: Map<String, String>,
+                timeout: Long,
+                workingDirectory: Path?,
+                onStart: ((Long) -> Unit)?
+            ): ProcessResult = when (command) {
+                listOf("opencode", "models") -> ProcessResult(
+                    exitCode = 1,
+                    stdout = "",
+                    stderr = "models lookup unavailable",
+                    isSuccess = false
+                )
+                else -> ProcessResult(
+                    exitCode = 0,
+                    stdout = "",
+                    stderr = "",
+                    isSuccess = true
+                )
+            }
+        }
+
+        val error = shouldThrow<ProcessExecutionException> {
+            plugin.execute(
+                ExecutionContext(
+                    agentName = "opencode",
+                    input = "hello",
+                    timeout = 1_000,
+                    parameters = mapOf("model" to OpenCodeDefaults.DEFAULT_MODEL),
+                    environment = emptyMap()
+                ),
+                processManager
+            )
+        }
+
+        error.message shouldBe "OpenCode execution failed"
+        error.stdout shouldBe "opencode run exit 0 but stdout and stderr were both empty"
+        error.stderr shouldBe "opencode run exit 0 but stdout and stderr were both empty"
+    }
+
+    test("writes prompt file inside working directory when workingDirectory is set") {
+        val workDir = Files.createTempDirectory("cotor-test-workdir-")
+        val plugin = OpenCodePlugin()
+        var capturedPromptPath: String? = null
+        val processManager = object : ProcessManager {
+            override suspend fun executeProcess(
+                command: List<String>,
+                input: String?,
+                environment: Map<String, String>,
+                timeout: Long,
+                workingDirectory: Path?,
+                onStart: ((Long) -> Unit)?
+            ): ProcessResult = when (command) {
+                listOf("opencode", "models") -> ProcessResult(
+                    exitCode = 1,
+                    stdout = "",
+                    stderr = "models lookup unavailable",
+                    isSuccess = false
+                )
+                else -> {
+                    capturedPromptPath = command.firstOrNull { it.startsWith("--file=") }
+                        ?.removePrefix("--file=")
+                    ProcessResult(
+                        exitCode = 0,
+                        stdout = """{"type":"text","text":"done"}""",
+                        stderr = "",
+                        isSuccess = true
+                    )
+                }
+            }
+        }
+
+        try {
+            plugin.execute(
+                ExecutionContext(
+                    agentName = "opencode",
+                    input = "hello",
+                    timeout = 1_000,
+                    parameters = mapOf("model" to OpenCodeDefaults.DEFAULT_MODEL),
+                    environment = emptyMap(),
+                    workingDirectory = workDir
+                ),
+                processManager
+            )
+
+            val promptPath = Path.of(capturedPromptPath!!)
+            promptPath.startsWith(workDir.resolve(".cotor/runtime/opencode-prompts")) shouldBe true
+        } finally {
+            workDir.toFile().deleteRecursively()
         }
     }
 })


### PR DESCRIPTION
## Summary

- **Root cause**: opencode 1.14.39's `external_directory` permission check silently blocked reading the CEO planning prompt file when it was written to the OS temp directory (`/var/folders/...`), causing `opencode run` to exit 0 with zero bytes on stdout. Cotor misclassified this as `CEO_PLANNING_INVALID_OUTPUT` and repeatedly blocked the planning issue.

- **Fix 1 — Prompt file location**: Moved the prompt file from OS temp to `context.workingDirectory/.cotor/runtime/opencode-prompts/<uuid>.md`. The file is now inside opencode's allowed directory tree, eliminating the permission block. Falls back to OS temp when `workingDirectory` is null.

- **Fix 2 — Blank stdout detection**: Added an explicit check after the exit-code guard: if opencode exits 0 but stdout and stderr are both empty, throw `ProcessExecutionException("opencode run exit 0 but stdout and stderr were both empty")`. This makes the failure visible in runtime logs and routes it through the standard retryable error path instead of being silently misclassified as invalid JSON.

## Files changed

- `src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt` — prompt file relocated into working directory; blank-stdout guard added
- `src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt` — fixed existing test that relied on blank-stdout success; added two new tests

## Test plan

- [x] `./gradlew test --tests com.cotor.data.plugin.OpenCodePluginTest` — all tests pass
- [x] `./gradlew test` — full suite passes (BUILD SUCCESSFUL in 1m 9s)
- [ ] Manual: rerun CEO planning in cotor-test sandbox and confirm opencode produces JSON event stream without `external_directory` permission block

🤖 Generated with [Claude Code](https://claude.com/claude-code)