### PR TITLE
feat(meeting-room): live agent motion — provider identity, live activity bubbles, stdout streaming

### DIFF
--- a/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomProjection.swift
@@ -58,6 +58,8 @@ struct MeetingRoomProjectionAgent: Identifiable, Hashable {
     let progress: Double
     let messageCount: Int
     let pullRequestState: String?
+    let liveActivity: String?
+    let lastLogLine: String?
 }
 
 struct MeetingRoomFlowItem: Identifiable, Hashable {
@@ -254,11 +256,13 @@ struct MeetingRoomProjection: Hashable {
                 visualState: visualState,
                 expression: messageCount > 0 ? .talking : expression(for: visualState),
                 zone: zone(for: visualState),
-                actionLine: actionLine(for: visualState, role: agent.title),
-                detailLine: detailLine(agent: agent, session: session, issue: issue, reviewCount: scopedReviews.count, runtime: runtime),
+                actionLine: session?.currentActivity ?? actionLine(for: visualState, role: agent.title),
+                detailLine: session?.lastLogLine ?? detailLine(agent: agent, session: session, issue: issue, reviewCount: scopedReviews.count, runtime: runtime),
                 progress: progress(for: visualState, session: session, issue: issue, enabled: agent.enabled),
                 messageCount: messageCount,
-                pullRequestState: issue?.pullRequestState
+                pullRequestState: issue?.pullRequestState,
+                liveActivity: session?.currentActivity,
+                lastLogLine: session?.lastLogLine
             )
         }
 

--- a/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
@@ -516,7 +516,7 @@ enum MeetingRoomSceneReducer {
                 movementStartedAt: shouldMove ? now : (existing?.movementStartedAt ?? now),
                 movementDuration: shouldMove ? movementDuration(for: focusEvent?.kind) : 0,
                 isSimplified: plan.mode != .full,
-                speechText: speechText(for: agent.id, event: focusEvent),
+                speechText: speechText(for: agent.id, event: focusEvent, liveActivity: agent.liveActivity),
                 focusEvent: focusEvent,
                 isFreshInteraction: isFresh
             )
@@ -711,8 +711,8 @@ enum MeetingRoomSceneReducer {
         }
     }
 
-    private static func speechText(for agentId: String, event: MeetingRoomInteractionEvent?) -> String? {
-        guard let event else { return nil }
+    private static func speechText(for agentId: String, event: MeetingRoomInteractionEvent?, liveActivity: String? = nil) -> String? {
+        guard let event else { return liveActivity }
         if event.fromAgentId == agentId {
             return event.speechText
         }

--- a/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
+++ b/macos/Sources/CotorDesktopApp/MeetingRoomView.swift
@@ -1085,7 +1085,7 @@ private struct PixelAgentSprite: View {
 
     private var bubbleText: String {
         guard let speech = sceneAgent.speechText else {
-            return agent.actionLine
+            return agent.lastLogLine ?? agent.actionLine
         }
         switch speech {
         case "Approval requested":
@@ -1239,7 +1239,31 @@ private struct PixelAgentSprite: View {
         Color(red: 0.05, green: 0.07, blue: 0.08)
     }
 
+    private var providerAccentColor: Color? {
+        switch agent.cli.lowercased() {
+        case "claude":
+            return Color(red: 0.62, green: 0.45, blue: 0.82)
+        case "codex":
+            return Color(red: 0.28, green: 0.78, blue: 0.54)
+        case "opencode":
+            return Color(red: 0.95, green: 0.64, blue: 0.25)
+        case "gemini":
+            return Color(red: 0.36, green: 0.62, blue: 0.95)
+        case "cursor":
+            return Color(red: 0.45, green: 0.72, blue: 0.98)
+        case "echo":
+            return ShellPalette.muted
+        default:
+            guard !agent.cli.isEmpty else { return nil }
+            let hue = Double(abs(agent.cli.hashValue) % 360) / 360.0
+            return Color(hue: hue, saturation: 0.62, brightness: 0.78)
+        }
+    }
+
     private var robotAccentTint: Color {
+        if let provider = providerAccentColor {
+            return provider
+        }
         if lowerRole.contains("ceo") || lowerRole.contains("lead") {
             return ShellPalette.warning
         }

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -1019,6 +1019,9 @@ struct RunningAgentSessionRecord: Codable, Hashable, Identifiable {
     let backendKind: String?
     let processId: Int64?
     let outputSnippet: String?
+    let currentActivity: String?
+    let progressPercent: Double?
+    let lastLogLine: String?
     let startedAt: Int64
     let updatedAt: Int64
 }

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -13235,6 +13235,9 @@ class DesktopAppService(
                     backendKind = run.backendKind,
                     processId = run.processId,
                     outputSnippet = run.output?.lineSequence()?.take(3)?.joinToString("\n"),
+                    currentActivity = run.liveActivity,
+                    progressPercent = run.liveProgressPercent,
+                    lastLogLine = run.lastLogLine,
                     startedAt = run.createdAt,
                     updatedAt = run.updatedAt
                 )
@@ -13975,6 +13978,7 @@ class DesktopAppService(
                 }
             }
 
+            var lastLiveChunkMs = 0L
             val executionMetadata = AgentExecutionMetadata(
                 repoRoot = Path.of(repository.localPath),
                 workspaceId = workspace.id,
@@ -13991,6 +13995,22 @@ class DesktopAppService(
                                 updatedAt = System.currentTimeMillis()
                             )
                         )
+                    }
+                },
+                onStdoutChunk = handler@{ chunk ->
+                    val line = chunk.trim().ifBlank { return@handler }
+                    val now = System.currentTimeMillis()
+                    if (now - lastLiveChunkMs < 750L) return@handler
+                    lastLiveChunkMs = now
+                    val sanitized = line.take(200).replace(Regex("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f]"), "")
+                    runBlocking {
+                        val existing = stateStore.load().runs.firstOrNull { it.id == startedRun.id }
+                            ?: return@runBlocking
+                        replaceRun(existing.copy(
+                            liveActivity = sanitized,
+                            lastLogLine = sanitized,
+                            updatedAt = System.currentTimeMillis()
+                        ))
                     }
                 }
             )

--- a/src/main/kotlin/com/cotor/app/DesktopModels.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopModels.kt
@@ -448,6 +448,9 @@ data class RunningAgentSession(
     val backendKind: ExecutionBackendKind? = null,
     val processId: Long? = null,
     val outputSnippet: String? = null,
+    val currentActivity: String? = null,
+    val progressPercent: Double? = null,
+    val lastLogLine: String? = null,
     val startedAt: Long,
     val updatedAt: Long
 )
@@ -739,6 +742,9 @@ data class AgentRun(
     val estimatedCostCents: Int? = null,
     val a2aSessionId: String? = null,
     val a2aEndpoint: String? = null,
+    val liveActivity: String? = null,
+    val liveProgressPercent: Double? = null,
+    val lastLogLine: String? = null,
     val createdAt: Long,
     val updatedAt: Long,
     val workflowLineage: WorkflowLineageSnapshot? = null

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -90,7 +90,8 @@ class ClaudePlugin : AgentPlugin {
             environment = context.environment,
             timeout = context.timeout,
             workingDirectory = context.workingDirectory,
-            onStart = context.onProcessStarted
+            onStart = context.onProcessStarted,
+            onStdoutChunk = context.onStdoutChunk
         )
 
         if (!result.isSuccess) {

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -38,7 +38,8 @@ interface ProcessManager {
         environment: Map<String, String>,
         timeout: Long,
         workingDirectory: Path? = null,
-        onStart: ((Long) -> Unit)? = null
+        onStart: ((Long) -> Unit)? = null,
+        onStdoutChunk: ((String) -> Unit)? = null
     ): ProcessResult
 }
 
@@ -55,7 +56,8 @@ class CoroutineProcessManager(
         environment: Map<String, String>,
         timeout: Long,
         workingDirectory: Path?,
-        onStart: ((Long) -> Unit)?
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?
     ): ProcessResult = withContext(Dispatchers.IO) {
         val resolvedCommand = resolveProcessCommand(command)
         val processBuilder = ProcessBuilder(resolvedCommand)
@@ -100,6 +102,7 @@ class CoroutineProcessManager(
                     synchronized(stdoutBuffer) {
                         stdoutBuffer.append(chunk, 0, read)
                     }
+                    onStdoutChunk?.invoke(String(chunk, 0, read))
                 }
             }
         }

--- a/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
+++ b/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
@@ -180,6 +180,7 @@ class DefaultAgentExecutor(
                     pipelineContext = metadata.pipelineContext,
                     currentStageId = metadata.stageId,
                     onProcessStarted = metadata.onProcessStarted,
+                    onStdoutChunk = metadata.onStdoutChunk,
                     validateCommand = securityValidator::validateCommand
                 )
 

--- a/src/main/kotlin/com/cotor/model/Models.kt
+++ b/src/main/kotlin/com/cotor/model/Models.kt
@@ -404,6 +404,7 @@ data class ExecutionContext(
     val pipelineContext: PipelineContext? = null,
     val currentStageId: String? = null,
     val onProcessStarted: ((Long) -> Unit)? = null,
+    val onStdoutChunk: ((String) -> Unit)? = null,
     val validateCommand: ((List<String>) -> Unit)? = null
 )
 
@@ -424,7 +425,8 @@ data class AgentExecutionMetadata(
     // through every public agent-facing API.
     @Serializable(with = NullablePathSerializer::class)
     val workingDirectory: Path? = null,
-    val onProcessStarted: ((Long) -> Unit)? = null
+    val onProcessStarted: ((Long) -> Unit)? = null,
+    val onStdoutChunk: ((String) -> Unit)? = null
 )
 
 /**


### PR DESCRIPTION
## Summary

- **Provider-based robot identity**: Each AI provider (claude, codex, opencode, gemini, cursor) now gets a deterministic accent color on its pixel robot — antenna LEDs, eyes, and mouth glow all reflect the provider. Role accessories (CEO crown, QA chip, builder bar) still apply independently.
- **Live activity speech bubbles**: Running agents now show real stdout output in their speech bubble (priority: `interaction.speechText` → `liveActivity` → `lastLogLine` → static `actionLine`). No waiting for a handoff event — the bubble updates as the agent works.
- **Stdout chunk streaming**: `ProcessManager` → `AgentExecutor` → `ExecutionContext` → `AgentExecutionMetadata` all thread a new optional `onStdoutChunk` callback. `DesktopAppService.executeAgentRun` installs a throttled handler (≥750ms between writes) that sanitizes and stores each line as `AgentRun.liveActivity` / `lastLogLine`. `computeRunningAgentSessions` propagates these into the company SSE snapshot.
- **Additive only**: all new fields have default values (`null`/`nil`). Existing callers, API responses, and serialized state are fully backward compatible.

## Changes

| Layer | File | What changed |
|-------|------|-------------|
| Kotlin models | `DesktopModels.kt`, `Models.kt` | `AgentRun` + `RunningAgentSession` + `ExecutionContext` + `AgentExecutionMetadata` get live fields |
| Kotlin process | `ProcessManager.kt`, `AgentExecutor.kt`, `AIModelPlugins.kt` | `onStdoutChunk` callback flows from process I/O thread to call site |
| Kotlin service | `DesktopAppService.kt` | Throttled chunk handler + live field propagation in session snapshot |
| Swift models | `Models.swift` | `RunningAgentSessionRecord` gets `currentActivity`, `progressPercent`, `lastLogLine` |
| Swift projection | `MeetingRoomProjection.swift` | `MeetingRoomProjectionAgent` gets `liveActivity`, `lastLogLine`; `actionLine`/`detailLine` prefer live data |
| Swift scene | `MeetingRoomScene.swift` | `speechText` returns `liveActivity` when no focusEvent |
| Swift view | `MeetingRoomView.swift` | `providerAccentColor` + `robotAccentTint` provider-first; `bubbleText` → `lastLogLine ?? actionLine` |

## Test plan

- [x] `./gradlew :compileKotlin -x test -x jacocoTestCoverageVerification` — clean
- [x] `./gradlew test -x jacocoTestCoverageVerification` — all pass
- [x] `swift build --package-path macos` — Build complete
- [x] `swift test --package-path macos` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)