### PR TITLE
[codex] add openswarm-inspired runtime guards

### DIFF
--- a/docs/ARCHITECTURE.ko.md
+++ b/docs/ARCHITECTURE.ko.md
@@ -31,7 +31,7 @@ flowchart LR
 | CLI | 명령 파싱, interactive/TUI 실행, packaged lifecycle 명령 | `src/main/kotlin/com/cotor/Main.kt`, `src/main/kotlin/com/cotor/presentation/cli/` |
 | App server | 로컬 HTTP API와 데스크톱 계약 | `src/main/kotlin/com/cotor/app/AppServer.kt`, `src/main/kotlin/com/cotor/app/DesktopModels.kt` |
 | Company workflow | 회사 상태 머신, 목표, 이슈, 리뷰 큐, 런타임 tick, 런타임 retention, 보고서, 운영 채팅 | `src/main/kotlin/com/cotor/app/DesktopAppService.kt`, `src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt`, `src/main/kotlin/com/cotor/app/runtime/` |
-| Pipeline runtime | 범용 파이프라인 계획, 오케스트레이션, 실행, 집계, 조건 평가 | `src/main/kotlin/com/cotor/domain/` |
+| Pipeline runtime | 범용 파이프라인 계획, 오케스트레이션, 실행, deterministic guard, stuck/conflict detection, 집계, 조건 평가 | `src/main/kotlin/com/cotor/domain/` |
 | Agent/tool execution | provider plugin, 로컬 프로세스 실행, 모델 기본값, 명령 adapter | `src/main/kotlin/com/cotor/data/plugin/`, `src/main/kotlin/com/cotor/data/process/`, `src/main/kotlin/com/cotor/model/` |
 | Context/memory/evidence | 프롬프트 context, durable snapshot, knowledge, provenance, verification bundle | `src/main/kotlin/com/cotor/context/`, `src/main/kotlin/com/cotor/runtime/`, `src/main/kotlin/com/cotor/knowledge/`, `src/main/kotlin/com/cotor/provenance/`, `src/main/kotlin/com/cotor/verification/` |
 | Policy/security | action policy 판정, 위험 gate, executable/path 검증 | `src/main/kotlin/com/cotor/policy/`, `src/main/kotlin/com/cotor/security/` |
@@ -141,6 +141,8 @@ app-server 계약이 Kotlin과 Swift 사이의 경계입니다. payload field는
 - merge conflict 복구와 stale PR 정리는 superseded lineage와 연결되어야 회사가 stale review artifact 없이 계속 진행할 수 있습니다.
 - no-diff code-producing run은 실제 변경 없이 완료를 주장하지 않고, 파일 수정 지시로 1회 재시도한 뒤 block합니다.
 - 런타임 tick의 recoverable 실패는 retry budget이 소진되기 전까지 `RUNNING` 상태와 실패 카운터로 남깁니다. 사용자 중지와 cancellation은 일반 runtime error가 아니라 interruption 상태입니다.
+- 에이전트 output은 downstream review state가 소비하기 전에 deterministic pipeline guard를 통과합니다. Guard finding은 범용 pipeline runtime에 머물며 company UI 개념을 import하지 않고 stage를 annotate 또는 block할 수 있습니다.
+- 병렬 pipeline 실행은 stage input이 같은 파일이나 dependency를 가리킬 때 conflict-safe batch로 나뉩니다. 같은 target을 쓰는 두 writer를 한 wave에서 동시에 실행하지 않습니다.
 
 ## 7. Autonomous Runtime v1
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ flowchart LR
 | CLI | command parsing, interactive/TUI launch, packaged lifecycle commands | `src/main/kotlin/com/cotor/Main.kt`, `src/main/kotlin/com/cotor/presentation/cli/` |
 | App server | local HTTP API and desktop contract | `src/main/kotlin/com/cotor/app/AppServer.kt`, `src/main/kotlin/com/cotor/app/DesktopModels.kt` |
 | Company workflow | company state machine, goals, issues, review queue, runtime ticks, runtime retention, reports, operator chat | `src/main/kotlin/com/cotor/app/DesktopAppService.kt`, `src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt`, `src/main/kotlin/com/cotor/app/runtime/` |
-| Pipeline runtime | generic pipeline planning, orchestration, execution, aggregation, condition evaluation | `src/main/kotlin/com/cotor/domain/` |
+| Pipeline runtime | generic pipeline planning, orchestration, execution, deterministic guards, stuck/conflict detection, aggregation, condition evaluation | `src/main/kotlin/com/cotor/domain/` |
 | Agent/tool execution | provider plugins, local process execution, model defaults, command adapters | `src/main/kotlin/com/cotor/data/plugin/`, `src/main/kotlin/com/cotor/data/process/`, `src/main/kotlin/com/cotor/model/` |
 | Context/memory/evidence | prompt context, durable snapshots, knowledge, provenance, verification bundles | `src/main/kotlin/com/cotor/context/`, `src/main/kotlin/com/cotor/runtime/`, `src/main/kotlin/com/cotor/knowledge/`, `src/main/kotlin/com/cotor/provenance/`, `src/main/kotlin/com/cotor/verification/` |
 | Policy/security | action policy decisions, risk gates, executable/path validation | `src/main/kotlin/com/cotor/policy/`, `src/main/kotlin/com/cotor/security/` |
@@ -139,6 +139,8 @@ The company automation layer has stricter invariants than the generic pipeline r
 - Merge-conflict recovery and stale PR cleanup stay tied to the superseded lineage so the company can continue without stale review artifacts.
 - No-diff code-producing runs retry once with explicit file-edit instructions and then block instead of claiming completion without changes.
 - Runtime loop recoverable tick failures remain `RUNNING` with failure counters until the retry budget is exhausted; user stop/cancellation is interruption state, not a generic runtime error.
+- Agent outputs pass through deterministic pipeline guards before downstream review state consumes them. Guard findings stay generic to the pipeline runtime and may annotate or block a stage without importing company UI concepts.
+- Parallel pipeline execution uses conflict-safe batches when stage inputs indicate overlapping files or dependencies, so generic parallel mode does not knowingly launch two writers against the same target in one wave.
 
 ## 7. Autonomous Runtime v1
 

--- a/docs/modules/README.ko.md
+++ b/docs/modules/README.ko.md
@@ -18,7 +18,7 @@
 | --- | --- | --- | --- |
 | CLI and presentation | 명령 파싱, interactive/TUI 실행, web adapter, 출력 formatting | `src/main/kotlin/com/cotor/Main.kt`, `src/main/kotlin/com/cotor/presentation/cli/Commands.kt`, `src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt` | `src/test/kotlin/com/cotor/presentation/cli/`, CLI 중심 integration test |
 | App server and company workflow | localhost `/api/app` route, 회사 dashboard/runtime/goals/issues/reviews/reports/operator chat, runtime retention | `src/main/kotlin/com/cotor/app/AppServer.kt`, `src/main/kotlin/com/cotor/app/DesktopAppService.kt`, `src/main/kotlin/com/cotor/app/DesktopModels.kt`, `src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt` | `src/test/kotlin/com/cotor/app/` |
-| Generic pipeline runtime | pipeline orchestration, stage execution, condition, aggregation, checkpoint | `src/main/kotlin/com/cotor/domain/orchestrator/`, `src/main/kotlin/com/cotor/domain/executor/` | `src/test/kotlin/com/cotor/` 아래 domain/orchestrator/executor test |
+| Generic pipeline runtime | pipeline orchestration, stage execution, deterministic guard, stuck/conflict detection, condition, aggregation, checkpoint | `src/main/kotlin/com/cotor/domain/orchestrator/`, `src/main/kotlin/com/cotor/domain/executor/` | `src/test/kotlin/com/cotor/` 아래 domain/orchestrator/executor test |
 | Agent/provider execution | provider plugin, local process 실행, model routing, OpenCode/Codex/local model adapter | `src/main/kotlin/com/cotor/data/plugin/`, `src/main/kotlin/com/cotor/data/process/`, `src/main/kotlin/com/cotor/model/` | plugin/model/process test |
 | Runtime evidence and memory | durable action, provenance, knowledge memory, verification bundle, A2A context | `src/main/kotlin/com/cotor/runtime/`, `src/main/kotlin/com/cotor/provenance/`, `src/main/kotlin/com/cotor/knowledge/`, `src/main/kotlin/com/cotor/verification/`, `src/main/kotlin/com/cotor/context/` | runtime/provenance/knowledge/verification test |
 | Policy and security | action allow/deny/approval 판정, executable allow-list, path/destructive command 검증 | `src/main/kotlin/com/cotor/policy/`, `src/main/kotlin/com/cotor/security/` | policy/security test |
@@ -49,12 +49,12 @@
 
 ### Generic pipeline runtime
 
-- 책임: desktop company product layer와 독립적인 configured pipeline 실행.
+- 책임: desktop company product layer와 독립적인 configured pipeline 실행. deterministic guard 검사와 conflict-safe parallel batching도 포함합니다.
 - Public entrypoint: orchestrator/executor package와 validation/config API.
 - 내부 전용: stage aggregation, loop/condition 내부, checkpoint 내부.
 - 의존 가능: config, validation, monitoring, provider execution interface.
 - 의존 금지: `app/DesktopAppService.kt`, `/api/app` DTO, macOS DTO.
-- 자주 바꾸는 작업: pipeline semantics, stage execution, retry behavior, checkpoint output. pipeline test와 command docs를 갱신합니다.
+- 자주 바꾸는 작업: pipeline semantics, stage execution, guard/stuck/conflict behavior, retry behavior, checkpoint output. pipeline test와 command docs를 갱신합니다.
 
 ### Agent/provider execution
 

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -16,7 +16,7 @@ Use this guide when changing source layout, public entrypoints, route payloads, 
 | --- | --- | --- | --- |
 | CLI and presentation | command parsing, interactive/TUI launch, web adapters, output formatting | `src/main/kotlin/com/cotor/Main.kt`, `src/main/kotlin/com/cotor/presentation/cli/Commands.kt`, `src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt` | `src/test/kotlin/com/cotor/presentation/cli/`, CLI-focused integration tests |
 | App server and company workflow | localhost `/api/app` routes, company dashboard/runtime/goals/issues/reviews/reports/operator chat, runtime retention | `src/main/kotlin/com/cotor/app/AppServer.kt`, `src/main/kotlin/com/cotor/app/DesktopAppService.kt`, `src/main/kotlin/com/cotor/app/DesktopModels.kt`, `src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt` | `src/test/kotlin/com/cotor/app/` |
-| Generic pipeline runtime | pipeline orchestration, stage execution, conditions, aggregation, checkpoints | `src/main/kotlin/com/cotor/domain/orchestrator/`, `src/main/kotlin/com/cotor/domain/executor/` | domain/orchestrator and executor tests under `src/test/kotlin/com/cotor/` |
+| Generic pipeline runtime | pipeline orchestration, stage execution, deterministic guards, stuck/conflict detection, conditions, aggregation, checkpoints | `src/main/kotlin/com/cotor/domain/orchestrator/`, `src/main/kotlin/com/cotor/domain/executor/` | domain/orchestrator and executor tests under `src/test/kotlin/com/cotor/` |
 | Agent/provider execution | provider plugins, local process execution, model routing, OpenCode/Codex/local model adapters | `src/main/kotlin/com/cotor/data/plugin/`, `src/main/kotlin/com/cotor/data/process/`, `src/main/kotlin/com/cotor/model/` | plugin/model/process tests under `src/test/kotlin/com/cotor/` |
 | Runtime evidence and memory | durable actions, provenance, knowledge memory, verification bundles, A2A context | `src/main/kotlin/com/cotor/runtime/`, `src/main/kotlin/com/cotor/provenance/`, `src/main/kotlin/com/cotor/knowledge/`, `src/main/kotlin/com/cotor/verification/`, `src/main/kotlin/com/cotor/context/` | runtime/provenance/knowledge/verification tests |
 | Policy and security | action allow/deny/approval decisions, executable allow-list, path and destructive command checks | `src/main/kotlin/com/cotor/policy/`, `src/main/kotlin/com/cotor/security/` | policy/security tests |
@@ -47,12 +47,12 @@ Use this guide when changing source layout, public entrypoints, route payloads, 
 
 ### Generic pipeline runtime
 
-- Responsibility: execute configured pipelines independently from the desktop company product layer.
+- Responsibility: execute configured pipelines independently from the desktop company product layer, including deterministic guard checks and conflict-safe parallel batching.
 - Public entrypoints: orchestrator/executor packages and validation/config APIs.
 - Internal-only files: stage aggregation, loop/condition internals, checkpoint internals.
 - May depend on: config, validation, monitoring, provider execution interfaces.
 - Must not depend on: `app/DesktopAppService.kt`, `/api/app` DTOs, macOS DTOs.
-- Common changes: pipeline semantics, stage execution, retry behavior, checkpoint output. Update pipeline tests and command docs.
+- Common changes: pipeline semantics, stage execution, guard/stuck/conflict behavior, retry behavior, checkpoint output. Update pipeline tests and command docs.
 
 ### Agent/provider execution
 

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -4305,6 +4305,7 @@ final class DesktopStore: ObservableObject {
         let generation = companyEventStreamGeneration
         companyEventTask = Task { [weak self] in
             guard let self else { return }
+            var reconnectDelaySeconds = 1
             defer {
                 Task { @MainActor [weak self] in
                     guard let self, self.companyEventStreamGeneration == generation else { return }
@@ -4333,6 +4334,7 @@ final class DesktopStore: ObservableObject {
                                 self.syncBackendFormState()
                             }
                         }
+                        reconnectDelaySeconds = 1
                         if envelope.companyDashboard == nil && envelope.dashboard == nil {
                             await self.refreshCompanyDashboard(restartEventStream: false)
                         }
@@ -4357,7 +4359,8 @@ final class DesktopStore: ObservableObject {
                     }
                     guard shouldRetry else { return }
                     await self.refreshCompanyDashboard(restartEventStream: false)
-                    try? await Task.sleep(for: .seconds(1))
+                    try? await Task.sleep(for: .seconds(reconnectDelaySeconds))
+                    reconnectDelaySeconds = min(reconnectDelaySeconds * 2, 15)
                 }
             }
         }
@@ -4367,6 +4370,11 @@ final class DesktopStore: ObservableObject {
         guard companyPollingTask == nil else { return }
         companyPollingTask = Task { [weak self] in
             guard let self else { return }
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.companyPollingTask = nil
+                }
+            }
             while !Task.isCancelled {
                 let pollState = await MainActor.run { () -> (shouldRefresh: Bool, isOffline: Bool) in
                     (
@@ -4390,7 +4398,12 @@ final class DesktopStore: ObservableObject {
 
     private func startEmbeddedBackendWatchdog() {
         guard backendWatchdogTask == nil else { return }
-        backendWatchdogTask = Task {
+        backendWatchdogTask = Task { [weak self] in
+            defer {
+                Task { @MainActor [weak self] in
+                    self?.backendWatchdogTask = nil
+                }
+            }
             while !Task.isCancelled {
                 await EmbeddedBackendLauncher.shared.ensureRunning()
                 try? await Task.sleep(for: .seconds(5))
@@ -4584,6 +4597,13 @@ final class DesktopStore: ObservableObject {
         tuiPollingTask = Task { [weak self] in
             guard let self else { return }
             var refreshCounter = 0
+            defer {
+                Task { @MainActor [weak self] in
+                    guard let self, self.polledTuiSessionID == sessionID else { return }
+                    self.tuiPollingTask = nil
+                    self.polledTuiSessionID = nil
+                }
+            }
 
             while !Task.isCancelled {
                 do {

--- a/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
@@ -923,6 +923,9 @@ private func session(agentId: String, agentName: String, issueId: String?, statu
         backendKind: "LOCAL_COTOR",
         processId: 123,
         outputSnippet: "working",
+        currentActivity: nil,
+        progressPercent: nil,
+        lastLogLine: nil,
         startedAt: 0,
         updatedAt: 10
     )

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -60,6 +60,7 @@ import java.io.IOException
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
 import java.nio.channels.OverlappingFileLockException
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
@@ -849,7 +850,9 @@ internal fun Application.cotorAppModule(
                     if (path.isBlank()) {
                         return@get call.respond(HttpStatusCode.BadRequest, mapOf("error" to "path must not be blank"))
                     }
-                    call.respond(desktopService.evidenceForFile(path))
+                    respondDesktopRequest {
+                        desktopService.evidenceForFile(path)
+                    }
                 }
 
                 get("/pull-requests/{pullRequestNumber}") {
@@ -2487,7 +2490,7 @@ private fun truncateForApi(value: String, maxChars: Int): String {
 private suspend fun RoutingContext.requireToken(token: String?): Boolean {
     val expected = token?.takeIf { it.isNotBlank() } ?: return true
     val actual = call.request.header(HttpHeaders.Authorization)
-    if (actual == "Bearer $expected") {
+    if (isBearerTokenMatch(actual, expected)) {
         return true
     }
     call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "Unauthorized"))
@@ -2501,6 +2504,27 @@ private suspend fun RoutingContext.requireControlToken(controlToken: String?): B
         return false
     }
     return requireToken(expected)
+}
+
+private fun isBearerTokenMatch(header: String?, expected: String): Boolean {
+    val actual = header
+        ?.takeIf { it.startsWith("Bearer ") }
+        ?.removePrefix("Bearer ")
+        ?: return false
+    return constantTimeEquals(actual, expected)
+}
+
+private fun constantTimeEquals(actual: String, expected: String): Boolean {
+    val actualBytes = actual.toByteArray(StandardCharsets.UTF_8)
+    val expectedBytes = expected.toByteArray(StandardCharsets.UTF_8)
+    val maxLength = maxOf(actualBytes.size, expectedBytes.size)
+    var diff = actualBytes.size xor expectedBytes.size
+    for (index in 0 until maxLength) {
+        val actualByte = actualBytes.getOrNull(index)?.toInt() ?: 0
+        val expectedByte = expectedBytes.getOrNull(index)?.toInt() ?: 0
+        diff = diff or (actualByte xor expectedByte)
+    }
+    return diff == 0
 }
 
 /**

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -247,6 +247,7 @@ class DesktopAppService(
         private const val SUPERSEDED_PR_RECONCILIATION_INTERVAL_MS = 5L * 60_000L
         private const val NO_OP_PR_REUSE_REFRESH_INTERVAL_MS = 60_000L
         private const val PR_METADATA_REFRESH_CACHE_MS = 60_000L
+        private const val AGENT_MODEL_DISCOVERY_CACHE_MS = 5L * 60_000L
         private const val CEO_PLANNING_SOURCE = "ceo-planning"
         private const val FALLBACK_PLANNING_SOURCE_PREFIX = "fallback-planning:"
         private const val CEO_PLANNING_INVALID_OUTPUT = "CEO_PLANNING_INVALID_OUTPUT"
@@ -288,6 +289,7 @@ class DesktopAppService(
     // cannot be partially overwritten when multiple agent runs finish at once.
     private val stateMutex = Mutex()
     private val companyRuntimeTickMutexes = mutableMapOf<String, Mutex>()
+    private val runtimeLifecycleLock = Any()
 
     // Runs execute in background coroutines so the API can return immediately after
     // the user presses "Run Task" in the desktop client.
@@ -339,10 +341,13 @@ class DesktopAppService(
 
     fun shutdown() {
         runBlocking {
-            val jobsToJoin = buildList {
-                addAll(activeTaskJobs.values.filterNotNull())
-                addAll(companyRuntimeJobs.values.filterNotNull())
-                addAll(automationRefreshJobs.values.filterNotNull())
+            serviceScope.cancel("DesktopAppService shutdown")
+            val jobsToJoin = synchronized(runtimeLifecycleLock) {
+                buildList {
+                    addAll(activeTaskJobs.values.filterNotNull())
+                    addAll(companyRuntimeJobs.values.filterNotNull())
+                    addAll(automationRefreshJobs.values.filterNotNull())
+                }.distinct()
             }.distinct()
             jobsToJoin.forEach { it.cancel() }
             withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
@@ -352,16 +357,19 @@ class DesktopAppService(
                 interruptActiveTasksForShutdown()
             }
         }
-        activeTaskJobs.clear()
-        companyRuntimeJobs.clear()
-        companyRuntimeTickMutexes.clear()
-        companyRuntimeWakeSignals.clear()
-        automationRefreshJobs.clear()
+        synchronized(runtimeLifecycleLock) {
+            activeTaskJobs.clear()
+            companyRuntimeJobs.clear()
+            companyRuntimeTickMutexes.clear()
+            companyRuntimeWakeSignals.clear()
+            automationRefreshJobs.clear()
+        }
         intentionallyInterruptedTaskIds.clear()
         recentCompanyAutomationTraceKeys.clear()
         recentSupersededPullRequestCleanupAt.clear()
         recentNoOpPullRequestRefreshAt.clear()
         recentPullRequestMetadataRefreshes.clear()
+        recentAgentModelDiscoveries.clear()
         codexAppServerManager.stopAll()
         serviceScope.cancel()
         liveServicesForTesting -= this
@@ -387,10 +395,20 @@ class DesktopAppService(
         "interruptedTaskIds" to intentionallyInterruptedTaskIds.size,
         "traceKeys" to recentCompanyAutomationTraceKeys.size,
         "supersededPrTimestamps" to recentSupersededPullRequestCleanupAt.size,
-        "pullRequestMetadataRefreshes" to recentPullRequestMetadataRefreshes.size
+        "pullRequestMetadataRefreshes" to recentPullRequestMetadataRefreshes.size,
+        "agentModelDiscoveries" to recentAgentModelDiscoveries.size
     )
 
+    private fun pruneRuntimeCaches(now: Long = System.currentTimeMillis()) {
+        recentCompanyAutomationTraceKeys.entries.removeIf { now - it.value > COMPANY_TRACE_DEDUP_WINDOW_MS }
+        recentSupersededPullRequestCleanupAt.entries.removeIf { now - it.value > SUPERSEDED_PR_RECONCILIATION_INTERVAL_MS * 2 }
+        recentNoOpPullRequestRefreshAt.entries.removeIf { now - it.value > NO_OP_PR_REUSE_REFRESH_INTERVAL_MS * 2 }
+        recentPullRequestMetadataRefreshes.entries.removeIf { now - it.value.refreshedAt > PR_METADATA_REFRESH_CACHE_MS * 2 }
+        recentAgentModelDiscoveries.entries.removeIf { now - it.value.discoveredAt > AGENT_MODEL_DISCOVERY_CACHE_MS * 2 }
+    }
+
     suspend fun dashboard(): DashboardResponse {
+        pruneRuntimeCaches()
         // Every dashboard read is also a chance to heal background loops after an app-server
         // restart. The read path stays cheap, but it nudges the automation layer back into the
         // expected steady state before serializing the full desktop snapshot.
@@ -2885,7 +2903,9 @@ class DesktopAppService(
         provenanceService.bundleForRun(runId)
 
     suspend fun evidenceForFile(path: String): EvidenceBundle =
-        provenanceService.bundleForFile(path)
+        provenanceService.bundleForFile(
+            EvidencePathPolicy.requireAllowedFilePath(path, stateStore.load()).toString()
+        )
 
     suspend fun evidenceForPullRequest(pullRequestNumber: Int): EvidenceBundle =
         provenanceService.bundleForPullRequest(pullRequestNumber)
@@ -12544,6 +12564,7 @@ class DesktopAppService(
     }
 
     fun settings(): DesktopSettings {
+        pruneRuntimeCaches()
         val state = runBlocking { stateStore.load() }
         val githubPublishStatus = runBlocking { computeGitHubPublishStatus(state = state) }
         val availableAgentModels = listOf("opencode", "gemma4", "ollama", "lmstudio")
@@ -12626,7 +12647,7 @@ class DesktopAppService(
     private fun discoverLocalModelsCached(cacheKey: String, discover: () -> List<String>): List<String> {
         val now = System.currentTimeMillis()
         recentAgentModelDiscoveries[cacheKey]
-            ?.takeIf { now - it.discoveredAt < 5 * 60_000L }
+            ?.takeIf { now - it.discoveredAt < AGENT_MODEL_DISCOVERY_CACHE_MS }
             ?.let { return it.models }
         val models = runCatching(discover).getOrDefault(emptyList())
         recentAgentModelDiscoveries[cacheKey] = CachedAgentModels(now, models)
@@ -12645,7 +12666,7 @@ class DesktopAppService(
     private fun discoverOpenCodeModelsCached(): List<String> {
         val now = System.currentTimeMillis()
         recentAgentModelDiscoveries["opencode"]
-            ?.takeIf { now - it.discoveredAt < 5 * 60_000L }
+            ?.takeIf { now - it.discoveredAt < AGENT_MODEL_DISCOVERY_CACHE_MS }
             ?.let { return it.models }
         if (!isExecutableAvailable("opencode")) {
             recentAgentModelDiscoveries["opencode"] = CachedAgentModels(now, emptyList())
@@ -14006,11 +14027,13 @@ class DesktopAppService(
                     runBlocking {
                         val existing = stateStore.load().runs.firstOrNull { it.id == startedRun.id }
                             ?: return@runBlocking
-                        replaceRun(existing.copy(
-                            liveActivity = sanitized,
-                            lastLogLine = sanitized,
-                            updatedAt = System.currentTimeMillis()
-                        ))
+                        replaceRun(
+                            existing.copy(
+                                liveActivity = sanitized,
+                                lastLogLine = sanitized,
+                                updatedAt = System.currentTimeMillis()
+                            )
+                        )
                     }
                 }
             )

--- a/src/main/kotlin/com/cotor/app/EvidencePathPolicy.kt
+++ b/src/main/kotlin/com/cotor/app/EvidencePathPolicy.kt
@@ -1,0 +1,31 @@
+package com.cotor.app
+
+import java.nio.file.Path
+
+/**
+ * Keeps evidence file lookups inside roots that the desktop state already owns.
+ */
+internal object EvidencePathPolicy {
+    fun requireAllowedFilePath(path: String, state: DesktopAppState): Path {
+        val requested = canonicalize(Path.of(path))
+        val roots = evidenceRoots(state)
+        require(roots.isNotEmpty()) { "No configured company, repository, or worktree roots are available for evidence lookup" }
+        require(roots.any { requested.startsWith(it) }) {
+            "Evidence file path must stay inside a configured company, repository, or worktree root"
+        }
+        return requested
+    }
+
+    private fun evidenceRoots(state: DesktopAppState): List<Path> {
+        val companyRoots = state.companies.mapNotNull { it.rootPath.takeIf(String::isNotBlank) }
+        val repositoryRoots = state.repositories.mapNotNull { it.localPath.takeIf(String::isNotBlank) }
+        val worktreeRoots = state.runs.mapNotNull { it.worktreePath.takeIf(String::isNotBlank) }
+        return (companyRoots + repositoryRoots + worktreeRoots)
+            .map { canonicalize(Path.of(it)) }
+            .distinct()
+    }
+
+    private fun canonicalize(path: Path): Path =
+        runCatching { path.toRealPath() }
+            .getOrElse { path.toAbsolutePath().normalize() }
+}

--- a/src/main/kotlin/com/cotor/data/plugin/OpenAIPlugin.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/OpenAIPlugin.kt
@@ -11,6 +11,7 @@ package com.cotor.data.plugin
 import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.process.ProcessManager
 import com.cotor.model.*
+import com.cotor.security.NetworkEndpointPolicy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -58,6 +59,13 @@ class OpenAIPlugin : AgentPlugin {
                 defaultValue = "https://api.openai.com/v1"
             ),
             AgentParameter(
+                name = "allowPrivateBaseUrl",
+                type = ParameterType.BOOLEAN,
+                required = false,
+                description = "Allow localhost/private OpenAI-compatible endpoints. Disabled by default to prevent SSRF.",
+                defaultValue = "false"
+            ),
+            AgentParameter(
                 name = "apiKeyEnv",
                 type = ParameterType.STRING,
                 required = false,
@@ -100,7 +108,13 @@ class OpenAIPlugin : AgentPlugin {
         val prompt = context.input ?: throw IllegalArgumentException("Input prompt is required")
 
         val model = context.parameters["model"] ?: "gpt-4o-mini"
-        val baseUrl = (context.parameters["baseUrl"] ?: "https://api.openai.com/v1").trimEnd('/')
+        val rawBaseUrl = context.parameters["baseUrl"] ?: "https://api.openai.com/v1"
+        val allowPrivateBaseUrl = context.parameters["allowPrivateBaseUrl"]?.toBooleanStrictOrNull() ?: false
+        val baseUrl = NetworkEndpointPolicy.requirePublicHttpUrl(
+            rawUrl = rawBaseUrl,
+            label = "OpenAI baseUrl",
+            allowPrivateHosts = allowPrivateBaseUrl
+        ).toString().trimEnd('/')
         val apiKeyEnv = context.parameters["apiKeyEnv"] ?: "OPENAI_API_KEY"
         val apiKey = resolveApiKey(context, apiKeyEnv)
         val system = context.parameters["system"].orEmpty()

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -38,9 +38,25 @@ interface ProcessManager {
         environment: Map<String, String>,
         timeout: Long,
         workingDirectory: Path? = null,
-        onStart: ((Long) -> Unit)? = null,
-        onStdoutChunk: ((String) -> Unit)? = null
+        onStart: ((Long) -> Unit)? = null
     ): ProcessResult
+
+    suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path? = null,
+        onStart: ((Long) -> Unit)? = null,
+        onStdoutChunk: ((String) -> Unit)?
+    ): ProcessResult = executeProcess(
+        command = command,
+        input = input,
+        environment = environment,
+        timeout = timeout,
+        workingDirectory = workingDirectory,
+        onStart = onStart
+    )
 }
 
 /**
@@ -49,6 +65,23 @@ interface ProcessManager {
 class CoroutineProcessManager(
     private val logger: Logger
 ) : ProcessManager {
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult = executeProcess(
+        command = command,
+        input = input,
+        environment = environment,
+        timeout = timeout,
+        workingDirectory = workingDirectory,
+        onStart = onStart,
+        onStdoutChunk = null
+    )
 
     override suspend fun executeProcess(
         command: List<String>,

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineGuardService.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineGuardService.kt
@@ -1,0 +1,139 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.model.AgentResult
+import com.cotor.model.FailureCategory
+import com.cotor.model.PipelineContext
+import com.cotor.model.PipelineStage
+
+enum class PipelineGuardSeverity {
+    WARNING,
+    BLOCKING
+}
+
+data class PipelineGuardFinding(
+    val code: String,
+    val severity: PipelineGuardSeverity,
+    val message: String
+)
+
+data class PipelineGuardResult(
+    val confidenceScore: Int,
+    val findings: List<PipelineGuardFinding>
+) {
+    val blockingFindings: List<PipelineGuardFinding>
+        get() = findings.filter { it.severity == PipelineGuardSeverity.BLOCKING }
+}
+
+class PipelineGuardService {
+    fun evaluate(
+        stage: PipelineStage,
+        result: AgentResult,
+        context: PipelineContext
+    ): PipelineGuardResult {
+        val text = listOfNotNull(result.output, result.error).joinToString("\n")
+        val lower = text.lowercase()
+        val findings = buildList {
+            detectUncertainty(lower)?.let(::add)
+            detectFakeData(lower)?.let(::add)
+            detectRiskyPatterns(text)?.let(::add)
+            detectMissingVerification(stage, result, lower)?.let(::add)
+            detectWorktreeHygiene(result, context)?.let(::add)
+        }
+        val confidencePenalty = findings.fold(0) { total, finding ->
+            total + when (finding.severity) {
+                PipelineGuardSeverity.BLOCKING -> 45
+                PipelineGuardSeverity.WARNING -> 12
+            }
+        }
+        val confidence = (100 - confidencePenalty).coerceIn(0, 100)
+        return PipelineGuardResult(confidence, findings)
+    }
+
+    fun apply(
+        stage: PipelineStage,
+        result: AgentResult,
+        context: PipelineContext
+    ): AgentResult {
+        val guardResult = evaluate(stage, result, context)
+        val findingSummary = guardResult.findings.joinToString(" | ") { "${it.severity}:${it.code}:${it.message}" }
+        val metadata = result.metadata + mapOf(
+            "pipelineGuardStatus" to if (guardResult.blockingFindings.isEmpty()) "PASS" else "BLOCK",
+            "pipelineGuardConfidence" to guardResult.confidenceScore.toString(),
+            "pipelineGuardFindings" to findingSummary,
+            "pipelineGuardBlockingCount" to guardResult.blockingFindings.size.toString()
+        )
+        if (guardResult.blockingFindings.isEmpty()) {
+            return result.copy(metadata = metadata)
+        }
+
+        val message = guardResult.blockingFindings.joinToString("; ") { it.message }
+        return result.copy(
+            isSuccess = false,
+            error = listOfNotNull(result.error, "Pipeline guard blocked stage ${stage.id}: $message").joinToString("\n"),
+            metadata = metadata + ("failureCategory" to FailureCategory.VALIDATION_FAILED.name)
+        )
+    }
+
+    private fun detectUncertainty(lower: String): PipelineGuardFinding? {
+        val patterns = listOf("not tested", "untested", "maybe", "probably", "workaround", "i think", "i assume")
+        val matched = patterns.firstOrNull { lower.contains(it) } ?: return null
+        return PipelineGuardFinding(
+            code = "UNCERTAINTY",
+            severity = PipelineGuardSeverity.WARNING,
+            message = "Agent output contains uncertainty marker '$matched'"
+        )
+    }
+
+    private fun detectFakeData(lower: String): PipelineGuardFinding? {
+        val patterns = listOf("faker.", "math.random(", "mock data", "dummy data", "placeholder data")
+        val matched = patterns.firstOrNull { lower.contains(it) } ?: return null
+        return PipelineGuardFinding(
+            code = "FAKE_DATA",
+            severity = PipelineGuardSeverity.WARNING,
+            message = "Agent output mentions fake or placeholder data marker '$matched'"
+        )
+    }
+
+    private fun detectRiskyPatterns(text: String): PipelineGuardFinding? {
+        val hardcodedSecret = Regex("""(?i)(api[_-]?key|secret|password|token)\s*=\s*["'][^"']{8,}["']""")
+        if (!hardcodedSecret.containsMatchIn(text)) return null
+        return PipelineGuardFinding(
+            code = "HARDCODED_SECRET",
+            severity = PipelineGuardSeverity.BLOCKING,
+            message = "Agent output appears to include a hardcoded secret assignment"
+        )
+    }
+
+    private fun detectMissingVerification(
+        stage: PipelineStage,
+        result: AgentResult,
+        lower: String
+    ): PipelineGuardFinding? {
+        if (!result.isSuccess) return null
+        if (stage.validation != null) return null
+        val verificationMarkers = listOf("test", "gradle", "swift build", "typecheck", "lint", "verified", "passed")
+        if (verificationMarkers.any { lower.contains(it) }) return null
+        return PipelineGuardFinding(
+            code = "MISSING_VERIFICATION",
+            severity = PipelineGuardSeverity.WARNING,
+            message = "Successful stage did not report test, build, lint, or verification evidence"
+        )
+    }
+
+    private fun detectWorktreeHygiene(
+        result: AgentResult,
+        context: PipelineContext
+    ): PipelineGuardFinding? {
+        val worktree = result.metadata["worktreePath"] ?: context.metadata["worktreePath"]?.toString()
+        val repoRoot = result.metadata["repositoryRoot"] ?: context.metadata["repositoryRoot"]?.toString()
+        if (worktree.isNullOrBlank() || repoRoot.isNullOrBlank()) return null
+        if (worktree == repoRoot) {
+            return PipelineGuardFinding(
+                code = "SHARED_REPO_WRITE",
+                severity = PipelineGuardSeverity.WARNING,
+                message = "Stage appears to have run in the shared repository root instead of an isolated worktree"
+            )
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -88,7 +88,9 @@ class DefaultPipelineOrchestrator(
     private val checkpointManager: CheckpointManager = CheckpointManager(),
     private val templateValidator: PipelineTemplateValidator = PipelineTemplateValidator(TemplateEngine()),
     private val observability: ObservabilityService = NoopObservabilityService,
-    private val durableRuntimeService: DurableRuntimeService = DurableRuntimeService()
+    private val durableRuntimeService: DurableRuntimeService = DurableRuntimeService(),
+    private val pipelineGuardService: PipelineGuardService = PipelineGuardService(),
+    private val stageConflictDetector: StageConflictDetector = StageConflictDetector()
 ) : PipelineOrchestrator {
     constructor(
         agentExecutor: AgentExecutor,
@@ -368,12 +370,15 @@ class DefaultPipelineOrchestrator(
         pipeline.stages.firstOrNull { it.type != StageType.EXECUTION }?.let {
             throw PipelineException("Stage ${it.id} uses ${it.type} which is not supported in PARALLEL mode")
         }
-        val results = pipeline.stages.map { stage ->
-            async(Dispatchers.Default) {
-                val interpolatedInput = stage.input?.let { templateEngine.interpolate(it, pipelineContext) }
-                executeStageWithGuards(stage, pipelineId, pipelineContext, interpolatedInput)
+        val results = stageConflictDetector.conflictSafeBatches(pipeline.stages, pipelineContext)
+            .flatMap { batch ->
+                batch.map { stage ->
+                    async(Dispatchers.Default) {
+                        val interpolatedInput = stage.input?.let { templateEngine.interpolate(it, pipelineContext) }
+                        executeStageWithGuards(stage, pipelineId, pipelineContext, interpolatedInput)
+                    }
+                }.awaitAll()
             }
-        }.awaitAll()
 
         aggregateResults(results, pipelineContext)
     }
@@ -594,7 +599,11 @@ class DefaultPipelineOrchestrator(
             return timeoutResult
         }
 
-        val stageResult = result.withStageMetadata(stage)
+        val stageResult = pipelineGuardService.apply(
+            stage = stage,
+            result = result.withStageMetadata(stage),
+            context = pipelineContext
+        )
         pipelineContext.addStageResult(stage.id, stageResult)
 
         if (stageResult.isSuccess) {

--- a/src/main/kotlin/com/cotor/domain/orchestrator/StageConflictDetector.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/StageConflictDetector.kt
@@ -1,0 +1,48 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.context.TemplateEngine
+import com.cotor.model.PipelineContext
+import com.cotor.model.PipelineStage
+
+class StageConflictDetector(
+    private val templateEngine: TemplateEngine = TemplateEngine()
+) {
+    fun conflictSafeBatches(
+        stages: List<PipelineStage>,
+        context: PipelineContext
+    ): List<List<PipelineStage>> {
+        val batches = mutableListOf<MutableList<PipelineStage>>()
+        val occupiedKeysByBatch = mutableListOf<MutableSet<String>>()
+
+        stages.forEach { stage ->
+            val keys = conflictKeys(stage, context)
+            val index = occupiedKeysByBatch.indexOfFirst { occupied -> occupied.intersect(keys).isEmpty() }
+            if (index >= 0) {
+                batches[index] += stage
+                occupiedKeysByBatch[index] += keys
+            } else {
+                batches += mutableListOf(stage)
+                occupiedKeysByBatch += keys.toMutableSet()
+            }
+        }
+
+        return batches
+    }
+
+    private fun conflictKeys(stage: PipelineStage, context: PipelineContext): Set<String> {
+        val input = stage.input
+            ?.let { runCatching { templateEngine.interpolate(it, context) }.getOrDefault(it) }
+            .orEmpty()
+        val pathKeys = pathPattern.findAll(input)
+            .map { it.value.trim().removePrefix("./") }
+            .filter { it.length > 2 }
+            .map { "path:$it" }
+            .toSet()
+        val dependencyKeys = stage.dependencies.map { "stage:$it" }.toSet()
+        return (pathKeys + dependencyKeys).ifEmpty { setOf("stage:${stage.id}") }
+    }
+
+    private companion object {
+        private val pathPattern = Regex("""(?:^|\s)([\w./-]+\.(?:kt|kts|swift|ts|tsx|js|jsx|java|go|rs|py|yaml|yml|json|md))""")
+    }
+}

--- a/src/main/kotlin/com/cotor/domain/orchestrator/StuckDetector.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/StuckDetector.kt
@@ -1,0 +1,51 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.model.AgentResult
+
+enum class StuckSignal {
+    SAME_ERROR,
+    REVISION_LOOP,
+    SAME_OUTPUT
+}
+
+class StuckDetector(
+    private val sameErrorRepeat: Int = 2,
+    private val revisionLoop: Int = 4,
+    private val sameOutputRepeat: Int = 3
+) {
+    private val errorFingerprints = mutableListOf<String>()
+    private val outputFingerprints = mutableListOf<String>()
+    private var revisions = 0
+
+    fun record(result: AgentResult): StuckSignal? {
+        revisions += 1
+
+        result.error?.fingerprint()?.takeIf { it.isNotBlank() }?.let { error ->
+            errorFingerprints += error
+            if (errorFingerprints.takeLast(sameErrorRepeat).size == sameErrorRepeat &&
+                errorFingerprints.takeLast(sameErrorRepeat).distinct().size == 1
+            ) {
+                return StuckSignal.SAME_ERROR
+            }
+        }
+
+        result.output?.fingerprint()?.takeIf { it.isNotBlank() }?.let { output ->
+            outputFingerprints += output
+            if (outputFingerprints.takeLast(sameOutputRepeat).size == sameOutputRepeat &&
+                outputFingerprints.takeLast(sameOutputRepeat).distinct().size == 1
+            ) {
+                return StuckSignal.SAME_OUTPUT
+            }
+        }
+
+        return if (revisions >= revisionLoop) StuckSignal.REVISION_LOOP else null
+    }
+
+    private fun String.fingerprint(): String =
+        lowercase()
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .take(12)
+            .joinToString("\n")
+}

--- a/src/main/kotlin/com/cotor/event/EventBus.kt
+++ b/src/main/kotlin/com/cotor/event/EventBus.kt
@@ -10,6 +10,8 @@ package com.cotor.event
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
@@ -49,18 +51,20 @@ interface EventBus {
 /**
  * Coroutine-based event bus implementation
  */
-class CoroutineEventBus : EventBus {
+class CoroutineEventBus(
+    capacity: Int = DEFAULT_CAPACITY
+) : EventBus, AutoCloseable {
     private val subscribers = ConcurrentHashMap<KClass<out CotorEvent>, MutableList<EventSubscription>>()
-    private val eventChannel = Channel<CotorEvent>(Channel.UNLIMITED)
-    private val scope = CoroutineScope(Dispatchers.Default)
+    private val eventChannel = Channel<CotorEvent>(capacity)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val processor = scope.launch {
+        for (event in eventChannel) {
+            processEvent(event)
+        }
+    }
 
     init {
-        // Start event processing coroutine
-        scope.launch {
-            for (event in eventChannel) {
-                processEvent(event)
-            }
-        }
+        require(capacity > 0) { "Event bus capacity must be positive" }
     }
 
     override suspend fun emit(event: CotorEvent) {
@@ -95,5 +99,16 @@ class CoroutineEventBus : EventBus {
                 }
             }
         }
+    }
+
+    override fun close() {
+        eventChannel.close()
+        processor.cancel()
+        scope.cancel()
+        subscribers.clear()
+    }
+
+    private companion object {
+        private const val DEFAULT_CAPACITY = 1024
     }
 }

--- a/src/main/kotlin/com/cotor/integrations/linear/LinearTrackerAdapter.kt
+++ b/src/main/kotlin/com/cotor/integrations/linear/LinearTrackerAdapter.kt
@@ -11,6 +11,7 @@ package com.cotor.integrations.linear
 import com.cotor.app.CompanyIssue
 import com.cotor.app.LinearConnectionConfig
 import com.cotor.data.http.CotorHttpClients
+import com.cotor.security.NetworkEndpointPolicy
 import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -22,7 +23,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
@@ -68,8 +68,9 @@ class LinearClient(
                 put("query", JsonPrimitive(query))
                 put("variables", variables)
             }
+            val endpoint = NetworkEndpointPolicy.requirePublicHttpUrl(config.endpoint, "Linear endpoint")
             val request = HttpRequest.newBuilder()
-                .uri(URI.create(config.endpoint))
+                .uri(endpoint)
                 .timeout(Duration.ofSeconds(30))
                 .header(HttpHeaders.Authorization, token)
                 .header(HttpHeaders.ContentType, "application/json")

--- a/src/main/kotlin/com/cotor/model/Models.kt
+++ b/src/main/kotlin/com/cotor/model/Models.kt
@@ -40,6 +40,8 @@ data class AgentConfig(
     val environment: Map<String, String> = emptyMap(),
     val timeout: Long = 30000, // 30 seconds
     val retryPolicy: RetryPolicy = RetryPolicy(),
+    val escalateAfterAttempt: Int? = null,
+    val escalateModel: String? = null,
     val tags: List<String> = emptyList(),
     val inputFormat: DataFormat = DataFormat.JSON,
     val outputFormat: DataFormat = DataFormat.JSON

--- a/src/main/kotlin/com/cotor/monitoring/Monitoring.kt
+++ b/src/main/kotlin/com/cotor/monitoring/Monitoring.kt
@@ -148,7 +148,7 @@ class MetricsCollector {
     }
 
     fun getMetrics(agentName: String): AgentMetrics {
-        val executionTimes = agentExecutionTimes[agentName] ?: emptyList()
+        val executionTimes = snapshotDurations(agentExecutionTimes[agentName])
         val successCount = agentSuccessRates[agentName]?.get() ?: 0
         val failureCount = agentFailureRates[agentName]?.get() ?: 0
 
@@ -193,13 +193,13 @@ class MetricsCollector {
         duration: Long,
         success: Boolean
     ) {
-        executionTimes.computeIfAbsent(name) { Collections.synchronizedList(mutableListOf()) }
-            .apply {
-                add(duration)
-                while (size > MAX_DURATION_SAMPLES_PER_KEY) {
-                    removeAt(0)
-                }
+        val samples = executionTimes.computeIfAbsent(name) { Collections.synchronizedList(mutableListOf()) }
+        synchronized(samples) {
+            samples.add(duration)
+            while (samples.size > MAX_DURATION_SAMPLES_PER_KEY) {
+                samples.removeAt(0)
             }
+        }
 
         if (success) {
             successRates.computeIfAbsent(name) { AtomicInteger(0) }
@@ -216,7 +216,7 @@ class MetricsCollector {
         successCount: Int?,
         failureCount: Int?
     ): ExecutionMetrics {
-        val durations = executionTimes ?: emptyList()
+        val durations = snapshotDurations(executionTimes)
         val successes = successCount ?: 0
         val failures = failureCount ?: 0
 
@@ -229,6 +229,11 @@ class MetricsCollector {
             minDuration = durations.minOrNull() ?: 0,
             maxDuration = durations.maxOrNull() ?: 0
         )
+    }
+
+    private fun snapshotDurations(executionTimes: List<Long>?): List<Long> {
+        if (executionTimes == null) return emptyList()
+        return synchronized(executionTimes) { executionTimes.toList() }
     }
 }
 

--- a/src/main/kotlin/com/cotor/monitoring/SpinnerAnimation.kt
+++ b/src/main/kotlin/com/cotor/monitoring/SpinnerAnimation.kt
@@ -27,13 +27,17 @@ class SpinnerAnimation(
     private val frames = listOf("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
     private var currentFrame = 0
     private val startTime = Instant.now()
+    private var scope: CoroutineScope? = null
     private var job: Job? = null
 
     /**
      * Start the spinner animation
      */
     fun start() {
-        job = CoroutineScope(Dispatchers.Default).launch {
+        if (job?.isActive == true) return
+        val animationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope = animationScope
+        job = animationScope.launch {
             while (isActive) {
                 render()
                 delay(80)
@@ -47,6 +51,9 @@ class SpinnerAnimation(
      */
     fun stop(finalMessage: String? = null) {
         job?.cancel()
+        job = null
+        scope?.cancel()
+        scope = null
         clearLine()
         if (finalMessage != null) {
             terminal.println(finalMessage)
@@ -128,10 +135,14 @@ class DotsAnimation(private val message: String) {
     private val terminal = Terminal()
     private var dots = ""
     private val maxDots = 3
+    private var scope: CoroutineScope? = null
     private var job: Job? = null
 
     fun start() {
-        job = CoroutineScope(Dispatchers.Default).launch {
+        if (job?.isActive == true) return
+        val animationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope = animationScope
+        job = animationScope.launch {
             while (isActive) {
                 clearLine()
                 terminal.print("\r$message$dots")
@@ -143,6 +154,9 @@ class DotsAnimation(private val message: String) {
 
     fun stop(finalMessage: String? = null) {
         job?.cancel()
+        job = null
+        scope?.cancel()
+        scope = null
         clearLine()
         if (finalMessage != null) {
             terminal.println(finalMessage)

--- a/src/main/kotlin/com/cotor/recovery/RecoveryExecutor.kt
+++ b/src/main/kotlin/com/cotor/recovery/RecoveryExecutor.kt
@@ -10,6 +10,7 @@ package com.cotor.recovery
 
 import com.cotor.data.registry.AgentRegistry
 import com.cotor.domain.executor.AgentExecutor
+import com.cotor.domain.orchestrator.StuckDetector
 import com.cotor.model.*
 import com.cotor.validation.output.OutputValidator
 import kotlinx.coroutines.delay
@@ -66,16 +67,43 @@ class RecoveryExecutor(
         var delayMs = recovery.retryDelayMs
         var lastResult: AgentResult? = null
         var currentInput = input
+        val stuckDetector = StuckDetector()
 
         repeat(attempts) { attempt ->
             val currentAttempt = attempt + 1
             logger.debug("Executing stage ${stage.id} attempt $currentAttempt/$attempts")
-            val result = runAgent(agentConfig, stage, currentInput, pipelineContext)
+            val effectiveAgent = agentConfig.escalatedForAttempt(currentAttempt)
+            val result = runAgent(effectiveAgent, stage, currentInput, pipelineContext)
+                .let { executionResult ->
+                    if (effectiveAgent === agentConfig) {
+                        executionResult
+                    } else {
+                        executionResult.copy(
+                            metadata = executionResult.metadata + mapOf(
+                                "escalatedModel" to requireNotNull(agentConfig.escalateModel),
+                                "escalatedFromAgent" to agentConfig.name,
+                                "escalatedAttempt" to currentAttempt.toString()
+                            )
+                        )
+                    }
+                }
             if (result.isSuccess) {
                 return result
             }
 
             lastResult = result
+            stuckDetector.record(result)?.let { signal ->
+                return result.copy(
+                    error = listOfNotNull(
+                        result.error,
+                        "Stage ${stage.id} stopped early because stuck detector signaled $signal"
+                    ).joinToString("\n"),
+                    metadata = result.metadata + mapOf(
+                        "stuckSignal" to signal.name,
+                        "failureCategory" to FailureCategory.AGENT_ERROR.name
+                    )
+                )
+            }
             if (!isRetryable(result.error, recovery.retryOn)) {
                 logger.debug("Stage ${stage.id} failure not retryable: ${result.error}")
                 return result
@@ -108,6 +136,13 @@ class RecoveryExecutor(
         }
 
         return lastResult ?: failureResult(agentConfig.name, "Stage ${stage.id} failed without result")
+    }
+
+    private fun AgentConfig.escalatedForAttempt(attempt: Int): AgentConfig {
+        val afterAttempt = escalateAfterAttempt ?: return this
+        val targetModel = escalateModel?.takeIf { it.isNotBlank() } ?: return this
+        if (attempt < afterAttempt.coerceAtLeast(1)) return this
+        return copy(parameters = parameters + ("model" to targetModel))
     }
 
     private suspend fun executeWithFallback(

--- a/src/main/kotlin/com/cotor/security/NetworkEndpointPolicy.kt
+++ b/src/main/kotlin/com/cotor/security/NetworkEndpointPolicy.kt
@@ -1,0 +1,70 @@
+package com.cotor.security
+
+import java.net.URI
+
+/**
+ * Validates user-configurable HTTP endpoints before outbound clients use them.
+ */
+object NetworkEndpointPolicy {
+    fun requirePublicHttpUrl(
+        rawUrl: String,
+        label: String,
+        allowPrivateHosts: Boolean = false
+    ): URI {
+        val trimmed = rawUrl.trim()
+        require(trimmed.isNotBlank()) { "$label is required" }
+
+        val uri = runCatching { URI(trimmed) }
+            .getOrElse { throw IllegalArgumentException("$label must be a valid URI") }
+            .normalize()
+        val scheme = uri.scheme?.lowercase()
+        require(scheme == "https" || scheme == "http") { "$label must use http or https" }
+        require(!uri.host.isNullOrBlank()) { "$label must include a host" }
+        require(uri.userInfo == null) { "$label must not include credentials" }
+
+        if (!allowPrivateHosts) {
+            val host = uri.host.trim().trim('[', ']').lowercase()
+            require(!isPrivateOrLocalHost(host)) { "$label must not target localhost or a private network address" }
+        }
+
+        return uri
+    }
+
+    private fun isPrivateOrLocalHost(host: String): Boolean {
+        if (host == "localhost" || host.endsWith(".localhost") || host == "0") return true
+        if (host == "::1" || host == "0:0:0:0:0:0:0:1") return true
+
+        parseIpv4(host)?.let { octets ->
+            val first = octets[0]
+            val second = octets[1]
+            return first == 0 ||
+                first == 10 ||
+                first == 127 ||
+                first == 169 && second == 254 ||
+                first == 172 && second in 16..31 ||
+                first == 192 && second == 168
+        }
+
+        if (host.contains(":")) {
+            val normalized = host.lowercase()
+            return normalized.startsWith("fc") ||
+                normalized.startsWith("fd") ||
+                normalized.startsWith("fe80") ||
+                normalized == "::" ||
+                normalized.startsWith("::ffff:127.") ||
+                normalized.startsWith("::ffff:10.") ||
+                normalized.startsWith("::ffff:192.168.")
+        }
+
+        return false
+    }
+
+    private fun parseIpv4(host: String): List<Int>? {
+        val parts = host.split('.')
+        if (parts.size != 4) return null
+        return parts.map { part ->
+            if (part.isEmpty() || part.any { !it.isDigit() }) return null
+            part.toIntOrNull()?.takeIf { it in 0..255 } ?: return null
+        }
+    }
+}

--- a/src/test/kotlin/com/cotor/app/EvidencePathPolicyTest.kt
+++ b/src/test/kotlin/com/cotor/app/EvidencePathPolicyTest.kt
@@ -1,0 +1,52 @@
+package com.cotor.app
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+
+class EvidencePathPolicyTest : FunSpec({
+    test("allows evidence files inside configured company repository and worktree roots") {
+        val root = Files.createTempDirectory("cotor-evidence-root")
+        val file = Files.createDirectories(root.resolve("src")).resolve("Main.kt")
+        Files.writeString(file, "fun main() = Unit\n")
+        val state = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Evidence Co",
+                    rootPath = root.toString(),
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1,
+                    updatedAt = 1
+                )
+            )
+        )
+
+        EvidencePathPolicy.requireAllowedFilePath(file.toString(), state) shouldBe file.toRealPath()
+    }
+
+    test("rejects traversal outside configured roots") {
+        val root = Files.createTempDirectory("cotor-evidence-root")
+        val outside = Files.createTempFile("cotor-evidence-outside", ".txt")
+        val state = DesktopAppState(
+            repositories = listOf(
+                ManagedRepository(
+                    id = "repo-1",
+                    name = "repo",
+                    localPath = root.toString(),
+                    sourceKind = RepositorySourceKind.LOCAL,
+                    defaultBranch = "master",
+                    createdAt = 1,
+                    updatedAt = 1
+                )
+            )
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            EvidencePathPolicy.requireAllowedFilePath(outside.toString(), state)
+        }.message shouldContain "must stay inside"
+    }
+})

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineGuardServiceTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineGuardServiceTest.kt
@@ -1,0 +1,55 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.model.AgentResult
+import com.cotor.model.PipelineContext
+import com.cotor.model.PipelineStage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class PipelineGuardServiceTest : FunSpec({
+    val service = PipelineGuardService()
+    val context = PipelineContext(pipelineId = "pipeline-1", pipelineName = "guards", totalStages = 1)
+
+    test("adds warning metadata for uncertainty and missing verification evidence") {
+        val guarded = service.apply(
+            stage = PipelineStage(id = "draft"),
+            result = AgentResult(
+                agentName = "worker",
+                isSuccess = true,
+                output = "Implemented the change, but maybe incomplete.",
+                error = null,
+                duration = 10,
+                metadata = emptyMap()
+            ),
+            context = context
+        )
+
+        guarded.isSuccess.shouldBeTrue()
+        guarded.metadata["pipelineGuardStatus"] shouldBe "PASS"
+        guarded.metadata["pipelineGuardFindings"] shouldContain "UNCERTAINTY"
+        guarded.metadata["pipelineGuardFindings"] shouldContain "MISSING_VERIFICATION"
+    }
+
+    test("blocks hardcoded secret shaped output before reviewer stages consume it") {
+        val guarded = service.apply(
+            stage = PipelineStage(id = "draft"),
+            result = AgentResult(
+                agentName = "worker",
+                isSuccess = true,
+                output = "val apiKey = \"sk-this-should-not-ship\"",
+                error = null,
+                duration = 10,
+                metadata = emptyMap()
+            ),
+            context = context
+        )
+
+        guarded.isSuccess.shouldBeFalse()
+        guarded.metadata["pipelineGuardStatus"] shouldBe "BLOCK"
+        guarded.metadata["failureCategory"] shouldBe "VALIDATION_FAILED"
+        guarded.error shouldContain "Pipeline guard blocked"
+    }
+})

--- a/src/test/kotlin/com/cotor/domain/orchestrator/StageConflictDetectorTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/StageConflictDetectorTest.kt
@@ -1,0 +1,25 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.model.PipelineContext
+import com.cotor.model.PipelineStage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class StageConflictDetectorTest : FunSpec({
+    test("separates parallel stages that target the same file") {
+        val detector = StageConflictDetector()
+        val context = PipelineContext("pipeline-1", "parallel", totalStages = 3)
+        val stages = listOf(
+            PipelineStage(id = "a", input = "edit src/main/kotlin/Foo.kt"),
+            PipelineStage(id = "b", input = "also edit src/main/kotlin/Foo.kt"),
+            PipelineStage(id = "c", input = "edit src/main/kotlin/Bar.kt")
+        )
+
+        val batches = detector.conflictSafeBatches(stages, context)
+
+        batches.size shouldBe 2
+        batches[0].map { it.id }.shouldContainExactly("a", "c")
+        batches[1].map { it.id }.shouldContainExactly("b")
+    }
+})

--- a/src/test/kotlin/com/cotor/domain/orchestrator/StuckDetectorTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/StuckDetectorTest.kt
@@ -1,0 +1,24 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.model.AgentResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class StuckDetectorTest : FunSpec({
+    test("signals same repeated error before max iteration exhaustion") {
+        val detector = StuckDetector(sameErrorRepeat = 2)
+        val first = AgentResult("worker", false, null, "compile failed on Foo.kt:10", 1, emptyMap())
+        val second = first.copy(duration = 2)
+
+        detector.record(first) shouldBe null
+        detector.record(second) shouldBe StuckSignal.SAME_ERROR
+    }
+
+    test("signals revision loop when failures keep changing") {
+        val detector = StuckDetector(sameErrorRepeat = 3, revisionLoop = 3)
+
+        detector.record(AgentResult("worker", false, null, "first", 1, emptyMap())) shouldBe null
+        detector.record(AgentResult("worker", false, null, "second", 1, emptyMap())) shouldBe null
+        detector.record(AgentResult("worker", false, null, "third", 1, emptyMap())) shouldBe StuckSignal.REVISION_LOOP
+    }
+})

--- a/src/test/kotlin/com/cotor/event/CoroutineEventBusTest.kt
+++ b/src/test/kotlin/com/cotor/event/CoroutineEventBusTest.kt
@@ -1,0 +1,21 @@
+package com.cotor.event
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.delay
+
+class CoroutineEventBusTest : FunSpec({
+    test("uses a bounded queue and close cancels processing resources") {
+        val bus = CoroutineEventBus(capacity = 4)
+        val received = mutableListOf<String>()
+        bus.subscribe(PipelineStartedEvent::class) { event ->
+            received += (event as PipelineStartedEvent).pipelineId
+        }
+
+        bus.emit(PipelineStartedEvent("pipeline-1", "one"))
+        delay(100)
+        received.shouldContainExactly("pipeline-1")
+
+        bus.close()
+    }
+})

--- a/src/test/kotlin/com/cotor/integrations/linear/LinearClientEndpointPolicyTest.kt
+++ b/src/test/kotlin/com/cotor/integrations/linear/LinearClientEndpointPolicyTest.kt
@@ -1,0 +1,21 @@
+package com.cotor.integrations.linear
+
+import com.cotor.app.LinearConnectionConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.string.shouldContain
+
+class LinearClientEndpointPolicyTest : FunSpec({
+    test("rejects private Linear GraphQL endpoints before sending a request") {
+        val result = LinearClient().graphql(
+            config = LinearConnectionConfig(
+                endpoint = "http://127.0.0.1:8080/graphql",
+                apiToken = "linear-token"
+            ),
+            query = "query CotorLinearViewer { viewer { id } }"
+        )
+
+        result.isFailure.shouldBeTrue()
+        result.exceptionOrNull()?.message shouldContain "private network"
+    }
+})

--- a/src/test/kotlin/com/cotor/recovery/RecoveryExecutorTest.kt
+++ b/src/test/kotlin/com/cotor/recovery/RecoveryExecutorTest.kt
@@ -130,7 +130,7 @@ class RecoveryExecutorTest : FunSpec({
             recoveryExecutor.executeWithRecovery(stage, "input", null)
         }
 
-        coVerify(exactly = 3) {
+        coVerify(exactly = 2) {
             agentExecutor.executeAgent(any(), any(), any())
         }
     }
@@ -160,7 +160,7 @@ class RecoveryExecutorTest : FunSpec({
             recoveryExecutor.executeWithRecovery(stage, "input", null)
         }
 
-        coVerify(exactly = 3) {
+        coVerify(exactly = 2) {
             agentExecutor.executeAgent(any(), any(), any())
         }
     }
@@ -190,6 +190,55 @@ class RecoveryExecutorTest : FunSpec({
         coVerify(exactly = 1) {
             agentExecutor.executeAgent(any(), any(), any())
         }
+    }
+
+    test("retry escalation swaps model parameters after configured attempt") {
+        val agentExecutor = mockk<AgentExecutor>()
+        val outputValidator = mockk<OutputValidator>(relaxed = true)
+        val registryWithEscalation = InMemoryAgentRegistry().apply {
+            registerAgent(
+                AgentConfig(
+                    name = "primary",
+                    pluginClass = "com.cotor.data.plugin.EchoPlugin",
+                    parameters = mapOf("model" to "cheap-model"),
+                    escalateAfterAttempt = 2,
+                    escalateModel = "strong-model"
+                )
+            )
+        }
+        val recoveryExecutor = RecoveryExecutor(agentExecutor, registryWithEscalation, outputValidator, logger)
+        val models = mutableListOf<String?>()
+        val stage = PipelineStage(
+            id = "stage1",
+            agent = AgentReference("primary"),
+            recovery = RecoveryConfig(
+                strategy = RecoveryStrategy.RETRY,
+                maxRetries = 2,
+                retryDelayMs = 0,
+                backoffStrategy = BackoffStrategy.FIXED,
+                retryOn = listOf("timeout")
+            )
+        )
+
+        coEvery {
+            agentExecutor.executeAgent(any(), any(), any())
+        } answers {
+            val agent = firstArg<AgentConfig>()
+            models += agent.parameters["model"]
+            if (models.size == 1) {
+                AgentResult("primary", false, null, "timeout on first attempt", 0, emptyMap())
+            } else {
+                AgentResult("primary", true, "ok", null, 0, emptyMap())
+            }
+        }
+
+        val result = runBlocking {
+            recoveryExecutor.executeWithRecovery(stage, "input", null)
+        }
+
+        result.isSuccess shouldBe true
+        models shouldBe listOf("cheap-model", "strong-model")
+        result.metadata["escalatedModel"] shouldBe "strong-model"
     }
 
     test("validation failure retries with a self-repair prompt that includes violations and prior output") {

--- a/src/test/kotlin/com/cotor/security/NetworkEndpointPolicyTest.kt
+++ b/src/test/kotlin/com/cotor/security/NetworkEndpointPolicyTest.kt
@@ -1,0 +1,36 @@
+package com.cotor.security
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class NetworkEndpointPolicyTest : FunSpec({
+    test("accepts public http and https endpoints") {
+        NetworkEndpointPolicy.requirePublicHttpUrl("https://api.linear.app/graphql", "Linear endpoint").host shouldBe "api.linear.app"
+        NetworkEndpointPolicy.requirePublicHttpUrl("http://example.com/v1", "OpenAI baseUrl").scheme shouldBe "http"
+    }
+
+    test("rejects localhost private and credential-bearing endpoints by default") {
+        shouldThrow<IllegalArgumentException> {
+            NetworkEndpointPolicy.requirePublicHttpUrl("http://127.0.0.1:8080/graphql", "Linear endpoint")
+        }.message shouldContain "private"
+
+        shouldThrow<IllegalArgumentException> {
+            NetworkEndpointPolicy.requirePublicHttpUrl("http://192.168.1.10:8080/v1", "OpenAI baseUrl")
+        }.message shouldContain "private"
+
+        shouldThrow<IllegalArgumentException> {
+            NetworkEndpointPolicy.requirePublicHttpUrl("https://user:pass@example.com/v1", "OpenAI baseUrl")
+        }.message shouldContain "credentials"
+    }
+
+    test("allows private endpoints only when an integration explicitly opts in") {
+        val uri = NetworkEndpointPolicy.requirePublicHttpUrl(
+            rawUrl = "http://127.0.0.1:11434/v1",
+            label = "OpenAI baseUrl",
+            allowPrivateHosts = true
+        )
+        uri.host shouldBe "127.0.0.1"
+    }
+})


### PR DESCRIPTION
## Summary
- Adds Cotor-native deterministic pipeline guards, stuck detection, model escalation, and conflict-safe parallel batching inspired by OpenSwarm's architecture.
- Hardens app-server bearer auth, evidence file path policy, EventBus lifecycle, outbound Linear/OpenAI endpoint validation, metrics sampling, animation scopes, runtime caches, and macOS event/polling task lifecycle.
- Updates architecture/module docs in English and Korean.

## Notes
- OpenSwarm was used only as an architectural reference. No GPL-3.0 OpenSwarm source code was copied into Cotor.
- Cotor keeps the Company/macOS/operator/capability-policy product model; this does not add Discord-first control flow or human approval queues for normal delegated work.

## Validation
- ./gradlew test
- ./gradlew formatCheck
- swift build --package-path macos
