### PR TITLE
[codex] recover CEO planning output contract

### DIFF
--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -139,6 +139,14 @@ private data class CeoPlanningPayload(
     val issues: List<CeoPlannedIssue> = emptyList()
 )
 
+private data class CeoPlanningPayloadResolution(
+    val payload: CeoPlanningPayload?,
+    val source: String? = null,
+    val diagnostics: List<String> = emptyList()
+) {
+    val isValid: Boolean get() = payload != null
+}
+
 @kotlinx.serialization.Serializable
 private data class CeoPlannedIssue(
     val refId: String,
@@ -252,6 +260,9 @@ class DesktopAppService(
         private const val FALLBACK_PLANNING_SOURCE_PREFIX = "fallback-planning:"
         private const val CEO_PLANNING_INVALID_OUTPUT = "CEO_PLANNING_INVALID_OUTPUT"
         private const val CEO_PLANNING_REPAIR_MARKER = "CEO_PLANNING_REPAIR"
+        private const val CEO_PLANNING_OUTPUT_FILE = ".cotor/runtime/ceo-plan.json"
+        private const val CEO_PLANNING_OUTPUT_ARTIFACT_DIR = ".cotor/runtime/run-outputs"
+        private const val CEO_PLANNING_MAX_OUTPUT_FILE_BYTES = 256L * 1024L
         private const val RUN_PROCESS_TERMINATION_TIMEOUT_MS = 2_000L
         private const val QA_REVIEW_SOURCE_PREFIX = "qa-review:"
         private const val CEO_APPROVAL_SOURCE_PREFIX = "ceo-approval:"
@@ -7506,6 +7517,97 @@ class DesktopAppService(
         issue
     }
 
+    private fun recoverBlockedCeoPlanningIssueFromArtifacts(
+        state: DesktopAppState,
+        planningIssue: CompanyIssue,
+        now: Long
+    ): DesktopAppState? {
+        val goal = state.goals.firstOrNull { it.id == planningIssue.goalId } ?: return null
+        val company = state.companies.firstOrNull { it.id == planningIssue.companyId } ?: return null
+        val workspace = state.workspaces.firstOrNull { it.id == planningIssue.workspaceId } ?: return null
+        val existingNonPlanning = state.issues.filter {
+            it.goalId == goal.id && !it.kind.equals("planning", ignoreCase = true)
+        }
+        if (existingNonPlanning.any { it.status != IssueStatus.DONE && it.status != IssueStatus.CANCELED }) {
+            return null
+        }
+        val taskRuns = state.tasks
+            .filter { it.issueId == planningIssue.id }
+            .sortedByDescending { it.updatedAt }
+            .flatMap { task ->
+                state.runs
+                    .filter { run -> run.taskId == task.id }
+                    .sortedByDescending { it.updatedAt }
+                    .map { run -> task to run }
+            }
+        val resolved = taskRuns.firstNotNullOfOrNull { (task, run) ->
+            resolveCeoPlanningPayload(task, run)
+                .takeIf { it.isValid }
+                ?.let { resolution -> task to (run to resolution) }
+        } ?: return null
+        val resolution = resolved.second.second
+        val parsedPlan = resolution.payload ?: return null
+        val profiles = ensureOrgProfiles(state.orgProfiles, state.companyAgentDefinitions, state.companies)
+        val plannedIssues = materializePlannedIssues(
+            goal = goal,
+            workspace = workspace,
+            profiles = profiles,
+            plan = parsedPlan,
+            now = now,
+            planningSource = "ceo"
+        )
+        val dependencyRecords = plannedIssues.flatMap { createdIssue ->
+            createdIssue.dependsOn.map { dependencyId ->
+                IssueDependency(
+                    id = UUID.randomUUID().toString(),
+                    issueId = createdIssue.id,
+                    dependsOnIssueId = dependencyId
+                )
+            }
+        }
+        val planningReason = "CEO planning recovered ${plannedIssues.size} downstream issues from ${resolution.source ?: "stored run output"}."
+        val updatedPlanningIssue = planningIssue.copy(
+            status = IssueStatus.DONE,
+            transitionReason = planningReason,
+            providerBlockReason = null,
+            blockedBy = emptyList(),
+            updatedAt = now
+        )
+        val decision = GoalOrchestrationDecision(
+            id = UUID.randomUUID().toString(),
+            companyId = company.id,
+            goalId = goal.id,
+            issueId = planningIssue.id,
+            title = "CEO planned execution graph",
+            summary = "CEO planning for \"${goal.title}\" was recovered from stored output and decomposed into ${plannedIssues.size} branchable issues.",
+            createdIssues = plannedIssues.map { it.id },
+            assignments = plannedIssues.mapNotNull { createdIssue ->
+                val assignee = profiles.firstOrNull { it.id == createdIssue.assigneeProfileId }?.roleName
+                assignee?.let { "${createdIssue.title} -> $it" }
+            },
+            escalations = emptyList(),
+            createdAt = now
+        )
+        return applyVerificationProjection(
+            state.copy(
+                issues = state.issues.filterNot { it.id == planningIssue.id } + updatedPlanningIssue + plannedIssues,
+                issueDependencies = state.issueDependencies.filterNot { dependency ->
+                    dependency.issueId == planningIssue.id
+                } + dependencyRecords,
+                goalDecisions = state.goalDecisions + decision
+            )
+        ).recordCompanyActivity(
+            companyId = company.id,
+            projectContextId = planningIssue.projectContextId,
+            goalId = goal.id,
+            issueId = planningIssue.id,
+            source = "ceo-planning",
+            title = "Recovered CEO planning",
+            detail = planningReason,
+            severity = "warning"
+        ).withDerivedMetrics()
+    }
+
     suspend fun decomposeGoal(goalId: String): List<CompanyIssue> {
         val planningIssueId = stateMutex.withLock {
             val state = stateStore.load()
@@ -7533,6 +7635,17 @@ class DesktopAppService(
                 listOf(existingPlanningIssue.transitionReason, existingPlanningIssue.providerBlockReason)
                     .any { it?.contains(CEO_PLANNING_INVALID_OUTPUT) == true }
             ) {
+                val recoveredState = recoverBlockedCeoPlanningIssueFromArtifacts(
+                    state = state,
+                    planningIssue = existingPlanningIssue,
+                    now = System.currentTimeMillis()
+                )
+                if (recoveredState != null) {
+                    stateStore.save(recoveredState)
+                    return recoveredState.issues
+                        .filter { it.goalId == goalId }
+                        .sortedByDescending { it.updatedAt }
+                }
                 return existing.sortedByDescending { it.updatedAt }
             }
             if (existingPlanningIssue != null &&
@@ -14234,6 +14347,9 @@ class DesktopAppService(
                 estimatedCostCents = estimatedCostCents.takeIf { it > 0 },
                 updatedAt = System.currentTimeMillis()
             )
+            if (issue?.kind.equals("planning", ignoreCase = true)) {
+                persistRunOutputArtifact(settledRun)
+            }
             replaceRun(
                 settledRun
             )
@@ -14393,6 +14509,30 @@ class DesktopAppService(
             branchName = "codex/cotor/${task.id.take(8)}/$normalizedAgent",
             worktreePath = Path.of(repository.localPath)
         )
+    }
+
+    private fun persistRunOutputArtifact(run: AgentRun) {
+        val output = run.output?.takeIf { it.isNotBlank() } ?: return
+        val worktreePath = run.worktreePath.takeIf { it.isNotBlank() }?.let { Path.of(it) } ?: return
+        runCatching {
+            val worktreeReal = worktreePath.toRealPath()
+            val artifactDir = worktreeReal.resolve(CEO_PLANNING_OUTPUT_ARTIFACT_DIR).normalize()
+            if (!artifactDir.startsWith(worktreeReal)) {
+                return
+            }
+            Files.createDirectories(artifactDir)
+            val artifactPath = artifactDir.resolve("${run.id}.txt").normalize()
+            if (!artifactPath.startsWith(artifactDir)) {
+                return
+            }
+            Files.writeString(
+                artifactPath,
+                output,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.WRITE
+            )
+        }
     }
 
     private suspend fun replaceRun(run: AgentRun) {
@@ -15520,6 +15660,8 @@ class DesktopAppService(
             appendLine("```json")
             appendLine("""{"goalSummary":"...","issues":[{"refId":"exec-1","title":"...","description":"...","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":true,"dependsOn":[],"acceptanceCriteria":["..."],"reviewRequired":true,"approvalRequired":true}]}""")
             appendLine("```")
+            appendLine("Also write the exact same JSON object to $CEO_PLANNING_OUTPUT_FILE if you use tools or create files.")
+            appendLine("Do not write planning JSON to the prompt file or any other path.")
             memoryBundle?.let { memory ->
                 appendLine()
                 appendLine(renderMemorySections(memory))
@@ -15547,6 +15689,105 @@ class DesktopAppService(
                 issue.refId.isNotBlank() && issue.title.isNotBlank() && issue.assigneeRole.isNotBlank()
             }
         }
+    }
+
+    private fun resolveCeoPlanningPayload(
+        task: AgentTask,
+        run: AgentRun?
+    ): CeoPlanningPayloadResolution {
+        val diagnostics = mutableListOf<String>()
+        parseCeoPlanningPayload(run?.output)?.let { payload ->
+            return CeoPlanningPayloadResolution(payload = payload, source = "run.output")
+        }
+        diagnostics += "run.output: ${describeCeoPlanningParseFailure(run?.output)}"
+
+        val worktree = run?.worktreePath
+            ?.takeIf { it.isNotBlank() }
+            ?.let { Path.of(it) }
+        if (worktree == null) {
+            diagnostics += "worktree: missing run worktree path"
+            return CeoPlanningPayloadResolution(payload = null, diagnostics = diagnostics)
+        }
+
+        val candidatePaths = buildList {
+            run.id.takeIf { it.isNotBlank() }?.let { runId ->
+                add("$CEO_PLANNING_OUTPUT_ARTIFACT_DIR/$runId.txt" to "run output artifact")
+            }
+            add(CEO_PLANNING_OUTPUT_FILE to "ceo plan file")
+            add("cotor-ceo-plan.json" to "ceo plan file")
+            add("landing_page_plan.json" to "legacy landing plan file")
+        }
+
+        var foundCandidateFile = false
+        candidatePaths.forEach { (relativePath, sourceName) ->
+            val readResult = readCeoPlanningCandidateFile(worktree, relativePath)
+            if (readResult.fileExists) {
+                foundCandidateFile = true
+            }
+            val content = readResult.content
+            if (content != null) {
+                parseCeoPlanningPayload(content)?.let { payload ->
+                    return CeoPlanningPayloadResolution(
+                        payload = payload,
+                        source = "$sourceName: $relativePath",
+                        diagnostics = diagnostics
+                    )
+                }
+                diagnostics += "$relativePath: ${describeCeoPlanningParseFailure(content)}"
+            } else if (readResult.diagnostic != null) {
+                diagnostics += "$relativePath: ${readResult.diagnostic}"
+            }
+        }
+        if (!foundCandidateFile) {
+            diagnostics += "worktree: no allowed CEO planning output file found for task ${task.id}"
+        }
+        return CeoPlanningPayloadResolution(payload = null, diagnostics = diagnostics)
+    }
+
+    private data class CeoPlanningFileReadResult(
+        val fileExists: Boolean,
+        val content: String? = null,
+        val diagnostic: String? = null
+    )
+
+    private fun readCeoPlanningCandidateFile(
+        worktreePath: Path,
+        relativePath: String
+    ): CeoPlanningFileReadResult {
+        val worktreeReal = runCatching { worktreePath.toRealPath() }.getOrNull()
+            ?: return CeoPlanningFileReadResult(fileExists = false, diagnostic = "worktree does not exist")
+        val candidate = worktreeReal.resolve(relativePath).normalize()
+        if (!Files.exists(candidate)) {
+            return CeoPlanningFileReadResult(fileExists = false)
+        }
+        val candidateReal = runCatching { candidate.toRealPath() }.getOrNull()
+            ?: return CeoPlanningFileReadResult(fileExists = true, diagnostic = "could not resolve canonical path")
+        if (!candidateReal.startsWith(worktreeReal)) {
+            return CeoPlanningFileReadResult(fileExists = true, diagnostic = "outside run worktree")
+        }
+        val size = runCatching { Files.size(candidateReal) }.getOrNull()
+            ?: return CeoPlanningFileReadResult(fileExists = true, diagnostic = "could not read file size")
+        if (size > CEO_PLANNING_MAX_OUTPUT_FILE_BYTES) {
+            return CeoPlanningFileReadResult(fileExists = true, diagnostic = "file exceeds ${CEO_PLANNING_MAX_OUTPUT_FILE_BYTES} byte limit")
+        }
+        val content = runCatching { Files.readString(candidateReal) }.getOrElse { error ->
+            return CeoPlanningFileReadResult(fileExists = true, diagnostic = "read failed: ${error.message ?: error::class.simpleName}")
+        }
+        return CeoPlanningFileReadResult(fileExists = true, content = content)
+    }
+
+    private fun describeCeoPlanningParseFailure(output: String?): String {
+        val text = output?.trim().orEmpty()
+        if (text.isBlank()) {
+            return "blank output"
+        }
+        if (text.contains("[compacted ", ignoreCase = true) || text.contains("[truncated ", ignoreCase = true)) {
+            return "output was compacted or truncated before a complete planning JSON block could be parsed"
+        }
+        if (extractJsonObject(text) == null) {
+            return "no complete JSON object found"
+        }
+        return "JSON object did not match CEO planning schema"
     }
 
     private fun extractJsonObject(text: String): String? {
@@ -17921,11 +18162,17 @@ class DesktopAppService(
     private fun ceoPlanningInvalidOutputReason(
         task: AgentTask,
         run: AgentRun?,
-        finalStatus: DesktopTaskStatus
+        finalStatus: DesktopTaskStatus,
+        resolution: CeoPlanningPayloadResolution = resolveCeoPlanningPayload(task, run)
     ): String {
         val runRef = run?.id ?: "none"
         val summary = ceoPlanningRunOutputSummary(run)
-        return "$CEO_PLANNING_INVALID_OUTPUT: CEO planning task ${task.id} run $runRef ended with ${finalStatus.name} but did not produce a valid planning JSON block. Output summary: $summary"
+        val diagnostics = resolution.diagnostics
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString("; ")
+            ?.let { " Diagnostics: $it." }
+            .orEmpty()
+        return "$CEO_PLANNING_INVALID_OUTPUT: CEO planning task ${task.id} run $runRef ended with ${finalStatus.name} but did not produce a valid planning JSON block.$diagnostics Output summary: $summary"
     }
 
     private fun isRetryableCeoPlanningInterruption(
@@ -17995,6 +18242,8 @@ class DesktopAppService(
             appendLine("$CEO_PLANNING_REPAIR_MARKER:")
             appendLine("The previous CEO planning run did not produce valid planning JSON, so this is the only automatic repair attempt.")
             appendLine("Return JSON only inside one ```json fenced block. Do not use tools, do not inspect files, and do not write prose outside the JSON block.")
+            appendLine("If you still create a file, write the exact same JSON object to $CEO_PLANNING_OUTPUT_FILE in the current worktree and still return the fenced JSON.")
+            appendLine("Do not write planning JSON to the prompt file or any other path.")
             appendLine("Required schema:")
             appendLine("```json")
             appendLine("""{"goalSummary":"...","issues":[{"refId":"exec-1","title":"...","description":"...","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":true,"dependsOn":[],"acceptanceCriteria":["..."],"reviewRequired":true,"approvalRequired":true}]}""")
@@ -18125,7 +18374,12 @@ class DesktopAppService(
                 return@withLock
             }
 
-            val parsedPlan = if (finalStatus == DesktopTaskStatus.COMPLETED) parseCeoPlanningPayload(primaryRun?.output) else null
+            val planningResolution = if (finalStatus == DesktopTaskStatus.COMPLETED) {
+                resolveCeoPlanningPayload(task, primaryRun)
+            } else {
+                CeoPlanningPayloadResolution(payload = null, diagnostics = listOf("task ended with ${finalStatus.name}"))
+            }
+            val parsedPlan = planningResolution.payload
             if (parsedPlan == null) {
                 val retryableInterruption = isRetryableCeoPlanningInterruption(task, primaryRun, finalStatus)
                 if (retryableInterruption) {
@@ -18254,7 +18508,7 @@ class DesktopAppService(
                     stateStore.save(nextState)
                     return@withLock
                 }
-                val invalidPlanningReason = ceoPlanningInvalidOutputReason(task, primaryRun, finalStatus)
+                val invalidPlanningReason = ceoPlanningInvalidOutputReason(task, primaryRun, finalStatus, planningResolution)
                 val repairAttempts = state.tasks.count { candidate ->
                     candidate.issueId == currentIssue.id &&
                         candidate.prompt.contains(CEO_PLANNING_REPAIR_MARKER)
@@ -18382,7 +18636,11 @@ class DesktopAppService(
                     )
                 }
             }
-            val planningReason = "CEO planning run created ${decomposition.first.size} downstream issues."
+            val planningSourceDetail = planningResolution.source
+                ?.takeIf { it.isNotBlank() && it != "run.output" }
+                ?.let { " from $it" }
+                .orEmpty()
+            val planningReason = "CEO planning run created ${decomposition.first.size} downstream issues$planningSourceDetail."
             val updatedPlanningIssue = currentIssue.copy(
                 status = IssueStatus.DONE,
                 transitionReason = planningReason,

--- a/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
@@ -433,6 +433,13 @@ class DesktopStateStore(
                     task.id in latestRetainedTaskIds
             }
             val retainedTaskIds = retainedTasks.mapTo(linkedSetOf()) { it.id }
+            val unresolvedTaskIds = retainedTasks
+                .filter { task ->
+                    task.issueId in unresolvedIssueIds ||
+                        task.status == DesktopTaskStatus.RUNNING ||
+                        task.status == DesktopTaskStatus.QUEUED
+                }
+                .mapTo(linkedSetOf()) { it.id }
             val retainedRuns = runs
                 .groupBy { it.taskId }
                 .flatMap { (taskId, taskRuns) ->
@@ -453,7 +460,7 @@ class DesktopStateStore(
             }
             copy(
                 tasks = retainedTasks.map { compactTaskForPersistence(it, unresolvedIssueIds) },
-                runs = retainedRuns.map(::compactRunForPersistence),
+                runs = retainedRuns.map { compactRunForPersistence(it, unresolvedTaskIds) },
                 reviewQueue = reviewQueue.filter { it.issueId in retainedReviewQueueIssueIds },
                 companyActivity = companyActivity.sortedByDescending { it.createdAt }.take(200),
                 signals = signals.sortedByDescending { it.createdAt }.take(150),
@@ -485,8 +492,12 @@ class DesktopStateStore(
         )
     }
 
-    private fun compactRunForPersistence(run: AgentRun): AgentRun =
-        if (run.status == AgentRunStatus.RUNNING || run.status == AgentRunStatus.QUEUED) {
+    private fun compactRunForPersistence(run: AgentRun, unresolvedTaskIds: Set<String>): AgentRun =
+        if (
+            run.taskId in unresolvedTaskIds ||
+            run.status == AgentRunStatus.RUNNING ||
+            run.status == AgentRunStatus.QUEUED
+        ) {
             run
         } else {
             run.copy(output = compactText(run.output, MAX_PERSISTED_RUN_OUTPUT_CHARS))

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -3731,6 +3731,208 @@ class DesktopAppServiceTest : FunSpec({
         state.goalDecisions.last { it.goalId == goal.id }.title shouldBe "CEO planned execution graph"
     }
 
+    test("CEO planning run with long JSON output materializes before persistence compaction can break it") {
+        val appHome = Files.createTempDirectory("desktop-ceo-long-plan-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-long-plan-test").resolve("repo"))
+        val worktreeRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-long-plan-worktree").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val gitWorkspaceService = mockk<GitWorkspaceService>()
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { gitWorkspaceService.resolveRepositoryRoot(any()) } returns repoRoot
+        coEvery { gitWorkspaceService.detectDefaultBranch(any()) } returns "master"
+        coEvery { gitWorkspaceService.detectRemoteUrl(any()) } returns null
+        coEvery { gitWorkspaceService.ensureWorktree(any(), any(), any(), any(), any()) } returns WorktreeBinding(
+            branchName = "codex/cotor/ceo-long-plan/opencode",
+            worktreePath = worktreeRoot
+        )
+        val longDescription = "Preserve full planning output. ".repeat(180)
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } returns AgentResult(
+            agentName = "opencode",
+            isSuccess = true,
+            output = """
+                ```json
+                {"goalSummary":"$longDescription","issues":[{"refId":"exec-1","title":"Implement long CEO plan","description":"$longDescription","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":false,"dependsOn":[],"acceptanceCriteria":["Long CEO planning JSON remains parseable"],"reviewRequired":false,"approvalRequired":false}]}
+                ```
+            """.trimIndent(),
+            error = null,
+            duration = 10,
+            metadata = emptyMap(),
+            processId = 124L
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "CEO Long Plan Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Plan with long CEO JSON",
+            description = "The CEO output is longer than the persisted compaction threshold.",
+            autonomyEnabled = true,
+            startRuntimeIfNeeded = false
+        )
+        val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
+
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
+        withTimeout(5_000) {
+            while (stateStore.load().issues.single { it.id == planningIssue.id }.status == IssueStatus.PLANNED) {
+                delay(50)
+            }
+        }
+
+        val state = stateStore.load()
+        state.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
+        state.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE
+    }
+
+    test("blocked CEO planning issue recovers from legacy landing page plan file") {
+        val appHome = Files.createTempDirectory("desktop-ceo-legacy-plan-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-legacy-plan-test").resolve("repo"))
+        val worktreeRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-legacy-plan-worktree").resolve("repo"))
+        Files.writeString(
+            worktreeRoot.resolve("landing_page_plan.json"),
+            """{"goalSummary":"Recovered landing plan","issues":[{"refId":"exec-1","title":"Implement recovered landing page","description":"Build the recovered landing page slice.","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":false,"dependsOn":[],"acceptanceCriteria":["Recovered landing page issue exists"],"reviewRequired":false,"approvalRequired":false}]}"""
+        )
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val gitWorkspaceService = mockk<GitWorkspaceService>()
+        coEvery { gitWorkspaceService.resolveRepositoryRoot(any()) } returns repoRoot
+        coEvery { gitWorkspaceService.detectDefaultBranch(any()) } returns "master"
+        coEvery { gitWorkspaceService.detectRemoteUrl(any()) } returns null
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "CEO Legacy Recovery Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Recover legacy plan",
+            description = "Recover a blocked CEO planning issue from the worktree file.",
+            autonomyEnabled = true,
+            startRuntimeIfNeeded = false
+        )
+        val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
+        val state = stateStore.load()
+        val blockedPlanningIssue = planningIssue.copy(
+            status = IssueStatus.BLOCKED,
+            transitionReason = "CEO_PLANNING_INVALID_OUTPUT: compacted output.",
+            providerBlockReason = "CEO_PLANNING_INVALID_OUTPUT: compacted output.",
+            updatedAt = 20L
+        )
+        val task = AgentTask(
+            id = "legacy-task",
+            workspaceId = planningIssue.workspaceId,
+            issueId = planningIssue.id,
+            title = planningIssue.title,
+            prompt = "prompt",
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.COMPLETED,
+            createdAt = 10L,
+            updatedAt = 10L
+        )
+        val run = AgentRun(
+            id = "legacy-run",
+            taskId = task.id,
+            workspaceId = planningIssue.workspaceId,
+            repositoryId = company.repositoryId,
+            agentName = "opencode",
+            branchName = "codex/cotor/legacy/opencode",
+            worktreePath = worktreeRoot.toString(),
+            status = AgentRunStatus.COMPLETED,
+            output = "```json\n{\"goalSummary\":\"cut off\"\n\n[compacted 22 chars]",
+            createdAt = 10L,
+            updatedAt = 10L
+        )
+        stateStore.save(
+            state.copy(
+                issues = state.issues.map { if (it.id == planningIssue.id) blockedPlanningIssue else it },
+                tasks = state.tasks + task,
+                runs = state.runs + run
+            )
+        )
+
+        service.decomposeGoal(goal.id)
+
+        val recovered = stateStore.load()
+        recovered.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE
+        recovered.issues.single { it.id == planningIssue.id }.providerBlockReason shouldBe null
+        recovered.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
+        recovered.issues.single { it.title == "Implement recovered landing page" }.transitionReason shouldContain "CEO planning run assigned this issue"
+    }
+
+    test("CEO planning blocks with diagnostics when repair prose claims a missing file") {
+        val appHome = Files.createTempDirectory("desktop-ceo-missing-plan-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-missing-plan-test").resolve("repo"))
+        val worktreeRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-missing-plan-worktree").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val gitWorkspaceService = mockk<GitWorkspaceService>()
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { gitWorkspaceService.resolveRepositoryRoot(any()) } returns repoRoot
+        coEvery { gitWorkspaceService.detectDefaultBranch(any()) } returns "master"
+        coEvery { gitWorkspaceService.detectRemoteUrl(any()) } returns null
+        coEvery { gitWorkspaceService.ensureWorktree(any(), any(), any(), any(), any()) } returns WorktreeBinding(
+            branchName = "codex/cotor/ceo-missing-plan/opencode",
+            worktreePath = worktreeRoot
+        )
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } returns AgentResult(
+            agentName = "opencode",
+            isSuccess = true,
+            output = "The JSON has been written to the prompt file as instructed.",
+            error = null,
+            duration = 10,
+            metadata = emptyMap(),
+            processId = 125L
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "CEO Missing Plan Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Plan with missing file",
+            description = "The CEO claims a file exists but does not create one.",
+            autonomyEnabled = true,
+            startRuntimeIfNeeded = false
+        )
+        val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
+
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 15_000)
+        withTimeout(15_000) {
+            while (stateStore.load().issues.single { it.id == planningIssue.id }.status != IssueStatus.BLOCKED) {
+                delay(50)
+            }
+        }
+
+        val blockedIssue = stateStore.load().issues.single { it.id == planningIssue.id }
+        blockedIssue.providerBlockReason shouldContain "CEO_PLANNING_INVALID_OUTPUT"
+        blockedIssue.providerBlockReason shouldContain "no complete JSON object found"
+        blockedIssue.providerBlockReason shouldContain ".cotor/runtime/run-outputs"
+    }
+
     test("autonomous CEO planning retries invalid output once and accepts repaired JSON") {
         val appHome = Files.createTempDirectory("desktop-ceo-repair-plan-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-ceo-repair-plan-test").resolve("repo"))
@@ -3801,7 +4003,9 @@ class DesktopAppServiceTest : FunSpec({
         service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
 
         runCount shouldBe 2
+        prompts.first().orEmpty() shouldContain ".cotor/runtime/ceo-plan.json"
         prompts.last().orEmpty() shouldContain "CEO_PLANNING_REPAIR"
+        prompts.last().orEmpty() shouldContain ".cotor/runtime/ceo-plan.json"
         val state = stateStore.load()
         state.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
         state.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE

--- a/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
@@ -342,4 +342,61 @@ class DesktopStateStoreTest : FunSpec({
         persisted.shouldContain(longPrompt.take(200))
         persisted.shouldNotContain("[compacted ")
     }
+
+    test("save preserves full run output for unresolved issue tasks") {
+        val appHome = Files.createTempDirectory("desktop-state-store-unresolved-output-home")
+        val store = DesktopStateStore { appHome }
+        val longOutput = "```json\n{\"goalSummary\":\"" + "plan-".repeat(900) + "\",\"issues\":[{\"refId\":\"exec-1\",\"title\":\"Work\",\"description\":\"Do work\",\"assigneeRole\":\"Builder\"}]}\n```"
+        val state = DesktopAppState(
+            issues = listOf(
+                CompanyIssue(
+                    id = "issue-1",
+                    companyId = "company-1",
+                    projectContextId = "project-1",
+                    goalId = "goal-1",
+                    workspaceId = "workspace-1",
+                    title = "Blocked planning issue",
+                    description = "Still needs planning sync.",
+                    status = IssueStatus.BLOCKED,
+                    kind = "planning",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            tasks = listOf(
+                AgentTask(
+                    id = "task-1",
+                    workspaceId = "workspace-1",
+                    issueId = "issue-1",
+                    title = "Planning task",
+                    prompt = "prompt",
+                    agents = listOf("opencode"),
+                    status = DesktopTaskStatus.COMPLETED,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            runs = listOf(
+                AgentRun(
+                    id = "run-1",
+                    taskId = "task-1",
+                    workspaceId = "workspace-1",
+                    repositoryId = "repo-1",
+                    agentName = "opencode",
+                    branchName = "codex/cotor/test",
+                    worktreePath = "/tmp/worktree",
+                    status = AgentRunStatus.COMPLETED,
+                    output = longOutput,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            )
+        )
+
+        store.save(state)
+        val persisted = appHome.resolve("state.json").readText()
+
+        store.load().runs.single().output shouldBe longOutput
+        persisted.shouldNotContain("[compacted ")
+    }
 })


### PR DESCRIPTION
## Summary
- Preserve completed run output for unresolved issue-linked tasks until planning reconciliation can consume it.
- Recover CEO planning payloads from stdout, full-output artifacts, and canonical worktree plan files.
- Let blocked CEO planning issues with legacy `landing_page_plan.json` recover during reconciliation without manual state edits.

## Root Cause
CEO planning could fail even after the agent produced a useful plan because run output was compacted before sync completed, or because the agent wrote the full JSON to a worktree file instead of stdout. That left the planning issue blocked with `CEO_PLANNING_INVALID_OUTPUT` and no downstream execution graph.

## Changes
- Add a CEO planning resolver that checks `run.output`, `.cotor/runtime/run-outputs/<runId>.txt`, `.cotor/runtime/ceo-plan.json`, `cotor-ceo-plan.json`, and legacy `landing_page_plan.json`.
- Validate candidate files with canonical worktree containment and a size limit before parsing.
- Persist planning run output artifacts before replacing completed runs.
- Update CEO planning and repair prompts to keep fenced stdout JSON while also naming the stable plan file path for tool-using agents.
- Add reconciliation recovery for blocked CEO planning issues that already have a valid stored plan file and no active downstream work.
- Add regression coverage for unresolved output preservation, long planning JSON, legacy plan recovery, and prose-only missing-file failures.

## Validation
- `./gradlew test`
- Local installed Cotor Desktop build was previously smoke-tested against the blocked landing-page CEO planning issue; the issue recovered to `DONE`, downstream landing-page issues were created, and an `index.html` output rendered in browser.