### PR TITLE
[codex] Harden local app-server auth

### DIFF
--- a/docs/DESKTOP_APP.ko.md
+++ b/docs/DESKTOP_APP.ko.md
@@ -50,18 +50,25 @@ cotor delete
 cotor app-server --port 8787
 ```
 
-로컬 인증 토큰을 붙이려면:
+app-server는 `/api/app/**`와 A2A route를 항상 bearer auth로 보호합니다. 토큰을 주지 않으면 로컬 토큰을 생성해 사용자 runtime token file에 저장합니다.
+
+```bash
+cotor app-server --port 8787
+cat "$HOME/Library/Application Support/CotorDesktop/runtime/backend/app-server.token"
+```
+
+특정 토큰을 직접 쓰려면:
 
 ```bash
 export COTOR_APP_TOKEN='your-local-token'
-cotor app-server --port 8787 --token your-local-token
+cotor app-server --port 8787 --token "$COTOR_APP_TOKEN"
 ```
 
 MCP 제어 도구를 별도 토큰으로 열려면:
 
 ```bash
 export COTOR_APP_CONTROL_TOKEN='your-local-control-token'
-cotor app-server --port 8787 --token your-local-token --control-token your-local-control-token
+cotor app-server --port 8787 --token your-local-token --control-token "$COTOR_APP_CONTROL_TOKEN"
 ```
 
 `/api/app/mcp`는 읽기 전용입니다. 상태를 바꾸는 MCP 도구는 `/api/app/mcp/control`에 있으며 control token이 필요합니다.
@@ -80,7 +87,7 @@ export COTOR_APP_TOKEN='your-local-token'
 swift run --package-path macos CotorDesktopApp
 ```
 
-번들 backend를 launcher가 관리할 때 launcher와 `DesktopAPI`는 같은 `COTOR_APP_TOKEN` 값을 읽습니다. 환경 변수가 없으면 양쪽 모두 embedded session용 desktop-local token으로 폴백합니다. 패키지 launcher는 이 token을 backend process argument에 넣지 않고 backend 환경 변수와 `0600` runtime token file로 전달합니다.
+번들 backend를 launcher가 관리할 때 launcher와 `DesktopAPI`는 `COTOR_APP_TOKEN`이 있으면 같은 값을 사용합니다. 환경 변수가 없으면 static fallback token이 아니라 사용자별 runtime token file을 사용합니다. 패키지 launcher는 이 token을 backend process argument에 넣지 않고 backend 환경 변수와 `0600` runtime token file로 전달합니다.
 embedded backend에는 부모 shell 환경 전체가 아니라 최소한으로 정리된 환경만 전달됩니다. 따라서 우연히 설정된 API key, GitHub/Linear token, password 계열 변수는 로컬 app-server로 상속되지 않습니다. 특정 workflow가 환경 변수 기반 credential을 꼭 필요로 한다면 외부 `cotor app-server`를 명시적으로 실행해서 연결하세요.
 
 ## 로컬 앱 번들 설치

--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -45,18 +45,25 @@ cotor delete     # Remove app
 cotor app-server --port 8787
 ```
 
-Optional local auth:
+The app-server always protects `/api/app/**` and A2A routes with bearer auth. If no token is provided, it generates a local token and stores it in the user-owned runtime token file:
+
+```bash
+cotor app-server --port 8787
+cat "$HOME/Library/Application Support/CotorDesktop/runtime/backend/app-server.token"
+```
+
+To provide a specific token instead:
 
 ```bash
 export COTOR_APP_TOKEN='your-local-token'
-cotor app-server --port 8787 --token your-local-token
+cotor app-server --port 8787 --token "$COTOR_APP_TOKEN"
 ```
 
 Optional MCP control auth:
 
 ```bash
 export COTOR_APP_CONTROL_TOKEN='your-local-control-token'
-cotor app-server --port 8787 --token your-local-token --control-token your-local-control-token
+cotor app-server --port 8787 --token your-local-token --control-token "$COTOR_APP_CONTROL_TOKEN"
 ```
 
 `/api/app/mcp` is read-only. Mutating MCP tools live under `/api/app/mcp/control` and require the control token.
@@ -75,7 +82,7 @@ export COTOR_APP_TOKEN='your-local-token'
 swift run --package-path macos CotorDesktopApp
 ```
 
-When the bundled backend is launcher-managed, the launcher and `DesktopAPI` both read the same `COTOR_APP_TOKEN` value. If the variable is unset, both sides fall back to the desktop-local token used for embedded sessions. The packaged launcher passes this token through the backend environment and a `0600` runtime token file rather than placing it in the backend process arguments.
+When the bundled backend is launcher-managed, the launcher and `DesktopAPI` both use the same `COTOR_APP_TOKEN` value when one is provided. If the variable is unset, they use the per-user runtime token file instead of a static fallback token. The packaged launcher passes this token through the backend environment and a `0600` runtime token file rather than placing it in the backend process arguments.
 The embedded backend receives a minimal sanitized environment instead of the full parent shell environment, so incidental API keys, GitHub/Linear tokens, and password-like variables are not inherited by the local app-server. Run an external `cotor app-server` explicitly if a workflow must provide additional environment-scoped credentials.
 
 ## Install A Local App Bundle

--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 
 // MARK: - File Overview
@@ -11,9 +12,75 @@ import Foundation
 /// Keeping transport concerns here lets the view model stay focused on user intent
 /// and state transitions instead of URLSession boilerplate.
 struct DesktopAPI {
-    static let embeddedAppToken = "cotor-desktop-local-token"
-    static var appToken: String {
-        ProcessInfo.processInfo.environment["COTOR_APP_TOKEN"] ?? embeddedAppToken
+    static var appToken: String? {
+        configuredAppToken() ?? readRuntimeAppToken() ?? processGeneratedAppToken
+    }
+
+    static func ensureAppToken() -> String {
+        appToken ?? processGeneratedAppToken
+    }
+
+    private static let processGeneratedAppToken: String = {
+        let token = generateAppToken()
+        _ = writeRuntimeAppToken(token)
+        return token
+    }()
+
+    internal static func configuredAppToken(processEnvironment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        nonEmpty(processEnvironment["COTOR_APP_TOKEN"])
+    }
+
+    internal static func readRuntimeAppToken(appHome: URL = defaultDesktopAppHome()) -> String? {
+        let tokenURL = runtimeAppTokenURL(appHome: appHome)
+        guard let token = try? String(contentsOf: tokenURL, encoding: .utf8) else {
+            return nil
+        }
+        return nonEmpty(token)
+    }
+
+    @discardableResult
+    internal static func writeRuntimeAppToken(_ token: String, appHome: URL = defaultDesktopAppHome()) -> URL? {
+        guard let token = nonEmpty(token) else {
+            return nil
+        }
+        let tokenURL = runtimeAppTokenURL(appHome: appHome)
+        do {
+            try FileManager.default.createDirectory(
+                at: tokenURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try token.write(to: tokenURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenURL.path)
+            return tokenURL
+        } catch {
+            AppLogger.warning("Failed to persist app-server token: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    internal static func runtimeAppTokenURL(appHome: URL = defaultDesktopAppHome()) -> URL {
+        appHome
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("backend", isDirectory: true)
+            .appendingPathComponent("app-server.token")
+    }
+
+    internal static func defaultDesktopAppHome() -> URL {
+        let userHome = FileManager.default.homeDirectoryForCurrentUser
+        return userHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("CotorDesktop", isDirectory: true)
+    }
+
+    private static func generateAppToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status == errSecSuccess {
+            return Data(bytes).base64URLEncodedString()
+        }
+        return "\(UUID().uuidString)-\(UUID().uuidString)"
     }
     static func decodeCompanyEventLine(_ line: String) -> CompanyEventEnvelopePayload? {
         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -37,7 +104,12 @@ struct DesktopAPI {
             preconditionFailure("Default app server URL must be valid")
         }
         self.baseURL = URL(string: rawURL) ?? fallbackURL
-        self.token = Self.appToken
+        self.token = Self.ensureAppToken()
+    }
+
+    internal init(baseURL: URL, token: String?) {
+        self.baseURL = baseURL
+        self.token = token
     }
 
     /// Fetch the full dashboard payload used to bootstrap most of the app state.
@@ -47,23 +119,23 @@ struct DesktopAPI {
 
     /// Fetch the focused company snapshot used for live company-mode updates.
     func companyDashboard(companyId: String) async throws -> CompanyDashboardPayload {
-        try await get(path: "api/app/companies/\(companyId)/dashboard")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "dashboard"])
     }
 
     func agentPerformance(companyId: String) async throws -> [AgentPerformanceSnapshotRecord] {
-        try await get(path: "api/app/companies/\(companyId)/agents/performance")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "agents", "performance"])
     }
 
     func companyReports(companyId: String) async throws -> [CompanyDailyReportSummaryRecord] {
-        try await get(path: "api/app/companies/\(companyId)/reports")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "reports"])
     }
 
     func companyReport(companyId: String, date: String) async throws -> CompanyDailyReportRecord {
-        try await get(path: "api/app/companies/\(companyId)/reports/\(date)")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "reports", date])
     }
 
     func generateCompanyReport(companyId: String) async throws -> CompanyDailyReportRecord {
-        try await post(path: "api/app/companies/\(companyId)/reports/generate", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "reports", "generate"], body: EmptyPayload())
     }
 
     func companyMemorySnapshot(companyId: String, issueId: String?, agentProfileId: String?) async throws -> CompanyMemorySnapshotPayload {
@@ -74,24 +146,24 @@ struct DesktopAPI {
         if let agentProfileId, !agentProfileId.isEmpty {
             query.append(URLQueryItem(name: "agentProfileId", value: agentProfileId))
         }
-        return try await get(path: "api/app/companies/\(companyId)/memory-snapshot", query: query)
+        return try await get(pathSegments: ["api", "app", "companies", companyId, "memory-snapshot"], query: query)
     }
 
     func companyProblemSignals(companyId: String) async throws -> [CompanyProblemSignalRecord] {
-        try await get(path: "api/app/companies/\(companyId)/problem-signals")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "problem-signals"])
     }
 
     func runCompanyDiscoveryScan(companyId: String) async throws -> [CompanyProblemSignalRecord] {
-        try await post(path: "api/app/companies/\(companyId)/autonomy/discovery-scan", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "autonomy", "discovery-scan"], body: EmptyPayload())
     }
 
     func companyGitHubStatus(companyId: String) async throws -> GitHubPublishStatusPayload {
-        try await get(path: "api/app/companies/\(companyId)/github/status")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "github", "status"])
     }
 
     func configureCompanyGitHubOrigin(companyId: String, remoteURL: String) async throws -> GitHubPublishStatusPayload {
         try await post(
-            path: "api/app/companies/\(companyId)/github/origin",
+            pathSegments: ["api", "app", "companies", companyId, "github", "origin"],
             body: ConfigureGitHubOriginPayload(remoteUrl: remoteURL)
         )
     }
@@ -114,7 +186,7 @@ struct DesktopAPI {
 
     /// Return the selectable base branches for the currently focused repository.
     func repositoryBranches(repositoryId: String) async throws -> [String] {
-        try await get(path: "api/app/repositories/\(repositoryId)/branches")
+        try await get(pathSegments: ["api", "app", "repositories", repositoryId, "branches"])
     }
 
     /// Expose the built-in agent roster advertised by the backend.
@@ -134,16 +206,16 @@ struct DesktopAPI {
 
     /// Fetch all persisted runs belonging to one company issue.
     func issueRuns(issueId: String) async throws -> [RunRecord] {
-        try await get(path: "api/app/issues/\(issueId)/runs")
+        try await get(pathSegments: ["api", "app", "issues", issueId, "runs"])
     }
 
     func issueExecutionDetails(issueId: String) async throws -> [IssueAgentExecutionDetailRecord] {
-        try await get(path: "api/app/issues/\(issueId)/execution-details")
+        try await get(pathSegments: ["api", "app", "issues", issueId, "execution-details"])
     }
 
     /// Fetch the git diff summary for one task/agent pair.
     func changes(taskId: String, agentName: String) async throws -> ChangeSummaryPayload {
-        try await get(path: "api/app/tasks/\(taskId)/changes/\(agentName)")
+        try await get(pathSegments: ["api", "app", "tasks", taskId, "changes", agentName])
     }
 
     /// Fetch the git diff summary for one concrete run.
@@ -154,7 +226,7 @@ struct DesktopAPI {
     /// Fetch the nested file tree rooted at one agent worktree.
     func files(taskId: String, agentName: String, path: String?) async throws -> [FileTreeNodePayload] {
         let query = path.flatMap { $0.isEmpty ? nil : URLQueryItem(name: "path", value: $0) }.map { [$0] } ?? []
-        return try await get(path: "api/app/tasks/\(taskId)/files/\(agentName)", query: query)
+        return try await get(pathSegments: ["api", "app", "tasks", taskId, "files", agentName], query: query)
     }
 
     /// Fetch the nested file tree rooted at one concrete run worktree.
@@ -165,7 +237,7 @@ struct DesktopAPI {
 
     /// Fetch ports exposed by the process attached to one agent run.
     func ports(taskId: String, agentName: String) async throws -> [PortEntryPayload] {
-        try await get(path: "api/app/tasks/\(taskId)/ports/\(agentName)")
+        try await get(pathSegments: ["api", "app", "tasks", taskId, "ports", agentName])
     }
 
     /// Fetch ports exposed by one concrete run process.
@@ -193,7 +265,7 @@ struct DesktopAPI {
 
     func updateWorkspaceBaseBranch(workspaceId: String, baseBranch: String) async throws -> WorkspaceRecord {
         try await patch(
-            path: "api/app/workspaces/\(workspaceId)/base-branch",
+            pathSegments: ["api", "app", "workspaces", workspaceId, "base-branch"],
             body: UpdateWorkspaceBaseBranchPayload(baseBranch: baseBranch)
         )
     }
@@ -208,7 +280,7 @@ struct DesktopAPI {
 
     func createGoal(companyId: String, title: String, description: String, successMetrics: [String] = [], autonomyEnabled: Bool = true) async throws -> GoalRecord {
         try await post(
-            path: "api/app/companies/\(companyId)/goals",
+            pathSegments: ["api", "app", "companies", companyId, "goals"],
             body: CreateGoalPayload(
                 title: title,
                 description: description,
@@ -220,7 +292,7 @@ struct DesktopAPI {
 
     func createChatIntake(companyId: String, message: String, startRuntime: Bool = false) async throws -> ChatIntakeResponsePayload {
         try await post(
-            path: "api/app/companies/\(companyId)/chat-intake",
+            pathSegments: ["api", "app", "companies", companyId, "chat-intake"],
             body: ChatIntakeRequestPayload(message: message, startRuntime: startRuntime)
         )
     }
@@ -233,7 +305,7 @@ struct DesktopAPI {
         confirmStaffing: Bool = false
     ) async throws -> OperatorCommandResponsePayload {
         try await post(
-            path: "api/app/companies/\(companyId)/operator/commands",
+            pathSegments: ["api", "app", "companies", companyId, "operator", "commands"],
             body: OperatorCommandRequestPayload(
                 message: message,
                 automationMode: automationMode,
@@ -251,7 +323,7 @@ struct DesktopAPI {
         confirmStaffing: Bool = false
     ) async throws -> OperatorChatResponsePayload {
         try await post(
-            path: "api/app/companies/\(companyId)/operator/chat",
+            pathSegments: ["api", "app", "companies", companyId, "operator", "chat"],
             body: OperatorCommandRequestPayload(
                 message: message,
                 automationMode: automationMode,
@@ -273,7 +345,7 @@ struct DesktopAPI {
         parameters: [String: String] = [:]
     ) async throws -> SkillRunResultRecord {
         try await post(
-            path: "api/app/skills/\(name)/run",
+            pathSegments: ["api", "app", "skills", name, "run"],
             body: SkillRunRequestPayload(
                 companyId: companyId,
                 agentId: agentId,
@@ -289,38 +361,36 @@ struct DesktopAPI {
         settings: [String: AgentCapabilitySettingRecord]
     ) async throws -> AgentCapabilityProfileRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)/agents/\(agentId)/capabilities",
+            pathSegments: ["api", "app", "companies", companyId, "agents", agentId, "capabilities"],
             body: UpdateAgentCapabilitiesPayload(settings: settings)
         )
     }
 
     func marketingPolicies(companyId: String? = nil, agentId: String? = nil) async throws -> [MarketingDelegationPolicyRecord] {
-        var queryItems: [String] = []
+        var queryItems: [URLQueryItem] = []
         if let companyId, !companyId.isEmpty {
-            queryItems.append("companyId=\(companyId)")
+            queryItems.append(URLQueryItem(name: "companyId", value: companyId))
         }
         if let agentId, !agentId.isEmpty {
-            queryItems.append("agentId=\(agentId)")
+            queryItems.append(URLQueryItem(name: "agentId", value: agentId))
         }
-        let suffix = queryItems.isEmpty ? "" : "?\(queryItems.joined(separator: "&"))"
-        return try await get(path: "api/app/marketing/policies\(suffix)")
+        return try await get(path: "api/app/marketing/policies", query: queryItems)
     }
 
     func marketingRuns(companyId: String? = nil, agentId: String? = nil) async throws -> [MarketingRunRecord] {
-        var queryItems: [String] = []
+        var queryItems: [URLQueryItem] = []
         if let companyId, !companyId.isEmpty {
-            queryItems.append("companyId=\(companyId)")
+            queryItems.append(URLQueryItem(name: "companyId", value: companyId))
         }
         if let agentId, !agentId.isEmpty {
-            queryItems.append("agentId=\(agentId)")
+            queryItems.append(URLQueryItem(name: "agentId", value: agentId))
         }
-        let suffix = queryItems.isEmpty ? "" : "?\(queryItems.joined(separator: "&"))"
-        return try await get(path: "api/app/marketing/runs\(suffix)")
+        return try await get(path: "api/app/marketing/runs", query: queryItems)
     }
 
     func upsertMarketingPolicy(_ payload: UpsertMarketingDelegationPolicyPayload) async throws -> MarketingDelegationPolicyRecord {
         if let id = payload.id, !id.isEmpty {
-            return try await patch(path: "api/app/marketing/policies/\(id)", body: payload)
+            return try await patch(pathSegments: ["api", "app", "marketing", "policies", id], body: payload)
         }
         return try await post(path: "api/app/marketing/policies", body: payload)
     }
@@ -334,7 +404,7 @@ struct DesktopAPI {
         autonomyEnabled: Bool = true
     ) async throws -> GoalRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)/goals/\(goalId)",
+            pathSegments: ["api", "app", "companies", companyId, "goals", goalId],
             body: UpdateGoalPayload(
                 title: title,
                 description: description,
@@ -345,7 +415,7 @@ struct DesktopAPI {
     }
 
     func deleteGoal(companyId: String, goalId: String) async throws -> GoalRecord {
-        try await delete(path: "api/app/companies/\(companyId)/goals/\(goalId)")
+        try await delete(pathSegments: ["api", "app", "companies", companyId, "goals", goalId])
     }
 
     func createCompany(
@@ -378,7 +448,7 @@ struct DesktopAPI {
         monthlyBudgetCents: Int? = nil
     ) async throws -> CompanyRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)",
+            pathSegments: ["api", "app", "companies", companyId],
             body: UpdateCompanyPayload(
                 name: name,
                 defaultBaseBranch: defaultBaseBranch,
@@ -470,7 +540,7 @@ struct DesktopAPI {
         useGlobalDefault: Bool
     ) async throws -> CompanyRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)/backend",
+            pathSegments: ["api", "app", "companies", companyId, "backend"],
             body: UpdateCompanyBackendPayload(
                 backendKind: backendKind,
                 launchMode: launchMode,
@@ -489,19 +559,19 @@ struct DesktopAPI {
     }
 
     func companyBackendStatus(companyId: String) async throws -> ExecutionBackendStatusPayload {
-        try await get(path: "api/app/companies/\(companyId)/backend")
+        try await get(pathSegments: ["api", "app", "companies", companyId, "backend"])
     }
 
     func startCompanyBackend(companyId: String) async throws -> ExecutionBackendStatusPayload {
-        try await post(path: "api/app/companies/\(companyId)/backend/start", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "backend", "start"], body: EmptyPayload())
     }
 
     func stopCompanyBackend(companyId: String) async throws -> ExecutionBackendStatusPayload {
-        try await post(path: "api/app/companies/\(companyId)/backend/stop", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "backend", "stop"], body: EmptyPayload())
     }
 
     func restartCompanyBackend(companyId: String) async throws -> ExecutionBackendStatusPayload {
-        try await post(path: "api/app/companies/\(companyId)/backend/restart", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "backend", "restart"], body: EmptyPayload())
     }
 
     func updateCompanyLinear(
@@ -514,7 +584,7 @@ struct DesktopAPI {
         useGlobalDefault: Bool
     ) async throws -> CompanyRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)/linear",
+            pathSegments: ["api", "app", "companies", companyId, "linear"],
             body: UpdateCompanyLinearPayload(
                 enabled: enabled,
                 endpoint: endpoint,
@@ -528,11 +598,11 @@ struct DesktopAPI {
     }
 
     func resyncCompanyLinear(companyId: String) async throws -> LinearSyncResponsePayload {
-        try await post(path: "api/app/companies/\(companyId)/linear/resync", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "linear", "resync"], body: EmptyPayload())
     }
 
     func deleteCompany(companyId: String) async throws -> CompanyRecord {
-        try await delete(path: "api/app/companies/\(companyId)")
+        try await delete(pathSegments: ["api", "app", "companies", companyId])
     }
 
     func createIssue(
@@ -544,7 +614,7 @@ struct DesktopAPI {
         kind: String = "manual"
     ) async throws -> IssueRecord {
         try await post(
-            path: "api/app/companies/\(companyId)/issues",
+            pathSegments: ["api", "app", "companies", companyId, "issues"],
             body: CreateIssuePayload(
                 goalId: goalId,
                 title: title,
@@ -556,11 +626,11 @@ struct DesktopAPI {
     }
 
     func decomposeGoal(goalId: String) async throws -> [IssueRecord] {
-        try await post(path: "api/app/goals/\(goalId)/decompose", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "goals", goalId, "decompose"], body: EmptyPayload())
     }
 
     func deleteIssue(companyId: String, issueId: String) async throws -> IssueRecord {
-        try await delete(path: "api/app/companies/\(companyId)/issues/\(issueId)")
+        try await delete(pathSegments: ["api", "app", "companies", companyId, "issues", issueId])
     }
 
     func createCompanyAgent(
@@ -577,7 +647,7 @@ struct DesktopAPI {
         enabled: Bool = true
     ) async throws -> CompanyAgentDefinitionRecord {
         try await post(
-            path: "api/app/companies/\(companyId)/agents",
+            pathSegments: ["api", "app", "companies", companyId, "agents"],
             body: CreateCompanyAgentPayload(
                 title: title,
                 agentCli: agentCli,
@@ -608,7 +678,7 @@ struct DesktopAPI {
         enabled: Bool
     ) async throws -> CompanyAgentDefinitionRecord {
         try await patch(
-            path: "api/app/companies/\(companyId)/agents/\(agentId)",
+            pathSegments: ["api", "app", "companies", companyId, "agents", agentId],
             body: UpdateCompanyAgentPayload(
                 title: title,
                 agentCli: agentCli,
@@ -634,7 +704,7 @@ struct DesktopAPI {
         enabled: Bool?
     ) async throws -> [CompanyAgentDefinitionRecord] {
         try await patch(
-            path: "api/app/companies/\(companyId)/agents/batch",
+            pathSegments: ["api", "app", "companies", companyId, "agents", "batch"],
             body: BatchUpdateCompanyAgentsPayload(
                 agentIds: agentIds,
                 agentCli: agentCli,
@@ -646,42 +716,42 @@ struct DesktopAPI {
     }
 
     func startCompanyRuntime(companyId: String) async throws -> CompanyRuntimeSnapshotRecord {
-        try await post(path: "api/app/companies/\(companyId)/runtime/start", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "runtime", "start"], body: EmptyPayload())
     }
 
     func stopCompanyRuntime(companyId: String) async throws -> CompanyRuntimeSnapshotRecord {
-        try await post(path: "api/app/companies/\(companyId)/runtime/stop", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "companies", companyId, "runtime", "stop"], body: EmptyPayload())
     }
 
     func runIssue(issueId: String) async throws -> IssueRecord {
-        try await post(path: "api/app/issues/\(issueId)/run", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "issues", issueId, "run"], body: EmptyPayload())
     }
 
     func delegateIssue(issueId: String) async throws -> IssueRecord {
-        try await post(path: "api/app/issues/\(issueId)/delegate", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "issues", issueId, "delegate"], body: EmptyPayload())
     }
 
     func submitQaReviewVerdict(itemId: String, verdict: String, feedback: String?) async throws -> ReviewQueueItemRecord {
         try await post(
-            path: "api/app/review-queue/\(itemId)/qa",
+            pathSegments: ["api", "app", "review-queue", itemId, "qa"],
             body: ReviewQueueVerdictPayload(verdict: verdict, feedback: feedback)
         )
     }
 
     func submitCeoReviewVerdict(itemId: String, verdict: String, feedback: String?) async throws -> ReviewQueueItemRecord {
         try await post(
-            path: "api/app/review-queue/\(itemId)/ceo",
+            pathSegments: ["api", "app", "review-queue", itemId, "ceo"],
             body: ReviewQueueVerdictPayload(verdict: verdict, feedback: feedback)
         )
     }
 
     func mergeReviewQueueItem(itemId: String) async throws -> ReviewQueueItemRecord {
-        try await post(path: "api/app/review-queue/\(itemId)/merge", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "review-queue", itemId, "merge"], body: EmptyPayload())
     }
 
     /// Ask the backend to start executing an already-created task.
     func runTask(taskId: String) async throws -> TaskRecord {
-        try await post(path: "api/app/tasks/\(taskId)/run", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "tasks", taskId, "run"], body: EmptyPayload())
     }
 
     /// Open or reuse the interactive TUI session for one workspace.
@@ -700,32 +770,32 @@ struct DesktopAPI {
 
     /// Fetch the latest rolling transcript for an active TUI session.
     func tuiSession(sessionId: String) async throws -> TuiSessionRecord {
-        try await get(path: "api/app/tui/sessions/\(sessionId)")
+        try await get(pathSegments: ["api", "app", "tui", "sessions", sessionId])
     }
 
     /// Fetch only the terminal bytes appended after the provided cursor.
     func tuiDelta(sessionId: String, offset: Int64) async throws -> TuiSessionDeltaPayload {
         try await get(
-            path: "api/app/tui/sessions/\(sessionId)/delta",
+            pathSegments: ["api", "app", "tui", "sessions", sessionId, "delta"],
             query: [URLQueryItem(name: "offset", value: String(offset))]
         )
     }
 
     /// Forward raw terminal input into the running TUI process.
     func sendTuiInput(sessionId: String, input: String) async throws -> TuiSessionRecord {
-        try await post(path: "api/app/tui/sessions/\(sessionId)/input", body: TuiInputPayload(input: input))
+        try await post(pathSegments: ["api", "app", "tui", "sessions", sessionId, "input"], body: TuiInputPayload(input: input))
     }
 
     /// Gracefully stop the TUI session when the user wants a fresh start.
     func terminateTuiSession(sessionId: String) async throws -> TuiSessionRecord {
-        try await post(path: "api/app/tui/sessions/\(sessionId)/terminate", body: EmptyPayload())
+        try await post(pathSegments: ["api", "app", "tui", "sessions", sessionId, "terminate"], body: EmptyPayload())
     }
 
     func companyEvents(companyId: String) -> AsyncThrowingStream<CompanyEventEnvelopePayload, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    var request = URLRequest(url: try makeURL(path: "api/app/companies/\(companyId)/events"))
+                    var request = URLRequest(url: try makeURL(pathSegments: ["api", "app", "companies", companyId, "events"]))
                     request.httpMethod = "GET"
                     addHeaders(to: &request)
                     let (bytes, response) = try await URLSession.shared.bytes(for: request)
@@ -755,8 +825,23 @@ struct DesktopAPI {
         return try await decode(request)
     }
 
+    private func get<T: Decodable>(pathSegments: [String], query: [URLQueryItem] = []) async throws -> T {
+        var request = URLRequest(url: try makeURL(pathSegments: pathSegments, query: query))
+        request.httpMethod = "GET"
+        addHeaders(to: &request)
+        return try await decode(request)
+    }
+
     private func post<T: Decodable, Body: Encodable>(path: String, body: Body) async throws -> T {
         var request = URLRequest(url: try makeURL(path: path))
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(body)
+        addHeaders(to: &request)
+        return try await decode(request)
+    }
+
+    private func post<T: Decodable, Body: Encodable>(pathSegments: [String], body: Body) async throws -> T {
+        var request = URLRequest(url: try makeURL(pathSegments: pathSegments))
         request.httpMethod = "POST"
         request.httpBody = try JSONEncoder().encode(body)
         addHeaders(to: &request)
@@ -771,6 +856,14 @@ struct DesktopAPI {
         return try await decode(request)
     }
 
+    private func patch<T: Decodable, Body: Encodable>(pathSegments: [String], body: Body) async throws -> T {
+        var request = URLRequest(url: try makeURL(pathSegments: pathSegments))
+        request.httpMethod = "PATCH"
+        request.httpBody = try JSONEncoder().encode(body)
+        addHeaders(to: &request)
+        return try await decode(request)
+    }
+
     private func delete<T: Decodable>(path: String) async throws -> T {
         var request = URLRequest(url: try makeURL(path: path))
         request.httpMethod = "DELETE"
@@ -778,17 +871,42 @@ struct DesktopAPI {
         return try await decode(request)
     }
 
+    private func delete<T: Decodable>(pathSegments: [String]) async throws -> T {
+        var request = URLRequest(url: try makeURL(pathSegments: pathSegments))
+        request.httpMethod = "DELETE"
+        addHeaders(to: &request)
+        return try await decode(request)
+    }
+
     private func makeURL(path: String, query: [URLQueryItem] = []) throws -> URL {
+        try makeURL(pathSegments: path.split(separator: "/").map(String.init), query: query)
+    }
+
+    internal func makeURL(pathSegments: [String], query: [URLQueryItem] = []) throws -> URL {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
-        // All routes are relative to the localhost app-server root; callers only pass
-        // the resource path fragment so they do not need to know deployment details.
-        components?.path = "/" + path
+        let encodedPath = try pathSegments
+            .map(Self.percentEncodePathSegment)
+            .joined(separator: "/")
+        components?.percentEncodedPath = "/" + encodedPath
         components?.queryItems = query.isEmpty ? nil : query
         guard let url = components?.url else {
             throw URLError(.badURL)
         }
         return url
     }
+
+    private static func percentEncodePathSegment(_ segment: String) throws -> String {
+        guard let encoded = segment.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) else {
+            throw URLError(.badURL)
+        }
+        return encoded
+    }
+
+    private static let pathSegmentAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#%\\")
+        return allowed
+    }()
 
     private func decode<T: Decodable>(_ request: URLRequest) async throws -> T {
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -805,7 +923,6 @@ struct DesktopAPI {
 
     private func addHeaders(to request: inout URLRequest) {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        // Bearer auth is optional so local development can stay frictionless when desired.
         if let token, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
@@ -813,6 +930,22 @@ struct DesktopAPI {
 }
 
 private struct EmptyPayload: Codable {}
+
+private extension Data {
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private func nonEmpty(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+        return nil
+    }
+    return trimmed
+}
 
 private struct ConfigureGitHubOriginPayload: Codable {
     let remoteUrl: String

--- a/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
+++ b/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
@@ -242,7 +242,7 @@ actor EmbeddedBackendLauncher {
         }
         var request = URLRequest(url: url)
         request.timeoutInterval = 1.5
-        request.setValue("Bearer \(DesktopAPI.appToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(DesktopAPI.ensureAppToken())", forHTTPHeaderField: "Authorization")
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse {
@@ -261,7 +261,7 @@ actor EmbeddedBackendLauncher {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 1.5
-        request.setValue("Bearer \(DesktopAPI.appToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(DesktopAPI.ensureAppToken())", forHTTPHeaderField: "Authorization")
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse {
@@ -278,7 +278,7 @@ actor EmbeddedBackendLauncher {
             processEnvironment: ProcessInfo.processInfo.environment,
             javaPath: javaPath,
             appHomePath: defaultDesktopAppHome().path,
-            appToken: DesktopAPI.appToken
+            appToken: DesktopAPI.ensureAppToken()
         )
     }
 

--- a/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
@@ -180,6 +180,31 @@ struct ModelsTests {
     }
 
     @Test
+    func desktopAPIUsesOnlyConfiguredOrRuntimeToken() throws {
+        #expect(DesktopAPI.configuredAppToken(processEnvironment: [:]) == nil)
+        #expect(DesktopAPI.configuredAppToken(processEnvironment: ["COTOR_APP_TOKEN": " configured-token "]) == "configured-token")
+
+        let appHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cotor-desktop-token-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appHome) }
+
+        #expect(DesktopAPI.readRuntimeAppToken(appHome: appHome) == nil)
+        let tokenURL = try #require(DesktopAPI.writeRuntimeAppToken("runtime-token", appHome: appHome))
+
+        #expect(tokenURL.lastPathComponent == "app-server.token")
+        #expect(DesktopAPI.readRuntimeAppToken(appHome: appHome) == "runtime-token")
+    }
+
+    @Test
+    func desktopAPIEncodesDynamicPathSegments() throws {
+        let api = DesktopAPI(baseURL: try #require(URL(string: "http://127.0.0.1:8787")), token: "token")
+        let url = try api.makeURL(pathSegments: ["api", "app", "companies", "company/a?b#c", "dashboard"])
+
+        #expect(url.absoluteString == "http://127.0.0.1:8787/api/app/companies/company%2Fa%3Fb%23c/dashboard")
+    }
+
+    @Test
     func desktopSettingsDecodesMissingAgentModelFieldsAsEmpty() throws {
         let encoded = try JSONEncoder().encode(DashboardPayload.empty.settings)
         var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -30,6 +30,7 @@ import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.request.header
 import io.ktor.server.request.path
 import io.ktor.server.request.receive
+import io.ktor.server.request.uri
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.response.respondTextWriter
@@ -64,6 +65,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFilePermissions
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
@@ -88,6 +90,9 @@ class AppServer : KoinComponent {
         controlToken: String? = null
     ) {
         val lockRecord = desktopAppServerInstanceGuard.acquire(host = host, port = port)
+        token?.takeIf { it.isNotBlank() }?.let {
+            persistAppServerToken(it, lockRecord.appHome)
+        }
         println(
             "[cotor-app-server] acquired desktop app-server instance lock at " +
                 "${lockRecord.lockPath} for app home ${lockRecord.appHome}"
@@ -260,6 +265,36 @@ internal fun readDesktopAppServerInstanceStatus(appHome: Path): DesktopAppServer
     }.getOrNull() ?: return DesktopAppServerInstanceStatus(active = false)
     val active = ProcessHandle.of(metadata.pid).map(ProcessHandle::isAlive).orElse(false)
     return DesktopAppServerInstanceStatus(active = active, metadata = metadata.takeIf { active })
+}
+
+internal fun appServerTokenPath(appHome: Path = defaultDesktopAppHome()): Path {
+    return appHome.resolve("runtime").resolve("backend").resolve("app-server.token")
+}
+
+internal fun readPersistedAppServerToken(appHome: Path = defaultDesktopAppHome()): String? {
+    return runCatching {
+        Files.readString(appServerTokenPath(appHome)).trim().takeIf(String::isNotBlank)
+    }.getOrNull()
+}
+
+internal fun persistAppServerToken(token: String, appHome: Path = defaultDesktopAppHome()): Path {
+    val tokenPath = appServerTokenPath(appHome)
+    val runtimeDir = tokenPath.parent
+    Files.createDirectories(runtimeDir)
+    runCatching {
+        Files.setPosixFilePermissions(runtimeDir, PosixFilePermissions.fromString("rwx------"))
+    }
+    Files.writeString(
+        tokenPath,
+        token,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE
+    )
+    runCatching {
+        Files.setPosixFilePermissions(tokenPath, PosixFilePermissions.fromString("rw-------"))
+    }
+    return tokenPath
 }
 
 private val mcpJson = Json {
@@ -2484,12 +2519,15 @@ private fun truncateForApi(value: String, maxChars: Int): String {
     }
 }
 
-/**
- * Token auth is intentionally minimal because the server only binds to localhost.
- * The token mainly protects against accidental cross-process access on the same machine.
- */
 private suspend fun RoutingContext.requireToken(token: String?): Boolean {
-    val expected = token?.takeIf { it.isNotBlank() } ?: return true
+    if (!requireSafeRequestPath()) {
+        return false
+    }
+    val expected = token?.takeIf { it.isNotBlank() }
+    if (expected == null) {
+        call.respond(HttpStatusCode.Unauthorized, mapOf("error" to "App server token is not configured"))
+        return false
+    }
     val actual = call.request.header(HttpHeaders.Authorization)
     if (isBearerTokenMatch(actual, expected)) {
         return true
@@ -2505,6 +2543,18 @@ private suspend fun RoutingContext.requireControlToken(controlToken: String?): B
         return false
     }
     return requireToken(expected)
+}
+
+private suspend fun RoutingContext.requireSafeRequestPath(): Boolean {
+    val encodedPath = call.request.uri.substringBefore('?').lowercase()
+    val decodedSegments = call.request.path().split('/').filter(String::isNotEmpty)
+    val hasEncodedSeparator = encodedPath.contains("%2f") || encodedPath.contains("%5c")
+    val hasTraversalSegment = decodedSegments.any { it == "." || it == ".." || it.contains('\\') }
+    if (!hasEncodedSeparator && !hasTraversalSegment) {
+        return true
+    }
+    call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid path segment"))
+    return false
 }
 
 private fun isBearerTokenMatch(header: String?, expected: String): Boolean {

--- a/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/AppServerCommand.kt
@@ -9,11 +9,16 @@ package com.cotor.presentation.cli
  */
 
 import com.cotor.app.AppServer
+import com.cotor.app.appServerTokenPath
+import com.cotor.app.defaultDesktopAppHome
+import com.cotor.app.readPersistedAppServerToken
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
+import java.nio.file.Path
+import java.security.SecureRandom
+import java.util.Base64
 
 /**
  * CLI entrypoint used by the native macOS shell.
@@ -34,19 +39,32 @@ class AppServerCommand : CliktCommand(
         .default(System.getenv("COTOR_APP_CONTROL_TOKEN").orEmpty())
 
     override fun run() {
-        if (requiresTokenForHost(host) && token.isBlank()) {
-            throw CliktError("--token or COTOR_APP_TOKEN is required when binding app-server to non-loopback host '$host'")
+        val appHome = defaultDesktopAppHome()
+        val storedToken = readPersistedAppServerToken(appHome)
+        val effectiveToken = resolveAppServerToken(token, appHome)
+        if (token.isBlank() && storedToken == null) {
+            val tokenPath = appServerTokenPath(appHome)
+            println("[cotor-app-server] generated bearer token at $tokenPath")
         }
         AppServer().start(
             host = host,
             port = port,
-            token = token.ifBlank { null },
+            token = effectiveToken,
             controlToken = controlToken.ifBlank { null }
         )
     }
 }
 
-internal fun requiresTokenForHost(host: String): Boolean {
-    val normalized = host.trim().lowercase()
-    return normalized !in setOf("127.0.0.1", "localhost", "::1")
+private val appServerTokenRandom = SecureRandom()
+
+internal fun resolveAppServerToken(configuredToken: String, appHome: Path = defaultDesktopAppHome()): String {
+    return configuredToken.trim().takeIf { it.isNotBlank() }
+        ?: readPersistedAppServerToken(appHome)
+        ?: generateAppServerToken()
+}
+
+internal fun generateAppServerToken(randomBytes: (ByteArray) -> Unit = appServerTokenRandom::nextBytes): String {
+    val bytes = ByteArray(32)
+    randomBytes(bytes)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
 }

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -91,6 +91,26 @@ class A2aApiTest : FunSpec({
         }
     }
 
+    test("auth missing returns unauthorized when server token is not configured") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = null,
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.post("/api/a2a/v1/sessions") {
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(A2aHelloRequest(agentId = "agent-1", capabilities = listOf("task.assign"), tenant = A2aTenant("company-1"))))
+            }
+
+            response.status shouldBe HttpStatusCode.Unauthorized
+            response.bodyAsText() shouldContain "App server token is not configured"
+        }
+    }
+
     test("duplicate dedupe key returns already_processed") {
         testApplication {
             application {

--- a/src/test/kotlin/com/cotor/app/AppServerTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerTest.kt
@@ -81,6 +81,61 @@ class AppServerTest : FunSpec({
         }
     }
 
+    test("app routes reject requests when server token is not configured") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = null,
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val dashboard = client.get("/api/app/dashboard")
+            val shutdown = client.post("/api/app/shutdown")
+
+            dashboard.status shouldBe HttpStatusCode.Unauthorized
+            dashboard.bodyAsText() shouldContain "App server token is not configured"
+            shutdown.status shouldBe HttpStatusCode.Unauthorized
+        }
+    }
+
+    test("app routes reject requests when server token is blank") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.get("/api/app/dashboard")
+
+            response.status shouldBe HttpStatusCode.Unauthorized
+            response.bodyAsText() shouldContain "App server token is not configured"
+        }
+    }
+
+    test("app routes reject encoded path separators") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.get("/api/app/companies/company%2Fbad/dashboard") {
+                header("Authorization", "Bearer secret-token")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "Invalid path segment"
+        }
+    }
+
     test("company agent performance route returns scoped snapshots") {
         coEvery { desktopService.agentPerformance("company-performance") } returns listOf(
             AgentPerformanceSnapshot(

--- a/src/test/kotlin/com/cotor/presentation/cli/AppServerCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/AppServerCommandTest.kt
@@ -1,17 +1,50 @@
 package com.cotor.presentation.cli
 
+import com.cotor.app.persistAppServerToken
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotContain
+import java.nio.file.Files
 
 class AppServerCommandTest : FunSpec({
-    test("app-server allows loopback bind without token") {
-        requiresTokenForHost("127.0.0.1") shouldBe false
-        requiresTokenForHost("localhost") shouldBe false
-        requiresTokenForHost("::1") shouldBe false
+    test("app-server preserves configured bearer token") {
+        resolveAppServerToken(" configured-token ") shouldBe "configured-token"
     }
 
-    test("app-server requires token for non-loopback bind") {
-        requiresTokenForHost("0.0.0.0") shouldBe true
-        requiresTokenForHost("192.168.0.10") shouldBe true
+    test("app-server reuses persisted bearer token before generating a new one") {
+        val appHome = Files.createTempDirectory("cotor-app-server-token-reuse-test")
+        try {
+            persistAppServerToken("stored-token", appHome)
+
+            resolveAppServerToken("", appHome) shouldBe "stored-token"
+        } finally {
+            appHome.toFile().deleteRecursively()
+        }
+    }
+
+    test("app-server generates url-safe bearer token when none is configured") {
+        val token = generateAppServerToken { bytes ->
+            bytes.indices.forEach { index ->
+                bytes[index] = index.toByte()
+            }
+        }
+
+        token shouldNotBe ""
+        token shouldNotContain "+"
+        token shouldNotContain "/"
+        token shouldNotContain "="
+    }
+
+    test("app-server persists effective bearer token for desktop clients") {
+        val appHome = Files.createTempDirectory("cotor-app-server-token-test")
+        try {
+            val tokenPath = persistAppServerToken("secret-token", appHome)
+
+            tokenPath.fileName.toString() shouldBe "app-server.token"
+            Files.readString(tokenPath) shouldBe "secret-token"
+        } finally {
+            appHome.toFile().deleteRecursively()
+        }
     }
 })


### PR DESCRIPTION
## Summary
- make localhost app-server routes fail closed when bearer auth is missing
- generate/reuse a per-user runtime app-server token and remove the static desktop fallback token
- encode dynamic DesktopAPI path segments and reject encoded path separators on the server
- update desktop docs for generated runtime token behavior

## Root Cause
The localhost app-server treated a blank token as authenticated, while the desktop client could fall back to a known static token. Dynamic route paths were also built from raw interpolated strings.

## Validation
- ./gradlew test
- ./gradlew test --tests 'com.cotor.app.AppServerTest' --tests 'com.cotor.presentation.cli.AppServerCommandTest' --tests 'com.cotor.a2a.A2aApiTest' -x jacocoTestCoverageVerification\n- swift test --package-path macos --filter CotorDesktopAppTests\n- npm audit --omit=dev --json\n- focused gitleaks scans on changed source/config files\n- git diff --check\n\n## Notes\nLocal ignored config hardening was applied outside this PR: repo-local Codex sandbox was reduced from danger-full-access, broad home-directory executable allowlisting was removed, and local .opencode audit now reports zero vulnerabilities.