### PR TITLE
[codex] Fix Cotor review safety and publish hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /workspace/build/libs/cotor-*-all.jar /app/cotor.jar
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+
+RUN chmod +x /app/docker-entrypoint.sh
 
 EXPOSE 8787
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD ["curl", "--fail", "--silent", "http://127.0.0.1:8787/health"]
 
-ENTRYPOINT ["java", "-jar", "/app/cotor.jar"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["app-server", "--host", "0.0.0.0", "--port", "8787"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+is_loopback_host() {
+  case "$1" in
+    ""|"127.0.0.1"|"localhost"|"::1"|"[::1]")
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+random_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  else
+    od -An -N32 -tx1 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+command_name="${1:-}"
+host="${COTOR_APP_HOST:-127.0.0.1}"
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--host" ]; then
+    host="$arg"
+  fi
+  case "$arg" in
+    --host=*)
+      host="${arg#--host=}"
+      ;;
+  esac
+  previous="$arg"
+done
+
+if [ "$command_name" = "app-server" ] && ! is_loopback_host "$host" && [ -z "${COTOR_APP_TOKEN:-}" ]; then
+  export COTOR_APP_TOKEN="$(random_token)"
+  echo "Generated COTOR_APP_TOKEN for non-loopback app-server binding." >&2
+fi
+
+exec java -jar /app/cotor.jar "$@"

--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -95,6 +95,13 @@ struct DesktopAPI {
 
     let baseURL: URL
     let token: String?
+    let session: URLSession
+
+    internal init(baseURL: URL, token: String?, session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.token = token
+        self.session = session
+    }
 
     init() {
         // The desktop shell defaults to the standard localhost port but allows
@@ -103,13 +110,7 @@ struct DesktopAPI {
         guard let fallbackURL = URL(string: "http://127.0.0.1:8787") else {
             preconditionFailure("Default app server URL must be valid")
         }
-        self.baseURL = URL(string: rawURL) ?? fallbackURL
-        self.token = Self.ensureAppToken()
-    }
-
-    internal init(baseURL: URL, token: String?) {
-        self.baseURL = baseURL
-        self.token = token
+        self.init(baseURL: URL(string: rawURL) ?? fallbackURL, token: Self.ensureAppToken())
     }
 
     /// Fetch the full dashboard payload used to bootstrap most of the app state.
@@ -798,7 +799,7 @@ struct DesktopAPI {
                     var request = URLRequest(url: try makeURL(pathSegments: ["api", "app", "companies", companyId, "events"]))
                     request.httpMethod = "GET"
                     addHeaders(to: &request)
-                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    let (bytes, response) = try await session.bytes(for: request)
                     guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
                         throw URLError(.badServerResponse)
                     }
@@ -892,10 +893,14 @@ struct DesktopAPI {
 
     internal static func makeURL(baseURL: URL, pathSegments: [String], query: [URLQueryItem] = []) throws -> URL {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
-        let encodedPath = try pathSegments
+        let basePath = components?.percentEncodedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/")) ?? ""
+        let routePath = try pathSegments
             .map(Self.percentEncodePathSegment)
             .joined(separator: "/")
-        components?.percentEncodedPath = "/" + encodedPath
+        let joinedPath = [basePath, routePath]
+            .filter { !$0.isEmpty }
+            .joined(separator: "/")
+        components?.percentEncodedPath = joinedPath.isEmpty ? "/" : "/\(joinedPath)"
         components?.queryItems = query.isEmpty ? nil : query
         guard let url = components?.url else {
             throw URLError(.badURL)
@@ -917,7 +922,7 @@ struct DesktopAPI {
     }()
 
     private func decode<T: Decodable>(_ request: URLRequest) async throws -> T {
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -462,7 +462,7 @@ final class DesktopStore: ObservableObject {
     @Published var selectedCompanyReport: CompanyDailyReportRecord?
     @Published var isGeneratingCompanyReport = false
 
-    let api = DesktopAPI()
+    let api: DesktopAPI
     private var statusState: StatusState = .connecting
     private var tuiPollingTask: Task<Void, Never>?
     private var companyEventTask: Task<Void, Never>?
@@ -474,7 +474,8 @@ final class DesktopStore: ObservableObject {
     private var polledTuiSessionID: String?
     private var didInitializeShellMode = false
 
-    init() {
+    init(api: DesktopAPI = DesktopAPI()) {
+        self.api = api
         let storedLanguage = UserDefaults.standard.string(forKey: Self.languageDefaultsKey)
         language = AppLanguage(rawValue: storedLanguage ?? "") ?? .english
         let storedTheme = UserDefaults.standard.string(forKey: Self.themeDefaultsKey)
@@ -714,6 +715,10 @@ final class DesktopStore: ObservableObject {
 
     var selectedCompany: CompanyRecord? {
         companies.first { $0.id == selectedCompanyID }
+    }
+
+    private func isCurrentCompany(_ companyId: String) -> Bool {
+        (selectedCompanyID ?? selectedCompany?.id) == companyId
     }
 
     var selectedIssue: IssueRecord? {
@@ -1373,6 +1378,7 @@ final class DesktopStore: ObservableObject {
             let summaries = try await runWithEmbeddedBackendRecovery {
                 try await api.companyReports(companyId: scopedCompanyId)
             }
+            guard isCurrentCompany(scopedCompanyId) else { return }
             companyReports = companyReports.filter { $0.companyId != scopedCompanyId } + summaries
             let sortedSummaries = summaries.sorted {
                 if $0.date == $1.date {
@@ -1397,12 +1403,16 @@ final class DesktopStore: ObservableObject {
     func selectCompanyReport(date: String) async {
         guard let companyID = selectedCompanyID else { return }
         do {
-            selectedCompanyReportDate = date
-            selectedCompanyReport = try await runWithEmbeddedBackendRecovery {
+            let report = try await runWithEmbeddedBackendRecovery {
                 try await api.companyReport(companyId: companyID, date: date)
             }
+            guard isCurrentCompany(companyID) else { return }
+            selectedCompanyReportDate = date
+            selectedCompanyReport = report
         } catch {
-            errorMessage = error.localizedDescription
+            if isCurrentCompany(companyID) {
+                errorMessage = error.localizedDescription
+            }
             AppLogger.error("Company report load failed: \(error.localizedDescription)")
         }
     }
@@ -1415,6 +1425,7 @@ final class DesktopStore: ObservableObject {
             let report = try await runWithEmbeddedBackendRecovery {
                 try await api.generateCompanyReport(companyId: companyID)
             }
+            guard isCurrentCompany(companyID) else { return }
             selectedCompanyReportDate = report.date
             selectedCompanyReport = report
             await refreshCompanyReports(companyId: companyID)
@@ -2631,7 +2642,7 @@ final class DesktopStore: ObservableObject {
             let signals = try await runWithEmbeddedBackendRecovery {
                 try await api.companyProblemSignals(companyId: companyId)
             }
-            guard (explicitCompanyId != nil) || (selectedCompanyID ?? selectedCompany?.id) == companyId else { return }
+            guard isCurrentCompany(companyId) else { return }
             companyProblemSignals = signals
         } catch is CancellationError {
             return
@@ -2824,14 +2835,18 @@ final class DesktopStore: ObservableObject {
             return
         }
         do {
-            let status = try await api.companyGitHubStatus(companyId: company.id)
+            let companyId = company.id
+            let status = try await api.companyGitHubStatus(companyId: companyId)
+            guard isCurrentCompany(companyId) else { return }
             selectedCompanyGitHubStatus = status
             syncGitHubOriginInput(with: status)
             companyGitHubStatusMessage = githubRequirementMessage(for: status) ?? status.message
             errorMessage = nil
         } catch {
-            companyGitHubStatusMessage = error.localizedDescription
-            errorMessage = error.localizedDescription
+            if selectedCompany?.id == company.id {
+                companyGitHubStatusMessage = error.localizedDescription
+                errorMessage = error.localizedDescription
+            }
         }
     }
 

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -1126,6 +1126,115 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func staleCompanyAsyncResponsesDoNotOverwriteSelectedCompanyState() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            if path.contains("/github/status") {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+            let body: String
+            switch path {
+            case "/api/app/companies/company-a/github/status":
+                body = """
+                {
+                  "policy": "REQUIRE_GITHUB_PR",
+                  "ghInstalled": true,
+                  "ghAuthenticated": true,
+                  "originConfigured": true,
+                  "originUrl": "https://github.com/example/a.git",
+                  "bootstrapAvailable": true,
+                  "repositoryPath": "/tmp/a",
+                  "companyId": "company-a",
+                  "companyName": "Company A",
+                  "message": "ready"
+                }
+                """
+            case "/api/app/companies/company-a/reports":
+                body = """
+                [{
+                  "id": "report-a",
+                  "companyId": "company-a",
+                  "date": "2026-05-12",
+                  "generatedAt": 1,
+                  "periodStart": 0,
+                  "periodEnd": 1,
+                  "summary": "Company A report",
+                  "completedCount": 0,
+                  "blockedCount": 0,
+                  "qaPassedCount": 0,
+                  "changesRequestedCount": 0,
+                  "pullRequestCount": 0,
+                  "estimatedRunCostCents": 0,
+                  "activityCount": 0
+                }]
+                """
+            case "/api/app/companies/company-a/problem-signals":
+                body = """
+                [{
+                  "id": "signal-a",
+                  "companyId": "company-a",
+                  "kind": "risk",
+                  "title": "Company A signal",
+                  "detail": "stale response",
+                  "severity": "warning",
+                  "confidence": 0.9,
+                  "source": "test",
+                  "dedupeKey": "signal-a",
+                  "status": "OPEN",
+                  "goalId": null,
+                  "issueId": null,
+                  "reviewQueueItemId": null,
+                  "runId": null,
+                  "triageGoalId": null,
+                  "cooldownUntil": null,
+                  "firstSeenAt": 1,
+                  "lastSeenAt": 1,
+                  "updatedAt": 1
+                }]
+                """
+            default:
+                body = "{}"
+            }
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(body.utf8))
+        }
+        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        let store = DesktopStore(
+            api: DesktopAPI(
+                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                token: nil,
+                session: session
+            )
+        )
+        store.dashboard = scopedSelectionDashboard()
+        store.selectedCompanyID = "company-a"
+
+        let githubStatusTask = Task { await store.refreshSelectedCompanyGitHubStatus() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        store.selectedCompanyID = "company-b"
+        await githubStatusTask.value
+
+        #expect(store.selectedCompanyGitHubStatus == nil)
+        #expect(store.companyGitHubStatusMessage == nil)
+
+        await store.refreshCompanyReports(companyId: "company-a")
+        #expect(store.companyReports.isEmpty)
+        #expect(store.selectedCompanyReportDate == nil)
+        #expect(store.selectedCompanyReport == nil)
+
+        await store.refreshCompanyProblemSignals(companyId: "company-a")
+        #expect(store.companyProblemSignals.isEmpty)
+    }
+
+    @Test
     func selectedIssueTaskAndMetricsStayScopedToSelectedCompany() {
         let store = DesktopStore()
         store.dashboard = scopedSelectionDashboard()
@@ -1275,4 +1384,32 @@ struct DesktopStoreTests {
             dangerous: false
         )
     }
+}
+
+final class DesktopStoreCapturingURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            let (response, data) = try Self.requestHandler?(request) ?? {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+                return (response, Data())
+            }()
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
@@ -275,6 +275,35 @@ struct ModelsTests {
     }
 
     @Test
+    func desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopAPICapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        var capturedPath: String?
+        DesktopAPICapturingURLProtocol.requestHandler = { request in
+            capturedPath = request.url?.path
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"ok":true}"#.utf8))
+        }
+        defer { DesktopAPICapturingURLProtocol.requestHandler = nil }
+        let api = DesktopAPI(
+            baseURL: try #require(URL(string: "http://127.0.0.1:8787/prefix")),
+            token: nil,
+            session: session
+        )
+
+        let ok = try await api.health()
+
+        #expect(ok)
+        #expect(capturedPath == "/prefix/api/app/health")
+    }
+
+    @Test
     func desktopSettingsDecodesMissingAgentModelFieldsAsEmpty() throws {
         let encoded = try JSONEncoder().encode(DashboardPayload.empty.settings)
         var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
@@ -556,4 +585,32 @@ struct ModelsTests {
         #expect(decoded.specialties == ["qa", "review"])
         #expect(decoded.enabled == false)
     }
+}
+
+final class DesktopAPICapturingURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            let (response, data) = try Self.requestHandler?(request) ?? {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+                return (response, Data())
+            }()
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -1854,11 +1854,14 @@ internal fun Application.cotorAppModule(
 
                     patch("/{pipelineId}") {
                         if (!requireToken(token)) return@patch
+                        val companyId = call.parameters["companyId"]
+                            ?: return@patch call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
                         val pipelineId = call.parameters["pipelineId"]
                             ?: return@patch call.respond(HttpStatusCode.BadRequest, mapOf("error" to "pipelineId is required"))
                         val request = call.receive<UpdatePipelineRequest>()
                         respondDesktopRequest {
                             desktopService.updatePipeline(
+                                companyId = companyId,
                                 pipelineId = pipelineId,
                                 name = request.name,
                                 stages = request.stages?.mapIndexed { idx, s ->
@@ -1880,9 +1883,11 @@ internal fun Application.cotorAppModule(
 
                     delete("/{pipelineId}") {
                         if (!requireToken(token)) return@delete
+                        val companyId = call.parameters["companyId"]
+                            ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
                         val pipelineId = call.parameters["pipelineId"]
                             ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "pipelineId is required"))
-                        respondDesktopRequest { desktopService.deletePipeline(pipelineId) }
+                        respondDesktopRequest { desktopService.deletePipeline(companyId, pipelineId) }
                     }
 
                     post("/{pipelineId}/set-default") {
@@ -1926,10 +1931,14 @@ internal fun Application.cotorAppModule(
 
                     delete("/{entryId}") {
                         if (!requireToken(token)) return@delete
+                        val companyId = call.parameters["companyId"]
+                            ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
                         val entryId = call.parameters["entryId"]
                             ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "entryId is required"))
-                        desktopService.deleteContextEntry(entryId)
-                        call.respond(HttpStatusCode.OK, mapOf("deleted" to entryId))
+                        respondDesktopRequest {
+                            desktopService.deleteContextEntry(companyId, entryId)
+                            mapOf("deleted" to entryId)
+                        }
                     }
                 }
 

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -5037,12 +5037,13 @@ class DesktopAppService(
     }
 
     suspend fun updatePipeline(
+        companyId: String,
         pipelineId: String,
         name: String? = null,
         stages: List<WorkflowStageDefinition>? = null
     ): WorkflowPipelineDefinition = stateMutex.withLock {
         val state = stateStore.load()
-        val current = state.workflowPipelines.firstOrNull { it.id == pipelineId }
+        val current = state.workflowPipelines.firstOrNull { it.id == pipelineId && it.companyId == companyId }
             ?: throw IllegalArgumentException("Pipeline not found: $pipelineId")
         val now = System.currentTimeMillis()
         val updated = current.copy(
@@ -5056,9 +5057,9 @@ class DesktopAppService(
         updated
     }
 
-    suspend fun deletePipeline(pipelineId: String): WorkflowPipelineDefinition = stateMutex.withLock {
+    suspend fun deletePipeline(companyId: String, pipelineId: String): WorkflowPipelineDefinition = stateMutex.withLock {
         val state = stateStore.load()
-        val pipeline = state.workflowPipelines.firstOrNull { it.id == pipelineId }
+        val pipeline = state.workflowPipelines.firstOrNull { it.id == pipelineId && it.companyId == companyId }
             ?: throw IllegalArgumentException("Pipeline not found: $pipelineId")
         require(!pipeline.isDefault) { "Cannot delete the default pipeline" }
         stateStore.save(
@@ -5133,6 +5134,13 @@ class DesktopAppService(
     suspend fun deleteContextEntry(entryId: String) = stateMutex.withLock {
         val state = stateStore.load()
         stateStore.save(state.copy(agentContextEntries = state.agentContextEntries.filterNot { it.id == entryId }).withDerivedMetrics())
+    }
+
+    suspend fun deleteContextEntry(companyId: String, entryId: String) = stateMutex.withLock {
+        val state = stateStore.load()
+        val entry = state.agentContextEntries.firstOrNull { it.id == entryId && it.companyId == companyId }
+            ?: throw IllegalArgumentException("Context entry not found: $entryId")
+        stateStore.save(state.copy(agentContextEntries = state.agentContextEntries.filterNot { it.id == entry.id }).withDerivedMetrics())
     }
 
     suspend fun ingestAgentNote(
@@ -9494,14 +9502,21 @@ class DesktopAppService(
             subject = ceoActionSubject,
             approval = "ceo-review-queue"
         )
-        if (approvedMetadata.mergeability.equals("DIRTY", ignoreCase = true)) {
+        if (checksFailing(approvedMetadata.checksSummary)) {
+            return markReviewQueueFailedChecks(itemId, approvedMetadata)
+        }
+        val approvedPullRequestState = approvedMetadata.pullRequestState.orEmpty()
+        val approvedMergeability = approvedMetadata.mergeability.orEmpty()
+        if (!approvedPullRequestState.equals("OPEN", ignoreCase = true) ||
+            !approvedMergeability.equals("CLEAN", ignoreCase = true)
+        ) {
             return markReviewQueueMergeConflict(
                 itemId = itemId,
                 approvedMetadata = approvedMetadata,
                 mergeError = ProcessExecutionException(
                     message = "GH command failed",
                     exitCode = 1,
-                    stdout = "Pull request #$pullRequestNumber is not mergeable because the merge commit cannot be cleanly created.",
+                    stdout = "Pull request #$pullRequestNumber is not ready to merge. state=${approvedMetadata.pullRequestState ?: "UNKNOWN"}, mergeability=${approvedMetadata.mergeability ?: "UNKNOWN"}.",
                     stderr = ""
                 )
             )
@@ -9952,6 +9967,88 @@ class DesktopAppService(
             mirrorIssueToLinear(
                 executionIssue.id,
                 comment = "Cotor could not merge \"${executionIssue.title}\" because the pull request no longer merges cleanly: $conflictMessage"
+            )
+        }
+        return updatedItem
+    }
+
+    private suspend fun markReviewQueueFailedChecks(
+        itemId: String,
+        approvedMetadata: PublishMetadata
+    ): ReviewQueueItem {
+        val checksMessage = approvedMetadata.checksSummary
+            ?.takeIf { it.isNotBlank() }
+            ?: "Pull request checks failed."
+        val updatedItem = stateMutex.withLock {
+            val state = stateStore.load()
+            val currentItem = state.reviewQueue.firstOrNull { it.id == itemId }
+                ?: throw IllegalArgumentException("Review queue item not found: $itemId")
+            val executionIssue = state.issues.firstOrNull { it.id == currentItem.issueId }
+            val approvalIssue = currentItem.approvalIssueId?.let { approvalIssueId ->
+                state.issues.firstOrNull { it.id == approvalIssueId }
+            }
+            val now = System.currentTimeMillis()
+            val nextItem = currentItem.copy(
+                status = ReviewQueueStatus.FAILED_CHECKS,
+                pullRequestNumber = approvedMetadata.pullRequestNumber ?: currentItem.pullRequestNumber,
+                pullRequestUrl = approvedMetadata.pullRequestUrl ?: currentItem.pullRequestUrl,
+                pullRequestState = approvedMetadata.pullRequestState ?: currentItem.pullRequestState,
+                mergeability = approvedMetadata.mergeability ?: currentItem.mergeability,
+                checksSummary = approvedMetadata.checksSummary ?: currentItem.checksSummary,
+                ceoVerdict = currentItem.ceoVerdict ?: "APPROVE",
+                ceoReviewedAt = currentItem.ceoReviewedAt ?: now,
+                providerBlockReason = checksMessage,
+                updatedAt = now
+            )
+            val nextIssues = state.issues.map { issue ->
+                when (issue.id) {
+                    executionIssue?.id -> issue.copy(
+                        status = IssueStatus.BLOCKED,
+                        pullRequestNumber = nextItem.pullRequestNumber ?: issue.pullRequestNumber,
+                        pullRequestUrl = nextItem.pullRequestUrl ?: issue.pullRequestUrl,
+                        pullRequestState = nextItem.pullRequestState ?: issue.pullRequestState,
+                        providerBlockReason = checksMessage,
+                        transitionReason = "CEO merge blocked because pull request checks failed.",
+                        updatedAt = now
+                    )
+                    approvalIssue?.id -> issue.copy(
+                        status = IssueStatus.BLOCKED,
+                        providerBlockReason = checksMessage,
+                        transitionReason = "CEO merge is waiting for pull request checks to pass.",
+                        updatedAt = now
+                    )
+                    else -> issue
+                }
+            }
+            val nextState = state.copy(
+                reviewQueue = state.reviewQueue.map { if (it.id == itemId) nextItem else it },
+                issues = nextIssues
+            ).recordCompanyActivity(
+                companyId = executionIssue?.companyId ?: currentItem.companyId,
+                projectContextId = executionIssue?.projectContextId ?: currentItem.projectContextId,
+                goalId = executionIssue?.goalId,
+                issueId = executionIssue?.id ?: currentItem.issueId,
+                source = "review-queue",
+                title = "Pull request checks failed",
+                detail = checksMessage,
+                severity = "warning"
+            ).recordSignal(
+                source = "review-queue",
+                message = "PR ${nextItem.pullRequestUrl ?: nextItem.pullRequestNumber} cannot merge until checks pass: $checksMessage",
+                companyId = executionIssue?.companyId ?: currentItem.companyId,
+                projectContextId = executionIssue?.projectContextId ?: currentItem.projectContextId,
+                goalId = executionIssue?.goalId,
+                issueId = executionIssue?.id ?: currentItem.issueId,
+                severity = "warning"
+            ).withDerivedMetrics()
+            stateStore.save(nextState)
+            nextItem
+        }
+        val executionIssue = stateStore.load().issues.firstOrNull { it.id == updatedItem.issueId }
+        if (executionIssue != null) {
+            mirrorIssueToLinear(
+                executionIssue.id,
+                comment = "Cotor paused merge for \"${executionIssue.title}\" because pull request checks failed: $checksMessage"
             )
         }
         return updatedItem

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -10,6 +10,7 @@ package com.cotor.app
  * goals, issues, tasks, runs, and long-lived company runtime loops.
  */
 
+import com.cotor.app.runtime.CompanyIssueReadiness
 import com.cotor.app.runtime.CompanyRuntimeBindingService
 import com.cotor.app.runtime.CompanyRuntimeLoopDisposition
 import com.cotor.app.runtime.CompanyRuntimeLoopFailureDisposition
@@ -9177,48 +9178,11 @@ class DesktopAppService(
             blockedIssue
         }
 
-    private fun isDependencySatisfied(
-        issue: CompanyIssue,
-        dependency: CompanyIssue,
-        state: DesktopAppState
-    ): Boolean {
-        if (isSupersededCanceledDependency(dependency, state)) {
-            return true
-        }
-        return when (issue.kind.lowercase()) {
-            "review" ->
-                dependency.status == IssueStatus.IN_REVIEW ||
-                    dependency.status == IssueStatus.READY_FOR_CEO ||
-                    dependency.status == IssueStatus.DONE
-            else -> dependency.status == IssueStatus.DONE
-        }
-    }
-
     private fun runnableIssueStatusRank(status: IssueStatus): Int = when (status) {
         IssueStatus.DELEGATED -> 0
         IssueStatus.PLANNED -> 1
         IssueStatus.BACKLOG -> 2
         else -> 3
-    }
-
-    private fun isSupersededCanceledDependency(
-        dependency: CompanyIssue,
-        state: DesktopAppState
-    ): Boolean {
-        if (dependency.status != IssueStatus.CANCELED) {
-            return false
-        }
-        val latestSuccessfulReplacement = state.issues
-            .asSequence()
-            .filter { candidate ->
-                candidate.companyId == dependency.companyId &&
-                    candidate.id != dependency.id &&
-                    candidate.status == IssueStatus.DONE &&
-                    candidate.kind.equals(dependency.kind, ignoreCase = true) &&
-                    candidate.title.trim().equals(dependency.title.trim(), ignoreCase = true)
-            }
-            .maxOfOrNull { it.updatedAt }
-        return latestSuccessfulReplacement != null && latestSuccessfulReplacement > dependency.updatedAt
     }
 
     private data class StructuredVerdict(
@@ -10475,15 +10439,7 @@ class DesktopAppService(
                 .filter { issue ->
                     issue.goalId in activeGoalIds
                 }
-                .filter { issue -> issue.runtimeDisposition == "RUNNABLE" }
-                .filter { issue ->
-                    issue.status in setOf(
-                        IssueStatus.PLANNED,
-                        IssueStatus.BACKLOG,
-                        IssueStatus.DELEGATED,
-                        IssueStatus.IN_PROGRESS
-                    )
-                }
+                .filter { issue -> CompanyIssueReadiness.isRuntimeStartCandidate(issue, executionSnapshot) }
                 .filterNot { issue ->
                     issue.sourceSignal == "github-readiness"
                 }
@@ -10603,11 +10559,7 @@ class DesktopAppService(
         tickStartedAt: Long,
         autonomousGoalIds: Set<String>
     ): String? {
-        val dependenciesSatisfied = issue.dependsOn.all { dependencyId ->
-            val dependency = state.issues.firstOrNull { it.id == dependencyId } ?: return "waiting-dependency"
-            isDependencySatisfied(issue, dependency, state)
-        }
-        if (!dependenciesSatisfied) return "waiting-dependency"
+        if (!CompanyIssueReadiness.dependenciesSatisfied(issue, state)) return "waiting-dependency"
         val alreadyStarted = state.tasks.any { task ->
             task.issueId == issue.id &&
                 (task.status == DesktopTaskStatus.RUNNING || task.status == DesktopTaskStatus.QUEUED)

--- a/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
+++ b/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
@@ -498,8 +498,9 @@ class GitWorkspaceService(
             }
         ) {
             try {
-                if (hasUncommittedChanges(worktreePath)) {
-                    runGit(worktreePath, "add", "-A")
+                val publishablePaths = publishableChangedPaths(worktreePath)
+                if (publishablePaths.isNotEmpty()) {
+                    runGit(worktreePath, "add", "-A", "--", *publishablePaths.toTypedArray())
                     runGit(worktreePath, "commit", "-m", buildCommitMessage(task.title, agentName))
                 }
 
@@ -1573,6 +1574,43 @@ class GitWorkspaceService(
             .all(::isBenignCotorArtifact)
     }
 
+    private suspend fun publishableChangedPaths(worktreePath: Path): List<String> {
+        val statusResult = runGit(
+            worktreePath,
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+            failOnError = false,
+            timeoutMs = 10_000
+        )
+        if (!statusResult.isSuccess) {
+            return emptyList()
+        }
+        return parsePorcelainStatusPaths(statusResult.stdout)
+            .filterNot(::isLocalOrGeneratedArtifactPath)
+            .distinct()
+    }
+
+    private fun parsePorcelainStatusPaths(stdout: String): List<String> {
+        val tokens = stdout.split('\u0000').filter { it.isNotBlank() }
+        val paths = mutableListOf<String>()
+        var index = 0
+        while (index < tokens.size) {
+            val token = tokens[index]
+            if (token.length >= 4) {
+                val status = token.take(2)
+                paths += token.drop(3)
+                if (status.any { it == 'R' || it == 'C' }) {
+                    tokens.getOrNull(index + 1)?.let(paths::add)
+                    index += 1
+                }
+            }
+            index += 1
+        }
+        return paths
+    }
+
     private fun isBenignCotorArtifact(statusLine: String): Boolean {
         if (statusLine.length < 4) {
             return false
@@ -1582,11 +1620,40 @@ class GitWorkspaceService(
         if (status != "??") {
             return false
         }
-        return path == ".cotor" ||
-            path.startsWith(".cotor/") ||
+        return isLocalOrGeneratedArtifactPath(path)
+    }
+
+    private fun isLocalOrGeneratedArtifactPath(rawPath: String): Boolean {
+        val path = rawPath.removePrefix("./")
+        val firstSegment = path.substringBefore('/')
+        return path == ".DS_Store" ||
+            path == ".env" ||
+            path.startsWith(".env.") ||
             path == "cotor.log" ||
+            path == "firebase-debug.log" ||
+            path == "local.properties" ||
+            path == "cotor.yaml" ||
             path.matches(Regex("""cotor\.\d{4}-\d{2}-\d{2}\.\d+\.log""")) ||
-            path == ".DS_Store"
+            firstSegment in setOf(
+                ".cotor",
+                ".omx",
+                ".claude",
+                ".codex",
+                ".gradle",
+                ".idea",
+                ".kiro",
+                ".omc",
+                ".playwright-mcp",
+                ".sisyphus",
+                ".vscode",
+                "build",
+                "dist",
+                "graphify-out",
+                "qa-artifacts",
+                "test-results"
+            ) ||
+            path.startsWith("macos/.build/") ||
+            path.startsWith("Path(child of ")
     }
 
     private suspend fun repositoryCommonRoot(worktreePath: Path): Path {

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadiness.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadiness.kt
@@ -63,9 +63,11 @@ object CompanyIssueReadiness {
         }
 
     private fun dependencyIds(issue: CompanyIssue, state: DesktopAppState): Set<String> =
-        (issue.dependsOn + state.issueDependencies
-            .filter { it.issueId == issue.id }
-            .map { it.dependsOnIssueId })
+        (
+            issue.dependsOn + state.issueDependencies
+                .filter { it.issueId == issue.id }
+                .map { it.dependsOnIssueId }
+            )
             .filter { it.isNotBlank() }
             .toSet()
 

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadiness.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadiness.kt
@@ -1,0 +1,108 @@
+package com.cotor.app.runtime
+
+import com.cotor.app.CompanyIssue
+import com.cotor.app.DesktopAppState
+import com.cotor.app.IssueStatus
+import com.cotor.runtime.durable.DurableRunStatus
+
+object CompanyIssueReadiness {
+    const val RUNNABLE = "RUNNABLE"
+    const val ACTIVE = "ACTIVE"
+    const val WAITING_FOR_APPROVAL = "WAITING_FOR_APPROVAL"
+    const val WAITING_FOR_CI = "WAITING_FOR_CI"
+    const val WAITING_FOR_DEPENDENCY = "WAITING_FOR_DEPENDENCY"
+    const val QUARANTINED = "QUARANTINED"
+    const val RECOVERABLE = "RECOVERABLE"
+    const val TERMINAL = "TERMINAL"
+
+    private val startableStatuses = setOf(IssueStatus.BACKLOG, IssueStatus.PLANNED, IssueStatus.DELEGATED)
+    private val runtimeActiveStatuses = startableStatuses + IssueStatus.IN_PROGRESS
+
+    fun runtimeDisposition(
+        issue: CompanyIssue,
+        state: DesktopAppState,
+        pullRequestChecksSummary: String?,
+        matchingRunStatus: DurableRunStatus?,
+        hasPendingApprovalPause: Boolean,
+        hasActiveTask: Boolean = false
+    ): String = when {
+        matchingRunStatus == DurableRunStatus.WAITING_FOR_APPROVAL || hasPendingApprovalPause ->
+            WAITING_FOR_APPROVAL
+        issue.status == IssueStatus.WAITING_FOR_APPROVAL ->
+            WAITING_FOR_APPROVAL
+        pullRequestChecksSummary?.contains("FAILURE", ignoreCase = true) == true ->
+            WAITING_FOR_CI
+        matchingRunStatus == DurableRunStatus.FAILED && issue.status == IssueStatus.BLOCKED ->
+            QUARANTINED
+        issue.status == IssueStatus.BLOCKED && !issue.providerBlockReason.isNullOrBlank() ->
+            QUARANTINED
+        issue.status == IssueStatus.BLOCKED &&
+            (pullRequestChecksSummary?.contains("SUCCESS", ignoreCase = true) == true) ->
+            RECOVERABLE
+        issue.status in startableStatuses && !dependenciesSatisfied(issue, state) ->
+            WAITING_FOR_DEPENDENCY
+        issue.status == IssueStatus.IN_PROGRESS && hasActiveTask ->
+            ACTIVE
+        issue.status in runtimeActiveStatuses ->
+            RUNNABLE
+        issue.status in setOf(IssueStatus.DONE, IssueStatus.CANCELED) ->
+            TERMINAL
+        else ->
+            TERMINAL
+    }
+
+    fun isRuntimeStartCandidate(issue: CompanyIssue, state: DesktopAppState): Boolean =
+        issue.runtimeDisposition == RUNNABLE &&
+            issue.status in runtimeActiveStatuses &&
+            dependenciesSatisfied(issue, state)
+
+    fun dependenciesSatisfied(issue: CompanyIssue, state: DesktopAppState): Boolean =
+        dependencyIds(issue, state).all { dependencyId ->
+            val dependency = state.issues.firstOrNull { it.id == dependencyId } ?: return@all false
+            isDependencySatisfied(issue, dependency, state)
+        }
+
+    private fun dependencyIds(issue: CompanyIssue, state: DesktopAppState): Set<String> =
+        (issue.dependsOn + state.issueDependencies
+            .filter { it.issueId == issue.id }
+            .map { it.dependsOnIssueId })
+            .filter { it.isNotBlank() }
+            .toSet()
+
+    fun isDependencySatisfied(
+        issue: CompanyIssue,
+        dependency: CompanyIssue,
+        state: DesktopAppState
+    ): Boolean {
+        if (isSupersededCanceledDependency(dependency, state)) {
+            return true
+        }
+        return when (issue.kind.lowercase()) {
+            "review" ->
+                dependency.status == IssueStatus.IN_REVIEW ||
+                    dependency.status == IssueStatus.READY_FOR_CEO ||
+                    dependency.status == IssueStatus.DONE
+            else -> dependency.status == IssueStatus.DONE
+        }
+    }
+
+    private fun isSupersededCanceledDependency(
+        dependency: CompanyIssue,
+        state: DesktopAppState
+    ): Boolean {
+        if (dependency.status != IssueStatus.CANCELED) {
+            return false
+        }
+        val latestSuccessfulReplacement = state.issues
+            .asSequence()
+            .filter { candidate ->
+                candidate.companyId == dependency.companyId &&
+                    candidate.id != dependency.id &&
+                    candidate.status == IssueStatus.DONE &&
+                    candidate.kind.equals(dependency.kind, ignoreCase = true) &&
+                    candidate.title.trim().equals(dependency.title.trim(), ignoreCase = true)
+            }
+            .maxOfOrNull { it.updatedAt }
+        return latestSuccessfulReplacement != null && latestSuccessfulReplacement > dependency.updatedAt
+    }
+}

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
@@ -4,7 +4,6 @@ import com.cotor.app.CompanyIssue
 import com.cotor.app.CompanyRuntimeSnapshot
 import com.cotor.app.DesktopAppState
 import com.cotor.app.DesktopTaskStatus
-import com.cotor.app.IssueStatus
 import com.cotor.app.ReviewQueueItem
 import com.cotor.policy.PolicyEngine
 import com.cotor.providers.github.GitHubControlPlaneService
@@ -25,16 +24,6 @@ class CompanyRuntimeBindingService(
     private val policyEngine: PolicyEngine = PolicyEngine(),
     private val gitHubControlPlaneService: GitHubControlPlaneService = GitHubControlPlaneService()
 ) {
-    companion object {
-        private const val RUNNABLE = "RUNNABLE"
-        private const val ACTIVE = "ACTIVE"
-        private const val WAITING_FOR_APPROVAL = "WAITING_FOR_APPROVAL"
-        private const val WAITING_FOR_CI = "WAITING_FOR_CI"
-        private const val QUARANTINED = "QUARANTINED"
-        private const val RECOVERABLE = "RECOVERABLE"
-        private const val TERMINAL = "TERMINAL"
-    }
-
     fun bind(state: DesktopAppState, companyId: String, runtime: CompanyRuntimeSnapshot): BoundCompanyRuntime {
         val boundRunIds = state.issues
             .filter { it.companyId == companyId }
@@ -111,33 +100,14 @@ class CompanyRuntimeBindingService(
                 val matchingRun = runs.firstOrNull { run ->
                     run.runId == issue.durableRunId || run.pipelineName == issue.pipelineId
                 }
-                val runtimeDisposition = when {
-                    matchingRun?.status == DurableRunStatus.WAITING_FOR_APPROVAL || matchingRun?.approvalPauses?.any { it.status.name == "PENDING" } == true ->
-                        WAITING_FOR_APPROVAL
-                    issue.status == IssueStatus.WAITING_FOR_APPROVAL ->
-                        WAITING_FOR_APPROVAL
-                    issuePullRequest?.checksSummary?.contains("FAILURE", ignoreCase = true) == true ->
-                        WAITING_FOR_CI
-                    matchingRun?.status == DurableRunStatus.FAILED && issue.status == IssueStatus.BLOCKED ->
-                        QUARANTINED
-                    issue.status == IssueStatus.BLOCKED && !issue.providerBlockReason.isNullOrBlank() ->
-                        QUARANTINED
-                    issue.status == IssueStatus.BLOCKED &&
-                        (issuePullRequest?.checksSummary?.contains("SUCCESS", ignoreCase = true) == true) ->
-                        RECOVERABLE
-                    issue.status in setOf(
-                        IssueStatus.PLANNED,
-                        IssueStatus.BACKLOG,
-                        IssueStatus.DELEGATED
-                    ) -> RUNNABLE
-                    issue.status == IssueStatus.IN_PROGRESS && issue.id in activeIssueIds ->
-                        ACTIVE
-                    issue.status == IssueStatus.IN_PROGRESS ->
-                        RUNNABLE
-                    issue.status in setOf(IssueStatus.DONE, IssueStatus.CANCELED) ->
-                        TERMINAL
-                    else -> TERMINAL
-                }
+                val runtimeDisposition = CompanyIssueReadiness.runtimeDisposition(
+                    issue = issue,
+                    state = state,
+                    pullRequestChecksSummary = issuePullRequest?.checksSummary,
+                    matchingRunStatus = matchingRun?.status,
+                    hasPendingApprovalPause = matchingRun?.approvalPauses?.any { it.status.name == "PENDING" } == true,
+                    hasActiveTask = issue.id in activeIssueIds
+                )
                 issue.copy(
                     durableRunId = matchingRun?.runId ?: issue.durableRunId,
                     approvalPauseId = matchingRun?.approvalPauses?.firstOrNull { it.status.name == "PENDING" }?.id ?: issue.approvalPauseId,
@@ -157,16 +127,16 @@ class CompanyRuntimeBindingService(
             } else {
                 val snapshot = item.pullRequestNumber?.let(providerBlockByPr::get)
                 val runtimeDisposition = when {
-                    item.approvalPauseId != null -> WAITING_FOR_APPROVAL
-                    snapshot?.checksSummary?.contains("FAILURE", ignoreCase = true) == true -> WAITING_FOR_CI
-                    item.status == com.cotor.app.ReviewQueueStatus.FAILED_CHECKS -> RECOVERABLE
+                    item.approvalPauseId != null -> CompanyIssueReadiness.WAITING_FOR_APPROVAL
+                    snapshot?.checksSummary?.contains("FAILURE", ignoreCase = true) == true -> CompanyIssueReadiness.WAITING_FOR_CI
+                    item.status == com.cotor.app.ReviewQueueStatus.FAILED_CHECKS -> CompanyIssueReadiness.RECOVERABLE
                     item.status in setOf(
                         com.cotor.app.ReviewQueueStatus.AWAITING_QA,
                         com.cotor.app.ReviewQueueStatus.READY_FOR_CEO,
                         com.cotor.app.ReviewQueueStatus.READY_TO_MERGE
-                    ) -> RUNNABLE
-                    item.status == com.cotor.app.ReviewQueueStatus.MERGED -> TERMINAL
-                    else -> TERMINAL
+                    ) -> CompanyIssueReadiness.RUNNABLE
+                    item.status == com.cotor.app.ReviewQueueStatus.MERGED -> CompanyIssueReadiness.TERMINAL
+                    else -> CompanyIssueReadiness.TERMINAL
                 }
                 item.copy(
                     approvalPauseId = boundIssues.firstOrNull { it.id == item.issueId }?.approvalPauseId ?: item.approvalPauseId,
@@ -175,15 +145,23 @@ class CompanyRuntimeBindingService(
                 )
             }
         }
-        val pendingIssueIds = boundIssues.filter { it.runtimeDisposition == RUNNABLE }.map { it.id }
+        val pendingIssueIds = boundIssues.filter { it.runtimeDisposition == CompanyIssueReadiness.RUNNABLE }.map { it.id }
         val pendingApprovalIssueIds = boundIssues
-            .filter { it.runtimeDisposition == WAITING_FOR_APPROVAL && it.durableRunId !in pendingApprovalRunIds }
+            .filter { it.runtimeDisposition == CompanyIssueReadiness.WAITING_FOR_APPROVAL && it.durableRunId !in pendingApprovalRunIds }
             .map { it.id }
         val blockedIssueIds = boundIssues.filter {
-            it.runtimeDisposition in setOf(WAITING_FOR_CI, QUARANTINED)
+            it.runtimeDisposition in setOf(
+                CompanyIssueReadiness.WAITING_FOR_CI,
+                CompanyIssueReadiness.WAITING_FOR_DEPENDENCY,
+                CompanyIssueReadiness.QUARANTINED
+            )
         }.map { it.id }
         val reviewQueueAttentionIds = boundQueue.filter {
-            it.runtimeDisposition in setOf(WAITING_FOR_APPROVAL, WAITING_FOR_CI, RECOVERABLE)
+            it.runtimeDisposition in setOf(
+                CompanyIssueReadiness.WAITING_FOR_APPROVAL,
+                CompanyIssueReadiness.WAITING_FOR_CI,
+                CompanyIssueReadiness.RECOVERABLE
+            )
         }.map { it.id }
         return BoundCompanyRuntime(
             runtime = runtime.copy(

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -8,6 +8,7 @@ package com.cotor.data.plugin
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
+import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.process.ProcessManager
 import com.cotor.model.*
 import com.cotor.model.OpenCodeDefaults
@@ -27,7 +28,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import java.net.URI
-import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Files
@@ -507,7 +507,7 @@ class LocalModelPlugin : AgentPlugin {
     )
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val client = HttpClient.newBuilder().build()
+    private val client = CotorHttpClients.newClient()
 
     override suspend fun execute(
         context: ExecutionContext,
@@ -723,7 +723,7 @@ class OpenCodePlugin : AgentPlugin {
     )
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val httpClient = HttpClient.newBuilder().build()
+    private val httpClient = CotorHttpClients.newClient()
 
     override suspend fun execute(
         context: ExecutionContext,

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -193,18 +193,40 @@ class CoroutineProcessManager(
             logger.warn("Process timeout, destroying process")
             // Force-kill on timeout because some developer tools spawn interactive shells
             // that ignore polite termination and would otherwise leak in the background.
-            process.destroyForcibly()
+            destroyProcessTree(process, logger)
             joinReader(stdoutThread)
             joinReader(stderrThread)
             throw e
         } catch (e: Exception) {
             logger.error("Process execution failed", e)
-            process.destroyForcibly()
+            destroyProcessTree(process, logger)
             joinReader(stdoutThread)
             joinReader(stderrThread)
             throw e
         }
     }
+}
+
+private fun destroyProcessTree(process: Process, logger: Logger) {
+    val descendants = process.toHandle()
+        .descendants()
+        .toArray()
+        .filterIsInstance<ProcessHandle>()
+        .asReversed()
+    descendants.forEach { handle ->
+        if (handle.isAlive) {
+            runCatching { handle.destroyForcibly() }
+                .onFailure { logger.debug("Failed to destroy descendant process ${handle.pid()}", it) }
+        }
+    }
+    if (process.isAlive) {
+        runCatching { process.destroyForcibly() }
+            .onFailure { logger.debug("Failed to destroy process ${process.pid()}", it) }
+    }
+    descendants.forEach { handle ->
+        runCatching { handle.onExit().get(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+    }
+    runCatching { process.waitFor(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
 }
 
 private fun redactedCommandForLogs(command: List<String>): String {
@@ -224,6 +246,7 @@ private fun joinReader(thread: Thread) {
 }
 
 private const val READER_JOIN_TIMEOUT_MS = 250L
+private const val PROCESS_TREE_JOIN_TIMEOUT_MS = 500L
 
 private fun buildEffectivePath(
     inheritedPath: String?,

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceOwnershipTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceOwnershipTest.kt
@@ -1,0 +1,98 @@
+package com.cotor.app
+
+import com.cotor.data.config.ConfigRepository
+import com.cotor.domain.executor.AgentExecutor
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import java.nio.file.Files
+
+class DesktopAppServiceOwnershipTest : FunSpec({
+    afterTest {
+        DesktopAppService.shutdownAllForTesting()
+    }
+
+    test("updatePipeline rejects cross-company ids without changing state") {
+        val appHome = Files.createTempDirectory("desktop-ownership-pipeline")
+        val stateStore = DesktopStateStore { appHome }
+        val pipeline = WorkflowPipelineDefinition(
+            id = "pipeline-a",
+            companyId = "company-a",
+            name = "Company A pipeline",
+            stages = listOf(
+                WorkflowStageDefinition(
+                    id = "stage-a",
+                    kind = "execution",
+                    title = "Execute",
+                    order = 0
+                )
+            ),
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+        stateStore.save(DesktopAppState(workflowPipelines = listOf(pipeline)))
+        val service = ownershipService(stateStore)
+
+        shouldThrow<IllegalArgumentException> {
+            service.updatePipeline(
+                companyId = "company-b",
+                pipelineId = pipeline.id,
+                name = "Cross-company rewrite"
+            )
+        }
+
+        stateStore.load().workflowPipelines.single() shouldBe pipeline
+    }
+
+    test("deletePipeline rejects cross-company ids without deleting state") {
+        val appHome = Files.createTempDirectory("desktop-ownership-delete-pipeline")
+        val stateStore = DesktopStateStore { appHome }
+        val pipeline = WorkflowPipelineDefinition(
+            id = "pipeline-a",
+            companyId = "company-a",
+            name = "Company A pipeline",
+            stages = emptyList(),
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+        stateStore.save(DesktopAppState(workflowPipelines = listOf(pipeline)))
+        val service = ownershipService(stateStore)
+
+        shouldThrow<IllegalArgumentException> {
+            service.deletePipeline(companyId = "company-b", pipelineId = pipeline.id)
+        }
+
+        stateStore.load().workflowPipelines shouldBe listOf(pipeline)
+    }
+
+    test("deleteContextEntry rejects cross-company ids without deleting state") {
+        val appHome = Files.createTempDirectory("desktop-ownership-context")
+        val stateStore = DesktopStateStore { appHome }
+        val entry = AgentContextEntry(
+            id = "entry-a",
+            companyId = "company-a",
+            agentName = "codex",
+            kind = "note",
+            title = "Company A note",
+            content = "Keep this scoped to company A.",
+            createdAt = 1L
+        )
+        stateStore.save(DesktopAppState(agentContextEntries = listOf(entry)))
+        val service = ownershipService(stateStore)
+
+        shouldThrow<IllegalArgumentException> {
+            service.deleteContextEntry(companyId = "company-b", entryId = entry.id)
+        }
+
+        stateStore.load().agentContextEntries shouldBe listOf(entry)
+    }
+})
+
+private fun ownershipService(stateStore: DesktopStateStore): DesktopAppService =
+    DesktopAppService(
+        stateStore = stateStore,
+        gitWorkspaceService = mockk(relaxed = true),
+        configRepository = mockk<ConfigRepository>(relaxed = true),
+        agentExecutor = mockk<AgentExecutor>(relaxed = true)
+    )

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceReviewVerdictControlTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceReviewVerdictControlTest.kt
@@ -534,6 +534,48 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
         coVerify(exactly = 1) { gitWorkspaceService.mergePullRequest(any(), 88, true, any(), any()) }
     }
 
+    test("mergeReviewQueueItem records failed checks without calling merge") {
+        val fixture = mergeGuardFixture(
+            pullRequestNumber = 91,
+            pullRequestState = "OPEN",
+            mergeability = "CLEAN",
+            checksSummary = "ci=COMPLETED/FAILURE"
+        )
+
+        val updated = fixture.service.mergeReviewQueueItem(fixture.queueItem.id)
+        val refreshedIssue = fixture.stateStore.load().issues.first { it.id == fixture.executionIssue.id }
+
+        updated.status shouldBe ReviewQueueStatus.FAILED_CHECKS
+        updated.providerBlockReason shouldBe "ci=COMPLETED/FAILURE"
+        refreshedIssue.status shouldBe IssueStatus.BLOCKED
+        coVerify(exactly = 0) {
+            fixture.gitWorkspaceService.mergePullRequest(any(), 91, any(), any(), any())
+        }
+    }
+
+    test("mergeReviewQueueItem routes non-clean mergeability to remediation without calling merge") {
+        listOf("UNKNOWN", "BLOCKED", "DIRTY").forEachIndexed { index, mergeability ->
+            val pullRequestNumber = 92 + index
+            val fixture = mergeGuardFixture(
+                pullRequestNumber = pullRequestNumber,
+                pullRequestState = "OPEN",
+                mergeability = mergeability,
+                checksSummary = "ci=COMPLETED/SUCCESS"
+            )
+
+            val updated = fixture.service.mergeReviewQueueItem(fixture.queueItem.id)
+            val refreshedIssue = fixture.stateStore.load().issues.first { it.id == fixture.executionIssue.id }
+
+            updated.status shouldBe ReviewQueueStatus.CHANGES_REQUESTED
+            updated.mergeability shouldBe mergeability
+            refreshedIssue.status shouldBe IssueStatus.PLANNED
+            refreshedIssue.executionIntent shouldBe ExecutionIntent.MERGE_CONFLICT_REMEDIATION
+            coVerify(exactly = 0) {
+                fixture.gitWorkspaceService.mergePullRequest(any(), pullRequestNumber, any(), any(), any())
+            }
+        }
+    }
+
     test("submitQaReviewVerdict rejects a missing review queue item") {
         val appHome = Files.createTempDirectory("desktop-review-verdict-missing-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-review-verdict-missing-repo").resolve("repo"))
@@ -555,3 +597,149 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
         (error is IllegalArgumentException) shouldBe true
     }
 })
+
+private data class MergeGuardFixture(
+    val service: DesktopAppService,
+    val stateStore: DesktopStateStore,
+    val gitWorkspaceService: GitWorkspaceService,
+    val queueItem: ReviewQueueItem,
+    val executionIssue: CompanyIssue
+)
+
+private suspend fun mergeGuardFixture(
+    pullRequestNumber: Int,
+    pullRequestState: String,
+    mergeability: String,
+    checksSummary: String
+): MergeGuardFixture {
+    val appHome = Files.createTempDirectory("desktop-review-merge-guard-home")
+    val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-review-merge-guard-repo").resolve("repo"))
+    val stateStore = DesktopStateStore { appHome }
+    val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+    coEvery { gitWorkspaceService.commentOnPullRequest(any(), any(), any(), any(), any()) } returns Unit
+    coEvery {
+        gitWorkspaceService.submitPullRequestReview(
+            any(),
+            pullRequestNumber,
+            PullRequestReviewVerdict.APPROVE,
+            any(),
+            any(),
+            any()
+        )
+    } returns PublishMetadata(
+        pullRequestNumber = pullRequestNumber,
+        pullRequestUrl = "https://github.com/example/cotor/pull/$pullRequestNumber",
+        pullRequestState = pullRequestState,
+        mergeability = mergeability,
+        checksSummary = checksSummary
+    )
+    val service = DesktopAppService(
+        stateStore = stateStore,
+        gitWorkspaceService = gitWorkspaceService,
+        configRepository = mockk<ConfigRepository>(relaxed = true),
+        agentExecutor = mockk<AgentExecutor>(relaxed = true)
+    )
+    val now = System.currentTimeMillis()
+    val company = Company(
+        id = "company-merge-guard-$pullRequestNumber",
+        name = "Merge Guard Co",
+        rootPath = repoRoot.toString(),
+        repositoryId = "repo-merge-guard-$pullRequestNumber",
+        defaultBaseBranch = "master",
+        createdAt = now,
+        updatedAt = now
+    )
+    val workspace = Workspace(
+        id = "workspace-merge-guard-$pullRequestNumber",
+        repositoryId = company.repositoryId,
+        name = "repo · master",
+        baseBranch = "master",
+        createdAt = now,
+        updatedAt = now
+    )
+    val goal = CompanyGoal(
+        id = "goal-merge-guard-$pullRequestNumber",
+        companyId = company.id,
+        title = "Merge guarded work",
+        description = "Only clean PRs should merge.",
+        status = GoalStatus.ACTIVE,
+        autonomyEnabled = true,
+        createdAt = now,
+        updatedAt = now
+    )
+    val executionIssue = CompanyIssue(
+        id = "issue-merge-guard-$pullRequestNumber",
+        companyId = company.id,
+        goalId = goal.id,
+        workspaceId = workspace.id,
+        title = "Implement guarded feature",
+        description = "Ready for CEO merge.",
+        status = IssueStatus.READY_FOR_CEO,
+        priority = 1,
+        kind = "execution",
+        branchName = "codex/cotor/merge-guard-$pullRequestNumber/codex",
+        worktreePath = repoRoot.resolve(".cotor/worktrees/merge-guard-$pullRequestNumber/codex").toString(),
+        pullRequestNumber = pullRequestNumber,
+        pullRequestUrl = "https://github.com/example/cotor/pull/$pullRequestNumber",
+        pullRequestState = "OPEN",
+        qaVerdict = "PASS",
+        createdAt = now,
+        updatedAt = now
+    )
+    val approvalIssue = CompanyIssue(
+        id = "issue-approval-merge-guard-$pullRequestNumber",
+        companyId = company.id,
+        goalId = goal.id,
+        workspaceId = workspace.id,
+        title = "CEO approve guarded feature",
+        description = "Approve or request changes.",
+        status = IssueStatus.PLANNED,
+        priority = 3,
+        kind = "approval",
+        branchName = executionIssue.branchName,
+        worktreePath = executionIssue.worktreePath,
+        pullRequestNumber = executionIssue.pullRequestNumber,
+        pullRequestUrl = executionIssue.pullRequestUrl,
+        pullRequestState = executionIssue.pullRequestState,
+        qaVerdict = "PASS",
+        sourceSignal = "ceo-approval:${executionIssue.id}",
+        createdAt = now,
+        updatedAt = now
+    )
+    val queueItem = ReviewQueueItem(
+        id = "queue-merge-guard-$pullRequestNumber",
+        companyId = company.id,
+        issueId = executionIssue.id,
+        runId = "run-merge-guard-$pullRequestNumber",
+        branchName = executionIssue.branchName,
+        worktreePath = executionIssue.worktreePath,
+        pullRequestNumber = pullRequestNumber,
+        pullRequestUrl = executionIssue.pullRequestUrl,
+        pullRequestState = executionIssue.pullRequestState,
+        status = ReviewQueueStatus.READY_FOR_CEO,
+        mergeability = "CLEAN",
+        checksSummary = "ci=COMPLETED/SUCCESS",
+        qaVerdict = "PASS",
+        ceoVerdict = "APPROVE",
+        ceoFeedback = "Ship it",
+        approvalIssueId = approvalIssue.id,
+        createdAt = now,
+        updatedAt = now
+    )
+    stateStore.save(
+        DesktopAppState(
+            companies = listOf(company),
+            workspaces = listOf(workspace),
+            goals = listOf(goal),
+            issues = listOf(executionIssue, approvalIssue),
+            reviewQueue = listOf(queueItem)
+        )
+    )
+    return MergeGuardFixture(
+        service = service,
+        stateStore = stateStore,
+        gitWorkspaceService = gitWorkspaceService,
+        queueItem = queueItem,
+        executionIssue = executionIssue
+    )
+}

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
@@ -412,6 +412,86 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         stateStore.load().tasks.filter { it.issueId == issueId }.size shouldBe 1
         coVerify(exactly = 0) { agentExecutor.executeAgent(any(), any(), any()) }
     }
+
+    test("runCompanyRuntimeTick starts backlog issues when dependency edges are complete") {
+        val appHome = Files.createTempDirectory("desktop-runtime-backlog-dependency-home")
+        val repoRoot =
+            Files.createDirectories(Files.createTempDirectory("desktop-runtime-backlog-dependency-repo").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        val companyId = "company-1"
+        val dependencyId = "issue-dependency"
+        val issueId = "issue-backlog-after-dependency"
+        seedRuntimeDispositionWorkspace(stateStore, repoRoot, companyId)
+
+        val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+        coEvery { gitWorkspaceService.ensureWorktree(any(), any(), any(), any(), any()) } returns WorktreeBinding(
+            branchName = "codex/cotor/backlog-after-dependency/opencode",
+            worktreePath = repoRoot.resolve(".cotor/worktrees/backlog-after-dependency/opencode")
+        )
+        coEvery { gitWorkspaceService.publishRun(any(), any(), any(), any(), any(), any(), any()) } returns
+            PublishMetadata()
+
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } coAnswers {
+            delay(500)
+            AgentResult(
+                agentName = "opencode",
+                isSuccess = true,
+                output = "dependency-ready issue finished",
+                error = null,
+                duration = 500,
+                metadata = emptyMap()
+            )
+        }
+
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            agentExecutor = agentExecutor
+        )
+
+        val state = stateStore.load()
+        stateStore.save(
+            state.copy(
+                backendSettings = state.backendSettings.copy(codePublishMode = CodePublishMode.ALLOW_LOCAL_GIT),
+                companies = listOf(runtimeDispositionCompany(companyId, repoRoot)),
+                goals = listOf(runtimeDispositionGoal(companyId, "goal-dependency", autonomyEnabled = true)),
+                issues = listOf(
+                    runtimeDispositionIssue(
+                        companyId = companyId,
+                        issueId = dependencyId,
+                        goalId = "goal-dependency",
+                        status = IssueStatus.DONE
+                    ),
+                    runtimeDispositionIssue(
+                        companyId = companyId,
+                        issueId = issueId,
+                        goalId = "goal-dependency",
+                        status = IssueStatus.BACKLOG
+                    )
+                ),
+                issueDependencies = listOf(
+                    IssueDependency(
+                        id = "edge-dependency-to-backlog",
+                        issueId = issueId,
+                        dependsOnIssueId = dependencyId
+                    )
+                ),
+                companyRuntimes = listOf(
+                    CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+                )
+            )
+        )
+
+        val snapshot = service.runCompanyRuntimeTick(companyId)
+        val refreshed = stateStore.load()
+
+        snapshot.lastAction shouldBe "started:$issueId"
+        refreshed.tasks.shouldNotBeEmpty()
+        refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
+        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+    }
 })
 
 private suspend fun seedRuntimeDispositionWorkspace(

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -2222,7 +2222,7 @@ class DesktopAppServiceTest : FunSpec({
         fixture.service.runTask(task.id)
         fixture.awaitRuns()
 
-        withTimeout(10_000) {
+        withTimeout(90_000) {
             while (true) {
                 val candidate = fixture.stateStore.load().issues.single { it.id == issue.id }
                 val metadataCleared =
@@ -3756,14 +3756,8 @@ class DesktopAppServiceTest : FunSpec({
         )
         val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
 
-        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
-        withTimeout(5_000) {
-            while (stateStore.load().issues.single { it.id == planningIssue.id }.status == IssueStatus.PLANNED) {
-                delay(50)
-            }
-        }
-
-        val state = stateStore.load()
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 90_000)
+        val state = awaitIssueCount(stateStore, goal.id, kind = "execution", expected = 1, timeoutMs = 90_000)
         val executionIssues = state.issues.filter { it.goalId == goal.id && it.kind == "execution" }
         executionIssues shouldHaveSize 1
         executionIssues.single().sourceSignal shouldBe "ceo-planning:${goal.id}"
@@ -3821,14 +3815,8 @@ class DesktopAppServiceTest : FunSpec({
         )
         val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
 
-        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
-        withTimeout(5_000) {
-            while (stateStore.load().issues.single { it.id == planningIssue.id }.status == IssueStatus.PLANNED) {
-                delay(50)
-            }
-        }
-
-        val state = stateStore.load()
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 90_000)
+        val state = awaitIssueCount(stateStore, goal.id, kind = "execution", expected = 1, timeoutMs = 90_000)
         state.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
         state.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE
     }
@@ -13638,10 +13626,11 @@ private suspend fun awaitIssueCount(
     stateStore: DesktopStateStore,
     goalId: String,
     kind: String,
-    expected: Int
+    expected: Int,
+    timeoutMs: Long = 5_000
 ): DesktopAppState {
     var latest = stateStore.load()
-    withTimeout(5_000) {
+    withTimeout(timeoutMs) {
         while (true) {
             val snapshot = stateStore.load()
             latest = snapshot

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -11600,7 +11600,7 @@ class DesktopAppServiceTest : FunSpec({
             pullRequestUrl = "https://github.com/heodongun/cotor-test/pull/22",
             pullRequestState = "OPEN",
             reviewState = "APPROVED",
-            mergeability = "MERGEABLE"
+            mergeability = "CLEAN"
         )
         coEvery {
             gitWorkspaceService.mergePullRequest(any(), 22, true, any(), any())

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -901,7 +901,7 @@ class DesktopAppServiceTest : FunSpec({
 
         val pending = service.runOperatorCommand(
             companyId = company.id,
-            message = "프론트 화면 작업에 필요한 사람 고용해",
+            message = "Hire a frontend specialist for desktop UI work",
             automationMode = OperatorAutomationMode.ASK_ME
         )
         pending.pendingApprovals.single().status shouldBe "USER_CONFIRMATION_REQUIRED"
@@ -911,7 +911,7 @@ class DesktopAppServiceTest : FunSpec({
 
         val confirmed = service.runOperatorCommand(
             companyId = company.id,
-            message = "프론트 화면 작업에 필요한 사람 고용해",
+            message = "Hire a frontend specialist for desktop UI work",
             confirmStaffing = true
         )
         val definitions = service.listCompanyAgentDefinitions(company.id)
@@ -4028,13 +4028,18 @@ class DesktopAppServiceTest : FunSpec({
         )
         val planningIssue = service.listIssues(goal.id).single { it.kind == "planning" }
 
-        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 5_000)
+        service.runIssueAndAwaitSettlement(planningIssue.id, timeoutMs = 90_000)
 
+        withTimeout(90_000) {
+            while (runCount < 2) {
+                delay(25)
+            }
+        }
         runCount shouldBe 2
         prompts.first().orEmpty() shouldContain ".cotor/runtime/ceo-plan.json"
         prompts.last().orEmpty() shouldContain "CEO_PLANNING_REPAIR"
         prompts.last().orEmpty() shouldContain ".cotor/runtime/ceo-plan.json"
-        val state = awaitIssueCount(stateStore, goal.id, kind = "execution", expected = 1)
+        val state = awaitIssueCount(stateStore, goal.id, kind = "execution", expected = 1, timeoutMs = 90_000)
         state.issues.filter { it.goalId == goal.id && it.kind == "execution" } shouldHaveSize 1
         state.issues.single { it.id == planningIssue.id }.status shouldBe IssueStatus.DONE
         state.goalDecisions.last { it.goalId == goal.id }.title shouldBe "CEO planned execution graph"

--- a/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
@@ -1026,8 +1026,16 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-test")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, " M src/App.kt\n", "", true)),
-                FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(
+                    listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"),
+                    ProcessResult(
+                        0,
+                        " M src/App.kt\u0000?? .cotor/runtime/state.json\u0000?? graphify-out/report.md\u0000?? Path(child of #1#2)/graphify-out/report.md\u0000?? cotor.log\u0000",
+                        "",
+                        true
+                    )
+                ),
+                FakeProcessManager.Step(listOf("git", "add", "-A", "--", "src/App.kt"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "commit", "-m", "Ship desktop publish flow (codex)"), ProcessResult(0, "[branch abc1234] Ship desktop publish flow\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),
@@ -1077,7 +1085,7 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-empty")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "0\n", "", true))
             )
@@ -1112,8 +1120,8 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-rebase-conflict")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, " M index.html\n", "", true)),
-                FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, " M index.html\u0000", "", true)),
+                FakeProcessManager.Step(listOf("git", "add", "-A", "--", "index.html"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "commit", "-m", "Retry conflicted publish (codex)"), ProcessResult(0, "[branch abc1234] Retry conflicted publish\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),
@@ -1155,8 +1163,8 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-local-only")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, "?? smoke-artifact.txt\n", "", true)),
-                FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, "?? smoke-artifact.txt\u0000", "", true)),
+                FakeProcessManager.Step(listOf("git", "add", "-A", "--", "smoke-artifact.txt"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "commit", "-m", "Local-only execution (codex)"), ProcessResult(0, "[branch abc1234] Local-only execution\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),
@@ -1193,8 +1201,8 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-no-auto-github")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, " M README.md\n", "", true)),
-                FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, " M README.md\u0000", "", true)),
+                FakeProcessManager.Step(listOf("git", "add", "-A", "--", "README.md"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "commit", "-m", "Do not auto publish to GitHub (codex)"), ProcessResult(0, "[branch abc1234] Do not auto publish to GitHub\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),
@@ -1231,8 +1239,8 @@ class GitWorkspaceServiceTest : FunSpec({
         val worktree = Files.createTempDirectory("git-workspace-service-no-pr")
         val processManager = FakeProcessManager(
             listOf(
-                FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, " M README.md\n", "", true)),
-                FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, " M README.md\u0000", "", true)),
+                FakeProcessManager.Step(listOf("git", "add", "-A", "--", "README.md"), ProcessResult(0, "", "", true)),
                 FakeProcessManager.Step(listOf("git", "commit", "-m", "Publish without PR (codex)"), ProcessResult(0, "[branch abc1234] Publish without PR\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                 FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),
@@ -1279,8 +1287,8 @@ class GitWorkspaceServiceTest : FunSpec({
             markAsGitWorktree(worktree)
             val processManager = FakeProcessManager(
                 listOf(
-                    FakeProcessManager.Step(listOf("git", "status", "--porcelain"), ProcessResult(0, " M src/App.kt\n", "", true)),
-                    FakeProcessManager.Step(listOf("git", "add", "-A"), ProcessResult(0, "", "", true)),
+                    FakeProcessManager.Step(listOf("git", "status", "--porcelain=v1", "-z", "--untracked-files=all"), ProcessResult(0, " M src/App.kt\u0000", "", true)),
+                    FakeProcessManager.Step(listOf("git", "add", "-A", "--", "src/App.kt"), ProcessResult(0, "", "", true)),
                     FakeProcessManager.Step(listOf("git", "commit", "-m", "Ship desktop publish flow (codex)"), ProcessResult(0, "[branch abc1234] Ship desktop publish flow\n", "", true)),
                     FakeProcessManager.Step(listOf("git", "rev-parse", "HEAD"), ProcessResult(0, "abc1234567890\n", "", true)),
                     FakeProcessManager.Step(listOf("git", "rev-list", "--count", "master..HEAD"), ProcessResult(0, "1\n", "", true)),

--- a/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
@@ -8,8 +8,8 @@ import com.cotor.app.CompanyRuntimeStatus
 import com.cotor.app.DesktopAppState
 import com.cotor.app.DesktopTaskStatus
 import com.cotor.app.ExecutionBackendKind
-import com.cotor.app.IssueStatus
 import com.cotor.app.IssueDependency
+import com.cotor.app.IssueStatus
 import com.cotor.app.ReviewQueueItem
 import com.cotor.app.ReviewQueueStatus
 import com.cotor.policy.PolicyEngine

--- a/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
@@ -9,6 +9,7 @@ import com.cotor.app.DesktopAppState
 import com.cotor.app.DesktopTaskStatus
 import com.cotor.app.ExecutionBackendKind
 import com.cotor.app.IssueStatus
+import com.cotor.app.IssueDependency
 import com.cotor.app.ReviewQueueItem
 import com.cotor.app.ReviewQueueStatus
 import com.cotor.policy.PolicyEngine
@@ -33,6 +34,7 @@ import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.runtime.durable.DurableRuntimeStore
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import java.nio.file.Files
 
@@ -374,6 +376,112 @@ class CompanyRuntimeBindingServiceTest : FunSpec({
         bound.issues.single().runtimeDisposition shouldBe "RUNNABLE"
         bound.runtime.pendingIssueIds shouldContain issueId
     }
+
+    test("bind treats backlog issues with completed dependencies as runnable") {
+        val appHome = Files.createTempDirectory("company-runtime-backlog-ready")
+        val companyId = "company-backlog-ready"
+        val dependencyId = "issue-dependency"
+        val issueId = "issue-backlog-ready"
+        val service = CompanyRuntimeBindingService(
+            durableRuntimeService = DurableRuntimeService(runtimeStore = DurableRuntimeStore(appHome.resolve("runtime"))),
+            actionStore = ActionStore { appHome },
+            policyEngine = PolicyEngine(PolicyStore { appHome }),
+            gitHubControlPlaneService = GitHubControlPlaneService(store = GitHubControlPlaneStore { appHome })
+        )
+
+        val bound = service.bind(
+            state = DesktopAppState(
+                companies = listOf(testCompany(companyId)),
+                issues = listOf(
+                    CompanyIssue(
+                        id = dependencyId,
+                        companyId = companyId,
+                        goalId = "goal-ready",
+                        workspaceId = "workspace-ready",
+                        title = "Dependency",
+                        description = "done",
+                        status = IssueStatus.DONE,
+                        createdAt = 1L,
+                        updatedAt = 2L
+                    ),
+                    CompanyIssue(
+                        id = issueId,
+                        companyId = companyId,
+                        goalId = "goal-ready",
+                        workspaceId = "workspace-ready",
+                        title = "Backlog work",
+                        description = "ready",
+                        status = IssueStatus.BACKLOG,
+                        dependsOn = listOf(dependencyId),
+                        createdAt = 1L,
+                        updatedAt = 2L
+                    )
+                )
+            ),
+            companyId = companyId,
+            runtime = CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+        )
+
+        bound.issues.first { it.id == issueId }.runtimeDisposition shouldBe "RUNNABLE"
+        bound.runtime.pendingIssueIds shouldContain issueId
+        bound.runtime.blockedIssueIds shouldNotContain issueId
+    }
+
+    test("bind marks backlog issues with unresolved explicit dependencies as waiting") {
+        val appHome = Files.createTempDirectory("company-runtime-backlog-waiting")
+        val companyId = "company-backlog-waiting"
+        val dependencyId = "issue-unfinished-dependency"
+        val issueId = "issue-backlog-waiting"
+        val service = CompanyRuntimeBindingService(
+            durableRuntimeService = DurableRuntimeService(runtimeStore = DurableRuntimeStore(appHome.resolve("runtime"))),
+            actionStore = ActionStore { appHome },
+            policyEngine = PolicyEngine(PolicyStore { appHome }),
+            gitHubControlPlaneService = GitHubControlPlaneService(store = GitHubControlPlaneStore { appHome })
+        )
+
+        val bound = service.bind(
+            state = DesktopAppState(
+                companies = listOf(testCompany(companyId)),
+                issues = listOf(
+                    CompanyIssue(
+                        id = dependencyId,
+                        companyId = companyId,
+                        goalId = "goal-waiting",
+                        workspaceId = "workspace-waiting",
+                        title = "Dependency",
+                        description = "not done",
+                        status = IssueStatus.IN_PROGRESS,
+                        createdAt = 1L,
+                        updatedAt = 2L
+                    ),
+                    CompanyIssue(
+                        id = issueId,
+                        companyId = companyId,
+                        goalId = "goal-waiting",
+                        workspaceId = "workspace-waiting",
+                        title = "Backlog work",
+                        description = "blocked",
+                        status = IssueStatus.BACKLOG,
+                        createdAt = 1L,
+                        updatedAt = 2L
+                    )
+                ),
+                issueDependencies = listOf(
+                    IssueDependency(
+                        id = "dependency-edge",
+                        issueId = issueId,
+                        dependsOnIssueId = dependencyId
+                    )
+                )
+            ),
+            companyId = companyId,
+            runtime = CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+        )
+
+        bound.issues.first { it.id == issueId }.runtimeDisposition shouldBe "WAITING_FOR_DEPENDENCY"
+        bound.runtime.pendingIssueIds shouldNotContain issueId
+        bound.runtime.blockedIssueIds shouldContain issueId
+    }
 })
 
 private fun bindSingleIssueForRuntimeDisposition(
@@ -388,18 +496,7 @@ private fun bindSingleIssueForRuntimeDisposition(
         gitHubControlPlaneService = GitHubControlPlaneService(store = GitHubControlPlaneStore { appHome })
     ).bind(
         state = DesktopAppState(
-            companies = listOf(
-                Company(
-                    id = companyId,
-                    name = "Runtime Disposition",
-                    rootPath = ".",
-                    repositoryId = "repo-runtime-disposition",
-                    defaultBaseBranch = "main",
-                    backendKind = ExecutionBackendKind.LOCAL_COTOR,
-                    createdAt = 1L,
-                    updatedAt = 1L
-                )
-            ),
+            companies = listOf(testCompany(companyId)),
             issues = listOf(issue),
             tasks = tasks
         ),
@@ -407,6 +504,18 @@ private fun bindSingleIssueForRuntimeDisposition(
         runtime = CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
     )
 }
+
+private fun testCompany(companyId: String): Company =
+    Company(
+        id = companyId,
+        name = "Test",
+        rootPath = ".",
+        repositoryId = "repo-$companyId",
+        defaultBaseBranch = "main",
+        backendKind = ExecutionBackendKind.LOCAL_COTOR,
+        createdAt = 1L,
+        updatedAt = 1L
+    )
 
 private fun runtimeDispositionIssue(
     issueId: String,

--- a/src/test/kotlin/com/cotor/data/plugin/LocalModelPluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/LocalModelPluginTest.kt
@@ -128,6 +128,9 @@ private fun localJsonServer(path: String, body: String): HttpServer {
 
 private fun localRoutingServer(handler: (HttpExchange) -> Unit): HttpServer {
     val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.executor = java.util.concurrent.Executor { command ->
+        Thread(command, "local-model-plugin-http-test").apply { isDaemon = true }.start()
+    }
     server.createContext("/") { exchange ->
         handler(exchange)
     }

--- a/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
@@ -670,6 +670,9 @@ private fun assertOpenCodeRunCommand(command: List<String>, model: String, expec
 
 private fun localRoutingServer(handler: (HttpExchange) -> Unit): HttpServer {
     val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.executor = java.util.concurrent.Executor { command ->
+        Thread(command, "opencode-plugin-http-test").apply { isDaemon = true }.start()
+    }
     server.createContext("/") { exchange ->
         handler(exchange)
     }

--- a/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
+++ b/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
@@ -105,6 +105,28 @@ class ProcessManagerTest : FunSpec({
         }
     }
 
+    test("executeProcess kills background descendants when a command times out") {
+        val processManager = CoroutineProcessManager(mockk<Logger>(relaxed = true))
+        val tempDir = Files.createTempDirectory("process-manager-timeout-descendant")
+        val marker = tempDir.resolve("descendant-marker.txt")
+
+        shouldThrow<TimeoutCancellationException> {
+            processManager.executeProcess(
+                command = listOf(
+                    "/bin/sh",
+                    "-c",
+                    "(sleep 1; echo leaked > '${marker.toAbsolutePath()}') & sleep 30"
+                ),
+                input = null,
+                environment = emptyMap(),
+                timeout = 200
+            )
+        }
+        Thread.sleep(1_500)
+
+        Files.exists(marker) shouldBe false
+    }
+
     test("executeProcess returns when a subprocess leaves inherited pipes open") {
         val processManager = CoroutineProcessManager(mockk<Logger>(relaxed = true))
 

--- a/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
+++ b/src/test/kotlin/com/cotor/reliability/ProductionReliabilityBaselineTest.kt
@@ -28,6 +28,31 @@ class ProductionReliabilityBaselineTest {
             dockerfile.contains("CMD [\"app-server\", \"--host\", \"0.0.0.0\", \"--port\", \"8787\"]"),
             "Dockerfile should bind app-server to all container interfaces for published ports"
         )
+        assertTrue(
+            dockerfile.contains("COPY docker-entrypoint.sh /app/docker-entrypoint.sh") &&
+                dockerfile.contains("ENTRYPOINT [\"/app/docker-entrypoint.sh\"]"),
+            "Dockerfile should launch through the app-server entrypoint"
+        )
+    }
+
+    @Test
+    fun `docker entrypoint generates runtime token for non-loopback app server`() {
+        val dockerfile = Files.readString(Path.of("Dockerfile"))
+        val entrypoint = Files.readString(Path.of("docker-entrypoint.sh"))
+
+        assertTrue(
+            !dockerfile.contains("cotor-desktop-local-token") && !entrypoint.contains("cotor-desktop-local-token"),
+            "Docker startup should not bake the desktop development token into the container"
+        )
+        assertTrue(
+            entrypoint.contains("COTOR_APP_TOKEN") && entrypoint.contains("random_token"),
+            "Entrypoint should generate a runtime token when one is not provided"
+        )
+        assertTrue(
+            entrypoint.contains("! is_loopback_host \"\$host\"") &&
+                entrypoint.contains("[ \"\$command_name\" = \"app-server\" ]"),
+            "Entrypoint should only auto-generate tokens for non-loopback app-server binds"
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Centralize company issue readiness so BACKLOG items with satisfied dependencies can run and unresolved dependencies report WAITING_FOR_DEPENDENCY.
- Harden runtime execution, timeout cleanup, publish staging, CEO PR merge gates, Docker startup token handling, and company-scoped ownership checks.
- Preserve macOS app-server base paths, ignore stale company-scoped async responses, and remove the deprecated apple/swift-testing package dependency.
- Keep test HTTP servers from pinning the Gradle test JVM after the suite completes.

## Validation
- ./gradlew --no-daemon formatCheck test
- ./gradlew compileKotlin compileTestKotlin -q
- swift build --package-path macos
- swift test --package-path macos: attempted locally; this machine uses /Library/Developer/CommandLineTools and SwiftPM cannot import the toolchain Testing module (no such module Testing) after removing the deprecated package dependency.

## Notes
- External HTTP route paths are unchanged; ownership validation and service signatures were tightened internally.
- publishRun now stages only publishable product paths and leaves local/runtime artifacts out of git add.
