### PR TITLE
feat(desktop): stabilize agent runtime, TUI workspace, operator chat, and QA state

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -27,6 +27,7 @@ Cotor는 로컬 우선 AI 워크플로우 실행기에서 출발해, CEO AI가 �
 - `cotor help ai`는 줄글 형태의 사용 가이드를 출력합니다.
 - `cotor help web`은 명령어 모음집과 빠른 시작 안내를 웹 도움말 표면으로 엽니다.
 - interactive transcript는 `.cotor/interactive/...` 아래에 저장되며, 각 세션은 transcript 옆에 `interactive.log`도 기록합니다.
+- `cotor init --starter-template`는 AI CLI 인증 전에도 검증/실행이 되는 안전한 로컬 `example-agent` Echo scaffold를 생성합니다.
 - packaged install에서 로컬 config가 없으면 interactive starter config는 현재 디렉터리 대신 `~/.cotor/interactive/default/cotor.yaml` 아래에 생성됩니다.
 - packaged first-run interactive는 즉시 응답 가능한 AI starter만 자동 선택하고, 인증되지 않은 CLI 때문에 깨지는 대신 안전한 `example-agent` Echo starter로 내려갑니다.
 - 첫 인자가 알 수 없는 명령이면 직접 파이프라인 실행으로 폴백합니다.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Important entry behavior:
 - `cotor help ai` prints a prose usage guide for operators
 - `cotor help web` launches a web help page with the command collection and quick-start guidance
 - interactive transcripts live under `.cotor/interactive/...`, and each session now writes `interactive.log` beside the transcript files
+- `cotor init --starter-template` generates a safe local `example-agent` Echo scaffold so validate/run succeeds before any AI CLI is authenticated
 - packaged first-run interactive writes its auto-generated starter config under `~/.cotor/interactive/default/cotor.yaml` when no local config exists
 - packaged first-run interactive only auto-selects AI starters that are actually ready to answer immediately; otherwise it falls back to the safe `example-agent` echo starter instead of failing on an unauthenticated CLI
 - unknown first args fall back to direct pipeline execution

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor-runtime-queue-fix  (2026-05-12)
+# Graph Report - cotor  (2026-05-19)
 
 ## Corpus Check
-- 354 files · ~592,323 words
+- 360 files · ~609,202 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4637 nodes · 6294 edges · 304 communities detected
-- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 684 edges (avg confidence: 0.8)
+- 4727 nodes · 6483 edges · 304 communities detected
+- Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 719 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -316,16 +316,16 @@
 - [[_COMMUNITY_Community 307|Community 307]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 243 edges
+1. `DesktopStore` - 244 edges
 2. `DesktopTextKey` - 128 edges
 3. `CodingKeys` - 95 edges
 4. `DesktopAPI` - 93 edges
 5. `GitWorkspaceService` - 78 edges
-6. `language` - 56 edges
+6. `language` - 57 edges
 7. `DesktopStoreTests` - 52 edges
 8. `MeetingRoomProjectionTests` - 27 edges
-9. `DesktopStateStore` - 27 edges
-10. `runtime()` - 26 edges
+9. `Data` - 27 edges
+10. `DesktopStateStore` - 27 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `language` --calls--> `userFacingIssueKind()`  [INFERRED]
@@ -343,27 +343,27 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.0
-Nodes (50): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+42 more)
+Nodes (53): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+45 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (23): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+15 more)
+Nodes (238): settings(), CaseIterable, Codable, AgentSkillCardRecord, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto (+230 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (158): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+150 more)
+Cohesion: 0.02
+Nodes (18): CompanyMarketingDashboardProjection, availableAgentModels(), runIssue(), startCompanyRuntime(), stopCompanyRuntime(), updateGoal(), TuiSession, Array (+10 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.02
-Nodes (192): Codable, AgentSkillCardRecord, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, IssueRecord, MeetingRoomExpression (+184 more)
+Cohesion: 0.01
+Nodes (154): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, BrowserView, CenterPaneView (+146 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.03
-Nodes (23): ActionStore, AppLogger, APIError, http, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload (+15 more)
+Nodes (20): ActionStore, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload, nonEmpty() (+12 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
-Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
+Nodes (134): AppLanguage, english, korean, AppTheme, dark, light, system, DesktopStrings (+126 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
@@ -371,39 +371,39 @@ Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgent
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (115): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+107 more)
+Nodes (39): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+31 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Nodes (113): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+105 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.03
-Nodes (54): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch, companyCardRuntimeLabel(), ChatAgentProposal, ChatBackendAction, restart (+46 more)
+Cohesion: 0.02
+Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.03
 Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
 
 ### Community 13 - "Community 13"
+Cohesion: 0.07
+Nodes (8): MeetingRoomBrainGraph, MeetingRoomBrainGraphPane, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
+
+### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
-### Community 14 - "Community 14"
-Cohesion: 0.03
-Nodes (16): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, system, main() (+8 more)
-
 ### Community 15 - "Community 15"
-Cohesion: 0.04
-Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
+Cohesion: 0.05
+Nodes (52): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+44 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.06
@@ -418,104 +418,104 @@ Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.05
-Nodes (39): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+31 more)
+Cohesion: 0.07
+Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
 ### Community 21 - "Community 21"
-Cohesion: 0.13
-Nodes (3): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas
-
-### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 23 - "Community 23"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (7): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.07
 Nodes (2): CachedState, DesktopStateStore
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.07
 Nodes (2): DesktopTuiSessionService, RuntimeSession
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.07
 Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.08
 Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, StageExecution, StageStats, StatsDetails, StatsManager (+1 more)
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
 
-### Community 39 - "Community 39"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (1): Parser
 
-### Community 40 - "Community 40"
+### Community 39 - "Community 39"
 Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.12
 Nodes (1): A2aRouter
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (1): DurableRuntimeService
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
+
+### Community 43 - "Community 43"
+Cohesion: 0.12
+Nodes (2): CoroutineProcessManager, ProcessManager
 
 ### Community 44 - "Community 44"
 Cohesion: 0.12
@@ -531,239 +531,239 @@ Nodes (1): AgentCapabilityGuard
 
 ### Community 47 - "Community 47"
 Cohesion: 0.12
-Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
+Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
 ### Community 48 - "Community 48"
-Cohesion: 0.13
-Nodes (1): Scanner
+Cohesion: 0.12
+Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
 ### Community 49 - "Community 49"
-Cohesion: 0.13
-Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
+Cohesion: 0.12
+Nodes (1): StarterAgentSpec
 
 ### Community 50 - "Community 50"
 Cohesion: 0.13
-Nodes (1): RecoveryExecutor
+Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
-Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
+Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
 ### Community 52 - "Community 52"
 Cohesion: 0.13
-Nodes (1): ConditionEvaluator
+Nodes (1): RecoveryExecutor
 
 ### Community 53 - "Community 53"
 Cohesion: 0.13
-Nodes (1): StarterAgentSpec
+Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
 ### Community 54 - "Community 54"
-Cohesion: 0.14
-Nodes (1): BoardControllerTest
+Cohesion: 0.13
+Nodes (1): ConditionEvaluator
 
 ### Community 55 - "Community 55"
 Cohesion: 0.14
-Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
+Nodes (1): BoardControllerTest
 
 ### Community 56 - "Community 56"
 Cohesion: 0.14
-Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
+Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
 ### Community 57 - "Community 57"
 Cohesion: 0.14
-Nodes (2): DefaultSecurityValidator, SecurityValidator
+Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
 ### Community 58 - "Community 58"
 Cohesion: 0.14
-Nodes (1): DurableRuntimeStore
+Nodes (2): DefaultSecurityValidator, SecurityValidator
 
 ### Community 59 - "Community 59"
 Cohesion: 0.14
-Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
+Nodes (1): DurableRuntimeStore
 
 ### Community 60 - "Community 60"
 Cohesion: 0.14
-Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
+Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
 ### Community 61 - "Community 61"
 Cohesion: 0.14
-Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
+Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
 ### Community 62 - "Community 62"
-Cohesion: 0.15
-Nodes (12): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, ReplayApprovalRequiredException (+4 more)
+Cohesion: 0.14
+Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
 ### Community 63 - "Community 63"
 Cohesion: 0.15
-Nodes (2): AgentRegistry, InMemoryAgentRegistry
+Nodes (12): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, ReplayApprovalRequiredException (+4 more)
 
 ### Community 64 - "Community 64"
-Cohesion: 0.17
-Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
+Cohesion: 0.15
+Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
 ### Community 65 - "Community 65"
 Cohesion: 0.17
-Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
+Nodes (12): MeetingRoomInteractionKind, approvalGranted, blockedEscalation, ceoApprovalRequested, changesRequested, costPaused, handoff, issueAssigned (+4 more)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.17
-Nodes (1): GoalDrivenTaskPlannerTest
+Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
 ### Community 67 - "Community 67"
 Cohesion: 0.17
-Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
+Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
 ### Community 68 - "Community 68"
 Cohesion: 0.17
-Nodes (11): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionRequest, ActionResult (+3 more)
+Nodes (1): GoalDrivenTaskPlannerTest
 
 ### Community 69 - "Community 69"
 Cohesion: 0.17
-Nodes (2): CoroutineProcessManager, ProcessManager
+Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
 ### Community 70 - "Community 70"
 Cohesion: 0.17
-Nodes (4): PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
+Nodes (11): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionRequest, ActionResult (+3 more)
 
 ### Community 71 - "Community 71"
 Cohesion: 0.17
-Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
+Nodes (4): PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
 ### Community 72 - "Community 72"
-Cohesion: 0.18
-Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
+Cohesion: 0.17
+Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
 ### Community 73 - "Community 73"
 Cohesion: 0.18
-Nodes (1): BoardServiceTest
+Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
 ### Community 74 - "Community 74"
 Cohesion: 0.18
-Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+Nodes (1): BoardServiceTest
 
 ### Community 75 - "Community 75"
 Cohesion: 0.18
-Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
+Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
 ### Community 76 - "Community 76"
 Cohesion: 0.18
-Nodes (1): VerificationBundleService
+Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
 ### Community 77 - "Community 77"
 Cohesion: 0.18
-Nodes (1): ProvenanceService
+Nodes (1): VerificationBundleService
 
 ### Community 78 - "Community 78"
 Cohesion: 0.18
-Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
+Nodes (1): ProvenanceService
 
 ### Community 79 - "Community 79"
 Cohesion: 0.18
-Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
+Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.18
-Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
+Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
-Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
+Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
 ### Community 82 - "Community 82"
 Cohesion: 0.18
-Nodes (2): ErrorMessages, UserFriendlyError
+Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (1): StatsCommand
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.2
-Nodes (1): TemplateEngineTest
+Cohesion: 0.18
+Nodes (1): StatsCommand
 
 ### Community 86 - "Community 86"
-Cohesion: 0.2
-Nodes (1): ChatTranscriptWriter
+Cohesion: 0.18
+Nodes (1): DoctorCommand
 
 ### Community 87 - "Community 87"
 Cohesion: 0.2
-Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
+Nodes (1): TemplateEngineTest
 
 ### Community 88 - "Community 88"
 Cohesion: 0.2
-Nodes (1): VerificationStore
+Nodes (1): ChatTranscriptWriter
 
 ### Community 89 - "Community 89"
 Cohesion: 0.2
-Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
+Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
 ### Community 90 - "Community 90"
 Cohesion: 0.2
-Nodes (3): ErrorHelper, ErrorInfo, ErrorType
+Nodes (1): VerificationStore
 
 ### Community 91 - "Community 91"
 Cohesion: 0.2
-Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
+Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
 ### Community 92 - "Community 92"
 Cohesion: 0.2
-Nodes (1): DoctorCommand
+Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
 ### Community 93 - "Community 93"
 Cohesion: 0.2
-Nodes (1): PolicyStore
+Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
 
 ### Community 94 - "Community 94"
+Cohesion: 0.2
+Nodes (1): PolicyStore
+
+### Community 95 - "Community 95"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.22
 Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.22
 Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.22
 Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.22
 Nodes (1): LocalModelDefaults
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.22
 Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
-
-### Community 105 - "Community 105"
-Cohesion: 0.25
-Nodes (1): DesktopAppServiceRuntimeCleanupTest
 
 ### Community 106 - "Community 106"
 Cohesion: 0.25
@@ -983,31 +983,31 @@ Nodes (2): SyntaxValidationResult, SyntaxValidator
 
 ### Community 160 - "Community 160"
 Cohesion: 0.5
-Nodes (1): findPrimes()
-
-### Community 161 - "Community 161"
-Cohesion: 0.5
 Nodes (1): BoardServiceApplicationTests
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.67
 Nodes (2): BoardServiceApplication, main()
 
-### Community 163 - "Community 163"
-Cohesion: 0.67
-Nodes (2): fromEntity(), PostDetailResponse
-
-### Community 164 - "Community 164"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostSummaryResponse
 
-### Community 165 - "Community 165"
+### Community 163 - "Community 163"
 Cohesion: 0.5
 Nodes (1): PostRepository
 
-### Community 166 - "Community 166"
+### Community 164 - "Community 164"
 Cohesion: 0.5
 Nodes (1): Post
+
+### Community 165 - "Community 165"
+Cohesion: 0.5
+Nodes (1): findPrimes()
+
+### Community 166 - "Community 166"
+Cohesion: 0.67
+Nodes (2): fromEntity(), PostDetailResponse
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
@@ -1558,77 +1558,73 @@ Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **970 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+965 more)
+- **987 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+982 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 25`** (30 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `DesktopStateStore.kt`
+- **Thin community `Community 24`** (30 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `DesktopStateStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 25`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 28`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 32`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (18 nodes): `Parser`, `.advance()`, `.and()`, `.check()`, `.comparison()`, `.consume()`, `.equality()`, `.expression()`, `.isAtEnd()`, `.match()`, `.or()`, `.parse()`, `.peek()`, `.previous()`, `.primary()`, `.term()`, `.unary()`, `Parser.kt`
+- **Thin community `Community 38`** (18 nodes): `Parser`, `.advance()`, `.and()`, `.check()`, `.comparison()`, `.consume()`, `.equality()`, `.expression()`, `.isAtEnd()`, `.match()`, `.or()`, `.parse()`, `.peek()`, `.previous()`, `.primary()`, `.term()`, `.unary()`, `Parser.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 39`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 40`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 41`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 42`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 43`** (17 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 46`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
+- **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 52`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 54`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (15 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+- **Thin community `Community 55`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 58`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
+- **Thin community `Community 59`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
+- **Thin community `Community 64`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 68`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 74`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (12 nodes): `buildEffectivePath()`, `CoroutineProcessManager`, `.executeProcess()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `ProcessManager.kt`
+- **Thin community `Community 75`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 73`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 77`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 78`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 76`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 83`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 85`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 86`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 87`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 88`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 90`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 94`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 92`** (10 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 95`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 93`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 96`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 94`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 95`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (8 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
+- **Thin community `Community 102`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1730,19 +1726,19 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 159`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 160`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 161`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 162`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 163`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 164`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 165`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 166`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 167`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2014,17 +2010,17 @@ Nodes (1): RealtimeEvent
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 11`, `Community 15`, `Community 16`?**
-  _High betweenness centrality (0.087) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 5` to `Community 1`?**
-  _High betweenness centrality (0.035) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 11`, `Community 19`, `Community 21`?**
-  _High betweenness centrality (0.034) - this node is a cross-community bridge._
+- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 7`, `Community 15`, `Community 19`?**
+  _High betweenness centrality (0.104) - this node is a cross-community bridge._
+- **Why does `call_linear()` connect `Community 7` to `Community 4`?**
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
 - **Are the 29 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
   _`DesktopStore` has 29 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
-  _970 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
+  _987 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
+  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.02 - nodes in this community are weakly interconnected._

--- a/macos/Package.resolved
+++ b/macos/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "e5ff615f45b6f99824c4e99bb4951fb0f0c6c0253d9338e24c0caa4aba1ce6e4",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,35 +1,16 @@
 // swift-tools-version: 6.0
-import Foundation
 import PackageDescription
 
 // A plain Swift Package keeps the first macOS client easy to build from the repo
 // without introducing an Xcode project as an additional source of truth.
-let testingFrameworkPath = [
-    ProcessInfo.processInfo.environment["DEVELOPER_DIR"].map { "\($0)/Library/Developer/Frameworks" },
-    "/Applications/Xcode.app/Contents/Developer/Library/Developer/Frameworks",
-    "/Library/Developer/CommandLineTools/Library/Developer/Frameworks"
-]
-    .compactMap { $0 }
-    .first { FileManager.default.fileExists(atPath: "\($0)/Testing.framework") }
-let testingSwiftSettings: [SwiftSetting] = testingFrameworkPath.map {
-    [.unsafeFlags(["-F", $0, "-Xfrontend", "-disable-cross-import-overlays"])]
-} ?? []
-let testingLinkerSettings: [LinkerSetting] = testingFrameworkPath.map {
-    [
-        .unsafeFlags([
-            "-F", $0,
-            "-framework", "Testing",
-            "-Xlinker", "-rpath",
-            "-Xlinker", $0
-        ])
-    ]
-} ?? []
-
 let package = Package(
     name: "CotorDesktop",
     platforms: [.macOS(.v14)],
     products: [
         .executable(name: "CotorDesktopApp", targets: ["CotorDesktopApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0")
     ],
     targets: [
         .executableTarget(
@@ -42,10 +23,11 @@ let package = Package(
         ),
         .testTarget(
             name: "CotorDesktopAppTests",
-            dependencies: ["CotorDesktopApp"],
-            path: "Tests/CotorDesktopAppTests",
-            swiftSettings: testingSwiftSettings,
-            linkerSettings: testingLinkerSettings
+            dependencies: [
+                "CotorDesktopApp",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "Tests/CotorDesktopAppTests"
         )
     ]
 )

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -2932,7 +2932,7 @@ private struct IssueSummaryRow: View {
                         .foregroundStyle(ShellPalette.text)
                         .lineLimit(1)
                     Spacer()
-                    StatusSummaryPill(text: language.status(issue.status), tint: statusTint(for: issue.status))
+                    StatusSummaryPill(text: effectiveIssueStatusLabel(issue, language: language), tint: statusTint(for: issue.status))
                 }
                 if let assignee {
                     Text(assignee.roleName)
@@ -2972,7 +2972,7 @@ private struct IssueFocusRow: View {
                         .foregroundStyle(ShellPalette.text)
                         .lineLimit(1)
                     HStack(spacing: 8) {
-                        Text(language.status(issue.status))
+                        Text(effectiveIssueStatusLabel(issue, language: language))
                             .font(.system(size: 10, weight: .medium))
                             .foregroundStyle(ShellPalette.muted)
                         if let assignee {
@@ -3876,7 +3876,7 @@ private struct AgentSkillCardView: View {
                             Image(systemName: "play.fill")
                                 .font(.system(size: 8, weight: .bold))
                         }
-                        Text(isRunning ? language("Running", "실행 중") : language("Run", "실행"))
+                        Text(isRunning ? language("Running", "실행 중") : language("Skill Test", "스킬 테스트"))
                             .font(.system(size: 10, weight: .semibold))
                     }
                     .foregroundStyle(ShellPalette.text)
@@ -9161,6 +9161,18 @@ private func matches(query: String, values: [String?]) -> Bool {
         guard let value else { return false }
         return value.lowercased().contains(needle)
     }
+}
+
+/// Returns the status label for an issue, substituting a user-friendly
+/// "Paused · Resumable" string when a BLOCKED issue was interrupted by a
+/// manual runtime stop and can be retried automatically.
+private func effectiveIssueStatusLabel(_ issue: IssueRecord, language: AppLanguage) -> String {
+    if issue.status.uppercased() == "BLOCKED",
+       issue.blockedReasonCode == "RUNTIME_INTERRUPTED",
+       issue.blockedRetryable == true {
+        return language("Paused · Resumable", "중지됨 · 재개 가능")
+    }
+    return language.status(issue.status)
 }
 
 private func statusTint(for status: String) -> Color {

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -1746,6 +1746,16 @@ final class DesktopStore: ObservableObject {
             return
         }
 
+        // Eagerly clear stale detail state so the panel never momentarily shows
+        // data from the previously selected issue while the new one is loading.
+        let requestedIssueID = selectedIssueID
+        issueExecutionDetails = []
+        runs = []
+        changes = emptyChangeSummary()
+        files = []
+        ports = []
+        browserURL = nil
+
         if let issueId = selectedIssue?.id {
             do {
                 let fetchedIssueExecutionDetails = try await api.issueExecutionDetails(issueId: issueId)
@@ -1771,8 +1781,13 @@ final class DesktopStore: ObservableObject {
         let agent = selectedAgentName ?? task.agents.first
         selectedAgentName = agent
         guard let agent else { return }
-        let requestedIssueID = selectedIssueID
         let requestedTaskID = task.id
+
+        // Determine which task IDs belong to the selected issue so effectiveRun
+        // never crosses the issue boundary when falling back.
+        let issueTaskIDs: Set<String> = requestedIssueID.map { iid in
+            Set(tasks.filter { $0.issueId == iid }.map { $0.id })
+        } ?? []
 
         do {
             let fetchedRuns: [RunRecord]
@@ -1789,11 +1804,13 @@ final class DesktopStore: ObservableObject {
             runs = fetchedRuns
 
             let latestForTask = fetchedRuns.filter { $0.taskId == task.id }
+            // Only fall back to other runs when they belong to the same issue's tasks.
+            let issueRuns = issueTaskIDs.isEmpty ? fetchedRuns : fetchedRuns.filter { issueTaskIDs.contains($0.taskId) }
             let effectiveRun = latestForTask.first { $0.agentName.caseInsensitiveCompare(agent) == .orderedSame }
                 ?? latestForTask.first
-                ?? fetchedRuns.first { $0.agentName.caseInsensitiveCompare(agent) == .orderedSame }
-                ?? fetchedRuns.first
-            if let effectiveRun {
+                ?? issueRuns.first { $0.agentName.caseInsensitiveCompare(agent) == .orderedSame }
+                ?? issueRuns.first
+            if let effectiveRun, issueTaskIDs.isEmpty || issueTaskIDs.contains(effectiveRun.taskId) {
                 selectedTaskID = effectiveRun.taskId
             }
             let effectiveAgent = effectiveRun?.agentName ?? agent
@@ -3412,12 +3429,22 @@ final class DesktopStore: ObservableObject {
         )
     }
 
+    private func looksLikeStatusChatRequest(_ text: String) -> Bool {
+        containsAny(text, ["상태 확인", "잘 돌아", "잘돌", "에이전트 잘", "health check", "status check", "점검해", "상태 보고"])
+    }
+
     private func executeOperatorChatMessage(_ message: String, normalized: String) async -> String {
         if looksLikeCompanyCreateChatRequest(normalized) {
             return await createCompanyFromOperatorChat(message)
         }
         guard selectedCompany != nil else {
             return language("Select or create a company first.", "먼저 회사를 선택하거나 만들어주세요.")
+        }
+
+        // Status requests bypass the LLM planner entirely and return a
+        // deterministic reply from the operator-command status path.
+        if looksLikeStatusChatRequest(normalized) {
+            return await runOperatorCommandAsChatReply(message: message)
         }
 
         if let response = await runCompanyOperatorChat(message: message) {
@@ -4537,10 +4564,20 @@ final class DesktopStore: ObservableObject {
 
     private func selectWorkspaceForTuiIfNeeded() {
         if let session = activeTuiSession {
-            selectedTuiSessionID = session.id
-            selectedRepositoryID = session.repositoryId
-            selectedWorkspaceID = session.workspaceId
-            pendingWorkspaceBaseBranch = session.baseBranch
+            if session.workspaceId == selectedWorkspaceID {
+                // Session already matches the selected workspace — sync the session
+                // chip without touching the repository or workspace selection.
+                selectedTuiSessionID = session.id
+                pendingWorkspaceBaseBranch = session.baseBranch
+            } else if selectedWorkspaceID == nil {
+                // No workspace was selected yet — let the active session drive it.
+                selectedTuiSessionID = session.id
+                selectedRepositoryID = session.repositoryId
+                selectedWorkspaceID = session.workspaceId
+                pendingWorkspaceBaseBranch = session.baseBranch
+            }
+            // When the session's workspace differs from the user's current selection,
+            // preserve the user's selection and let ensureTuiSession open a new one.
             return
         }
 
@@ -4576,9 +4613,12 @@ final class DesktopStore: ObservableObject {
                       let refreshed = sessions.first(where: { $0.id == current.id }) {
                 selectedTuiSessionID = refreshed.id
                 tuiSession = refreshed
-            } else if let first = sessions.first {
-                selectedTuiSessionID = first.id
-                tuiSession = first
+            } else if let match = sessions.first(where: { $0.workspaceId == selectedWorkspaceID }) {
+                // Only adopt an unrelated session when it matches the current workspace.
+                // Falling back to sessions.first would silently override the user's
+                // folder selection with whatever session was opened last.
+                selectedTuiSessionID = match.id
+                tuiSession = match
             } else {
                 selectedTuiSessionID = nil
                 tuiSession = nil

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -764,6 +764,8 @@ struct IssueRecord: Codable, Identifiable, Hashable {
     let mergeResult: String?
     let transitionReason: String?
     let sourceSignal: String
+    let blockedReasonCode: String?
+    let blockedRetryable: Bool?
     let createdAt: Int64
     let updatedAt: Int64
 }
@@ -2031,6 +2033,8 @@ struct MockSeed {
                 mergeResult: nil,
                 transitionReason: nil,
                 sourceSignal: "goal-decomposition",
+                blockedReasonCode: nil,
+                blockedRetryable: nil,
                 createdAt: 0,
                 updatedAt: 0
             ),
@@ -2068,6 +2072,8 @@ struct MockSeed {
                 mergeResult: nil,
                 transitionReason: "Execution branch is active.",
                 sourceSignal: "goal-decomposition",
+                blockedReasonCode: nil,
+                blockedRetryable: nil,
                 createdAt: 0,
                 updatedAt: 0
             ),
@@ -2105,6 +2111,8 @@ struct MockSeed {
                 mergeResult: nil,
                 transitionReason: "QA is reviewing the execution PR.",
                 sourceSignal: "goal-decomposition",
+                blockedReasonCode: nil,
+                blockedRetryable: nil,
                 createdAt: 0,
                 updatedAt: 0
             )

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -1257,6 +1257,134 @@ struct DesktopStoreTests {
         #expect(metrics.readyToMergeCount == 0)
     }
 
+    @Test
+    func refreshTuiSessionListDoesNotOverwriteSelectedWorkspaceWithFirstSession() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            let body: String
+            if path.contains("/tui/sessions") {
+                // session-b has higher updatedAt and sorts first, but ws-a is the selected workspace.
+                body = """
+                [
+                  {"id":"session-a","workspaceId":"ws-a","repositoryId":"repo-a","repositoryPath":"/tmp/a","agentName":null,"baseBranch":"main","status":"IDLE","transcript":"","transcriptStartOffset":0,"transcriptEndOffset":0,"processId":null,"exitCode":null,"createdAt":1,"updatedAt":1},
+                  {"id":"session-b","workspaceId":"ws-b","repositoryId":"repo-b","repositoryPath":"/tmp/b","agentName":null,"baseBranch":"main","status":"IDLE","transcript":"","transcriptStartOffset":0,"transcriptEndOffset":0,"processId":null,"exitCode":null,"createdAt":2,"updatedAt":2}
+                ]
+                """
+            } else {
+                body = "[]"
+            }
+            let response = HTTPURLResponse(url: try #require(request.url), statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+            return (response, Data(body.utf8))
+        }
+        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        let store = DesktopStore(
+            api: DesktopAPI(
+                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                token: nil,
+                session: session
+            )
+        )
+        store.selectedWorkspaceID = "ws-a"
+
+        await store.refreshTuiSessionList()
+
+        // session-b sorts first (updatedAt=2) but must NOT be auto-selected because workspace differs.
+        #expect(store.tuiSession?.id == "session-a")
+        #expect(store.tuiSession?.workspaceId == "ws-a")
+        #expect(store.selectedWorkspaceID == "ws-a")
+    }
+
+    @Test
+    func refreshTuiSessionListSetsNilWhenNoSessionMatchesSelectedWorkspace() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+            let path = request.url?.path ?? ""
+            let body: String
+            if path.contains("/tui/sessions") {
+                body = """
+                [
+                  {"id":"session-b","workspaceId":"ws-b","repositoryId":"repo-b","repositoryPath":"/tmp/b","agentName":null,"baseBranch":"main","status":"IDLE","transcript":"","transcriptStartOffset":0,"transcriptEndOffset":0,"processId":null,"exitCode":null,"createdAt":1,"updatedAt":1}
+                ]
+                """
+            } else {
+                body = "[]"
+            }
+            let response = HTTPURLResponse(url: try #require(request.url), statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
+            return (response, Data(body.utf8))
+        }
+        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        let store = DesktopStore(
+            api: DesktopAPI(
+                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                token: nil,
+                session: session
+            )
+        )
+        store.selectedWorkspaceID = "ws-a"
+
+        await store.refreshTuiSessionList()
+
+        // No session matches ws-a — tuiSession must remain nil, not fall back to ws-b's session.
+        #expect(store.tuiSession == nil)
+        #expect(store.selectedTuiSessionID == nil)
+        #expect(store.selectedWorkspaceID == "ws-a")
+    }
+
+    @Test
+    func selectingExplicitTuiSessionMovesWorkspaceAndRepositorySelection() async {
+        let store = DesktopStore()
+        store.selectedWorkspaceID = "ws-a"
+        store.selectedRepositoryID = "repo-a"
+
+        let other = TuiSessionRecord(
+            id: "session-b",
+            workspaceId: "ws-b",
+            repositoryId: "repo-b",
+            repositoryPath: "/tmp/b",
+            agentName: nil,
+            baseBranch: "main",
+            status: "IDLE",
+            transcript: "",
+            transcriptStartOffset: 0,
+            transcriptEndOffset: 0,
+            processId: nil,
+            exitCode: nil,
+            createdAt: 1,
+            updatedAt: 1
+        )
+
+        await store.selectTuiSession(other)
+
+        #expect(store.selectedWorkspaceID == "ws-b")
+        #expect(store.selectedRepositoryID == "repo-b")
+        #expect(store.tuiSession?.id == "session-b")
+        #expect(store.selectedTuiSessionID == "session-b")
+    }
+
+    @Test
+    func issueBlockedReasonCodeDecodesRuntimeInterruptedVariant() throws {
+        let json = """
+        {
+          "id":"issue-qa","companyId":"c1","goalId":"g1","workspaceId":"ws1",
+          "title":"QA review","description":"","status":"BLOCKED",
+          "priority":0,"kind":"review","codeProducing":false,"riskLevel":"LOW",
+          "blockedBy":[],"dependsOn":[],"acceptanceCriteria":[],
+          "sourceSignal":"qa-review:issue-exec",
+          "blockedReasonCode":"RUNTIME_INTERRUPTED",
+          "createdAt":0,"updatedAt":0
+        }
+        """
+        let issue = try JSONDecoder().decode(IssueRecord.self, from: Data(json.utf8))
+
+        #expect(issue.blockedReasonCode == "RUNTIME_INTERRUPTED")
+        #expect(issue.status == "BLOCKED")
+    }
+
     private func scopedSelectionDashboard() -> DashboardPayload {
         DashboardPayload(
             repositories: [
@@ -1326,7 +1454,7 @@ struct DesktopStoreTests {
     }
 
     private func issue(id: String, companyId: String, goalId: String, workspaceId: String, status: String) -> IssueRecord {
-        IssueRecord(id: id, companyId: companyId, projectContextId: nil, goalId: goalId, workspaceId: workspaceId, title: id, description: id, status: status, priority: 0, kind: "execution", assigneeProfileId: nil, linearIssueId: nil, linearIssueIdentifier: nil, linearIssueUrl: nil, lastLinearSyncAt: nil, blockedBy: [], dependsOn: [], acceptanceCriteria: [], riskLevel: "LOW", codeProducing: true, executionIntent: nil, branchName: nil, worktreePath: nil, pullRequestNumber: nil, pullRequestUrl: nil, pullRequestState: nil, qaVerdict: nil, qaFeedback: nil, ceoVerdict: nil, ceoFeedback: nil, mergeResult: nil, transitionReason: nil, sourceSignal: "test", createdAt: 0, updatedAt: 0)
+        IssueRecord(id: id, companyId: companyId, projectContextId: nil, goalId: goalId, workspaceId: workspaceId, title: id, description: id, status: status, priority: 0, kind: "execution", assigneeProfileId: nil, linearIssueId: nil, linearIssueIdentifier: nil, linearIssueUrl: nil, lastLinearSyncAt: nil, blockedBy: [], dependsOn: [], acceptanceCriteria: [], riskLevel: "LOW", codeProducing: true, executionIntent: nil, branchName: nil, worktreePath: nil, pullRequestNumber: nil, pullRequestUrl: nil, pullRequestState: nil, qaVerdict: nil, qaFeedback: nil, ceoVerdict: nil, ceoFeedback: nil, mergeResult: nil, transitionReason: nil, sourceSignal: "test", blockedReasonCode: nil, blockedRetryable: nil, createdAt: 0, updatedAt: 0)
     }
 
     private func task(id: String, workspaceId: String, issueId: String) -> TaskRecord {

--- a/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift
@@ -902,6 +902,8 @@ private func issue(
         mergeResult: mergeResult,
         transitionReason: nil,
         sourceSignal: "test",
+        blockedReasonCode: nil,
+        blockedRetryable: nil,
         createdAt: 0,
         updatedAt: 1
     )

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -584,7 +584,7 @@ class DesktopAppService(
     ): CompanyDailyReport? {
         val state = stateStore.load()
         if (state.companies.none { it.id == companyId }) {
-            throw IllegalArgumentException("Company not found: $companyId")
+            return null
         }
         val reportDate = previousMorningReportDate(nowMillis)
         val path = companyReportPath(companyId, reportDate)
@@ -5895,6 +5895,14 @@ class DesktopAppService(
         userMessage: String,
         commandResponse: OperatorCommandResponse
     ): OperatorChatResponse {
+        // Status-check actions carry a fully deterministic detail string — skip the
+        // LLM call so the reply arrives within milliseconds instead of seconds.
+        if (commandResponse.actions.isNotEmpty() && commandResponse.actions.all { it.type == "status-check" }) {
+            val summary = commandResponse.summary ?: buildOperatorCompanySummary(companyId)
+            val message = buildDeterministicKoreanStatusMessage(summary)
+            return commandResponse.toOperatorChatResponse().copy(message = message)
+        }
+
         val execution = OperatorChatToolExecution(
             actions = commandResponse.actions,
             pendingApprovals = commandResponse.pendingApprovals,
@@ -5915,6 +5923,15 @@ class DesktopAppService(
             summary = commandResponse.summary ?: buildOperatorCompanySummary(companyId)
         ) ?: commandResponse.message
         return commandResponse.toOperatorChatResponse().copy(message = message)
+    }
+
+    private fun buildDeterministicKoreanStatusMessage(summary: OperatorCompanySummary): String {
+        val runtimeLabel = summary.runtimeStatus.uppercase()
+        return "확인했습니다. 현재 런타임은 ${runtimeLabel}이고 " +
+            "실행 중인 에이전트는 ${summary.activeAgentCount}개입니다. " +
+            "막힌 이슈는 ${summary.blockedIssueCount}개, " +
+            "리뷰 항목은 ${summary.reviewQueueCount}개, " +
+            "승인 대기는 ${summary.pendingApprovalCount}개입니다."
     }
 
     private suspend fun operatorChatPlannerFailureResponse(companyId: String, reason: String): OperatorChatResponse =
@@ -7839,7 +7856,8 @@ class DesktopAppService(
         )
 
     private fun shouldRouteOperatorChatThroughCommand(text: String): Boolean =
-        looksLikeCompanyWorkIntakeRequest(text) ||
+        looksLikeStatusRequest(text) ||
+            looksLikeCompanyWorkIntakeRequest(text) ||
             looksLikeRuntimeStart(text) ||
             looksLikeRuntimeStop(text) ||
             looksLikeBlockedIssueRetry(text) ||
@@ -8880,7 +8898,15 @@ class DesktopAppService(
     }
 
     suspend fun runIssueAndAwaitSettlement(issueId: String, timeoutMs: Long = ISSUE_RUN_AWAIT_TIMEOUT_MS): CompanyIssue {
-        val started = runIssue(issueId)
+        val delegated = delegateIssue(issueId)
+        val started = withTimeoutOrNull(timeoutMs) {
+            startDelegatedIssue(delegated, detachTask = false)
+        } ?: run {
+            val companyId = getIssue(issueId)?.companyId ?: delegated.companyId
+            interruptActiveCompanyTasksForRuntimeStop(companyId)
+            terminateActiveCompanyRunProcesses(companyId)
+            getIssue(issueId) ?: delegated
+        }
         return awaitIssueSettlement(issueId = issueId, timeoutMs = timeoutMs) ?: getIssue(issueId) ?: started
     }
 
@@ -8930,7 +8956,7 @@ class DesktopAppService(
         }
     }
 
-    private suspend fun startDelegatedIssue(issue: CompanyIssue): CompanyIssue {
+    private suspend fun startDelegatedIssue(issue: CompanyIssue, detachTask: Boolean = true): CompanyIssue {
         val executableIssue = ensureIssueWorkspace(issue)
         reconcileStaleTaskBeforeIssueStart(executableIssue.id)
         val state = stateStore.load()
@@ -9045,7 +9071,14 @@ class DesktopAppService(
             comment = "Cotor started work on \"${runningIssue.title}\" with agent ${profile.executionAgentName}."
         )
         if (task.status == DesktopTaskStatus.QUEUED) {
-            runCatching { runTaskIfPresent(task.id) }
+            runCatching {
+                if (detachTask) {
+                    runTaskIfPresent(task.id)
+                } else {
+                    executeTaskInline(task.id)
+                    getTask(task.id)
+                }
+            }
                 .onFailure { cause ->
                     markCompanyRuntimeError(executableIssue.companyId, cause)
                 }
@@ -17270,7 +17303,7 @@ class DesktopAppService(
         val recentDecisions = state.goalDecisions
             .filter { it.companyId == issue.companyId }
             .sortedByDescending { it.createdAt }
-            .take(5)
+            .take(2)
         val memoryBundle = company?.let {
             buildExecutionMemoryBundle(
                 state = state,
@@ -17282,8 +17315,7 @@ class DesktopAppService(
             )
         }
         return buildString {
-            appendLine("You are the CEO planning the next work graph for the company.")
-            appendLine()
+            appendLine("You are Cotor's CEO planner. Return only one ```json fenced block.")
             company?.let {
                 appendLine("Company: ${it.name}")
                 val workspaceName = runCatching { Path.of(it.rootPath).fileName?.toString() }
@@ -17295,64 +17327,47 @@ class DesktopAppService(
             }
             goal?.let {
                 appendLine("Goal: ${it.title}")
-                appendLine("Goal description:")
-                appendLine(it.description.ifBlank { it.title })
+                appendLine("Description: ${it.description.ifBlank { it.title }.singleLineLimit(220)}")
                 it.followUpContext?.let { context ->
-                    appendLine()
-                    appendLine("Follow-up context:")
-                    appendLine("- Root goal id: ${context.rootGoalId}")
-                    context.triggerIssueId?.let { triggerIssueId -> appendLine("- Trigger issue id: $triggerIssueId") }
-                    context.reviewQueueItemId?.let { reviewQueueItemId -> appendLine("- Review queue item id: $reviewQueueItemId") }
-                    context.pullRequestNumber?.let { pullRequestNumber -> appendLine("- Pull request number: #$pullRequestNumber") }
-                    appendLine("- Failure class: ${context.failureClass.name}")
+                    appendLine("Follow-up: failureClass=${context.failureClass.name}, rootGoal=${context.rootGoalId}")
                 }
             }
-            appendLine()
-            appendLine("Available roster:")
-            definitions.forEach { definition ->
-                appendLine("- ${definition.title}: ${definition.roleSummary}")
-                if (definition.specialties.isNotEmpty()) {
-                    appendLine("  specialties: ${definition.specialties.joinToString(", ")}")
-                }
-            }
+            appendLine("Roster roles: ${definitions.map { it.title }.distinct().take(10).joinToString(", ").ifBlank { profile.roleName }}")
             if (recentDecisions.isNotEmpty()) {
-                appendLine()
-                appendLine("Recent CEO decisions:")
-                recentDecisions.forEach { decision ->
-                    appendLine("- ${decision.summary}")
-                }
+                appendLine("Recent decisions: ${recentDecisions.joinToString("; ") { it.summary.singleLineLimit(120) }}")
             }
-            appendLine()
-            appendLine("Planning rules:")
-            appendLine("- Create only the concrete execution or research issues the company should do next.")
-            appendLine("- Do not create QA review or CEO approval issues; Cotor creates PR gates separately.")
-            appendLine("- Use one issue per branchable slice of work.")
-            appendLine("- Prefer a multi-issue execution graph over one giant issue.")
-            appendLine("- When the roster supports it, create 3 to 6 downstream issues and keep at least 2 implementation slices runnable in parallel.")
-            appendLine("- Generic work should route to Builder-first unless the goal clearly needs a specialist.")
-            appendLine("- Set codeProducing=true when the issue should end with a branch and GitHub PR.")
-            appendLine("- For validation-only or residual-risk follow-up work, set codeProducing=false and do not manufacture placeholder repository artifacts just to force a diff.")
-            appendLine("- For handoff, reporting, CEO decision, validation, or residual-risk tasks, default to codeProducing=false.")
+            appendLine("Rules: create 3 to 5 concrete branchable next issues; do not create QA review or CEO approval issues; route generic work to Builder; use dependsOn only when ordering matters.")
+            appendLine("Set codeProducing=true only when repository code must change and a PR is expected; validation, research, handoff, reporting, and residual-risk work should use codeProducing=false.")
             if (goal?.followUpContext?.failureClass == FollowUpFailureClass.MERGE_CONFLICT) {
-                appendLine("- This goal exists to remediate an existing merge conflict on the current PR lineage.")
-                appendLine("- Reuse the existing PR branch/worktree instead of inventing a new handoff PR or a new review lineage.")
+                appendLine("Merge-conflict follow-up: reuse the existing PR lineage instead of inventing a new handoff PR.")
             }
-            appendLine("- Use dependsOn with refIds from earlier issues when ordering matters.")
-            appendLine()
-            appendLine("Return JSON only inside one ```json fenced block using this schema:")
+            appendLine("Schema:")
             appendLine("```json")
-            appendLine("""{"goalSummary":"...","issues":[{"refId":"exec-1","title":"...","description":"...","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":true,"dependsOn":[],"acceptanceCriteria":["..."],"reviewRequired":true,"approvalRequired":true}]}""")
+            appendLine("""{"goalSummary":"...","issues":[{"refId":"exec-1","title":"...","description":"...","kind":"execution","assigneeRole":"Builder","priority":2,"codeProducing":false,"dependsOn":[],"acceptanceCriteria":["..."]}]}""")
             appendLine("```")
-            appendLine("Do not use tools, inspect files, or create files for this planning task.")
-            appendLine("Return the planning JSON only as assistant text inside the fenced JSON block.")
+            appendLine("Do not use tools, inspect files, or create files; include no prose outside the JSON block.")
             memoryBundle?.let { memory ->
-                appendLine()
-                appendLine(renderPlanningMemorySections(memory))
+                appendLine(compactPlanningMemoryLine(memory))
             }
-            appendLine()
-            appendLine("Do not include prose outside the JSON block.")
             appendLine("Current role: ${profile.roleName}")
         }.trim()
+    }
+
+    private fun compactPlanningMemoryLine(memory: CompanyMemorySnapshot): String {
+        return listOf(
+            "Company memory: ${memory.companyMemory.firstLineLimit(90)}",
+            "Project memory: ${memory.projectMemory.firstLineLimit(90)}",
+            "Team memory: ${memory.teamMemory.firstLineLimit(90)}",
+            "Agent memory: ${memory.agentMemory.firstLineLimit(90)}"
+        ).joinToString("\n")
+    }
+
+    private fun String.firstLineLimit(maxLength: Int): String =
+        lineSequence().firstOrNull { it.isNotBlank() }?.singleLineLimit(maxLength).orEmpty()
+
+    private fun String.singleLineLimit(maxLength: Int): String {
+        val normalized = replace(Regex("\\s+"), " ").trim()
+        return if (normalized.length <= maxLength) normalized else normalized.take(maxLength - 1).trimEnd() + "…"
     }
 
     private fun parseCeoPlanningPayload(output: String?): CeoPlanningPayload? {

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -827,6 +827,7 @@ class OpenCodePlugin : AgentPlugin {
         context: ExecutionContext,
         processManager: ProcessManager
     ): ProcessResult {
+        val planningOnly = isPlanningOnlyOpenCodeRun(context)
         // OpenCode run with --format json produces a structured JSON event stream
         // instead of launching an interactive TUI. Events include step_start, text,
         // step_finish, etc. We parse text events to extract the response content.
@@ -848,17 +849,24 @@ class OpenCodePlugin : AgentPlugin {
                 Files.writeString(path, prompt)
             }
         }
-        val ephemeralConfig = withContext(Dispatchers.IO) {
-            createEphemeralOpenCodeConfig(context)
-        }
+        val ephemeralConfig = if (planningOnly) null else withContext(Dispatchers.IO) { createEphemeralOpenCodeConfig(context) }
         val fatalRuntimeError = AtomicReference<String?>(null)
         val childProcessId = AtomicLong(-1L)
         val command = buildList {
             add("opencode")
             add("run")
+            if (planningOnly) {
+                add("--pure")
+            }
             add("--print-logs")
             add("--log-level")
             add("ERROR")
+            if (planningOnly) {
+                context.workingDirectory?.let {
+                    add("--dir")
+                    add(it.toString())
+                }
+            }
             context.parameters["agent"]
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
@@ -872,8 +880,15 @@ class OpenCodePlugin : AgentPlugin {
             }
             add("--format")
             add("json")
-            add("Execute the instructions in the attached prompt file.")
-            add("--file=$promptFile")
+            if (!planningOnly) {
+                add("Execute the instructions in the attached prompt file.")
+                add("--file=$promptFile")
+            }
+        }
+        val executionEnvironment = if (planningOnly) {
+            context.environment + planningOnlyOpenCodeEnvironment(context)
+        } else {
+            context.environment
         }
 
         return try {
@@ -896,23 +911,43 @@ class OpenCodePlugin : AgentPlugin {
                     }
                 }
                 try {
-                    processManager.executeProcess(
-                        command = command,
-                        input = null,
-                        environment = context.environment,
-                        timeout = context.timeout,
-                        workingDirectory = context.workingDirectory,
-                        onStart = { pid ->
-                            childProcessId.set(pid)
-                            context.onProcessStarted?.invoke(pid)
-                        },
-                        onStdoutChunk = context.onStdoutChunk,
-                        onStderrChunk = { chunk ->
-                            classifyFatalOpenCodeRuntimeLog(chunk)?.let { reason ->
-                                fatalRuntimeError.compareAndSet(null, reason)
+                    if (planningOnly) {
+                        processManager.executeProcessWithInputFile(
+                            command = command,
+                            inputFile = promptFile,
+                            environment = executionEnvironment,
+                            timeout = context.timeout,
+                            workingDirectory = context.workingDirectory,
+                            onStart = { pid ->
+                                childProcessId.set(pid)
+                                context.onProcessStarted?.invoke(pid)
+                            },
+                            onStdoutChunk = context.onStdoutChunk,
+                            onStderrChunk = { chunk ->
+                                classifyFatalOpenCodeRuntimeLog(chunk)?.let { reason ->
+                                    fatalRuntimeError.compareAndSet(null, reason)
+                                }
                             }
-                        }
-                    )
+                        )
+                    } else {
+                        processManager.executeProcess(
+                            command = command,
+                            input = null,
+                            environment = executionEnvironment,
+                            timeout = context.timeout,
+                            workingDirectory = context.workingDirectory,
+                            onStart = { pid ->
+                                childProcessId.set(pid)
+                                context.onProcessStarted?.invoke(pid)
+                            },
+                            onStdoutChunk = context.onStdoutChunk,
+                            onStderrChunk = { chunk ->
+                                classifyFatalOpenCodeRuntimeLog(chunk)?.let { reason ->
+                                    fatalRuntimeError.compareAndSet(null, reason)
+                                }
+                            }
+                        )
+                    }
                 } finally {
                     killer.cancel()
                 }
@@ -932,6 +967,18 @@ class OpenCodePlugin : AgentPlugin {
             }
         }
     }
+
+    private fun isPlanningOnlyOpenCodeRun(context: ExecutionContext): Boolean =
+        context.parameters["ephemeralOpencodeProfile"]?.trim() == "planning-only"
+
+    private fun planningOnlyOpenCodeEnvironment(context: ExecutionContext): Map<String, String> = mapOf(
+        "OPENCODE_CONFIG_CONTENT" to planningOnlyOpenCodeConfigJson(context),
+        "OPENCODE_DISABLE_PROJECT_CONFIG" to "true",
+        "OPENCODE_DISABLE_DEFAULT_PLUGINS" to "true",
+        "OPENCODE_DISABLE_AUTOUPDATE" to "true",
+        "OPENCODE_DISABLE_MODELS_FETCH" to "true",
+        "OPENCODE_PURE" to "true"
+    )
 
     private data class EphemeralOpenCodeConfig(
         val configPath: Path,

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -76,6 +76,26 @@ interface ProcessManager {
         onStart = onStart,
         onStdoutChunk = onStdoutChunk
     )
+
+    suspend fun executeProcessWithInputFile(
+        command: List<String>,
+        inputFile: Path,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path? = null,
+        onStart: ((Long) -> Unit)? = null,
+        onStdoutChunk: ((String) -> Unit)?,
+        onStderrChunk: ((String) -> Unit)?
+    ): ProcessResult = executeProcess(
+        command = command,
+        input = Files.readString(inputFile),
+        environment = environment,
+        timeout = timeout,
+        workingDirectory = workingDirectory,
+        onStart = onStart,
+        onStdoutChunk = onStdoutChunk,
+        onStderrChunk = onStderrChunk
+    )
 }
 
 /**
@@ -130,10 +150,55 @@ class CoroutineProcessManager(
         onStart: ((Long) -> Unit)?,
         onStdoutChunk: ((String) -> Unit)?,
         onStderrChunk: ((String) -> Unit)?
+    ): ProcessResult = executeProcessInternal(
+        command = command,
+        input = input,
+        inputFile = null,
+        environment = environment,
+        timeout = timeout,
+        workingDirectory = workingDirectory,
+        onStart = onStart,
+        onStdoutChunk = onStdoutChunk,
+        onStderrChunk = onStderrChunk
+    )
+
+    override suspend fun executeProcessWithInputFile(
+        command: List<String>,
+        inputFile: Path,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?,
+        onStderrChunk: ((String) -> Unit)?
+    ): ProcessResult = executeProcessInternal(
+        command = command,
+        input = null,
+        inputFile = inputFile,
+        environment = environment,
+        timeout = timeout,
+        workingDirectory = workingDirectory,
+        onStart = onStart,
+        onStdoutChunk = onStdoutChunk,
+        onStderrChunk = onStderrChunk
+    )
+
+    private suspend fun executeProcessInternal(
+        command: List<String>,
+        input: String?,
+        inputFile: Path?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?,
+        onStderrChunk: ((String) -> Unit)?
     ): ProcessResult = withContext(Dispatchers.IO) {
         val resolvedCommand = resolveProcessCommand(command)
         val processBuilder = ProcessBuilder(resolvedCommand)
             .redirectErrorStream(false)
+
+        inputFile?.let { processBuilder.redirectInput(it.toFile()) }
 
         workingDirectory?.let {
             // Every desktop agent run points this at its isolated worktree so file writes
@@ -197,7 +262,12 @@ class CoroutineProcessManager(
         }
 
         try {
-            if (input != null) {
+            if (inputFile != null) {
+                // Some CLIs, including OpenCode's non-interactive runner, behave
+                // differently when stdin is a JVM pipe. A real file-backed stdin
+                // preserves shell-style `< prompt.md` behavior without exposing
+                // prompt text in process arguments.
+            } else if (input != null) {
                 process.outputStream.bufferedWriter().use { writer ->
                     writer.write(input)
                     writer.flush()
@@ -214,6 +284,7 @@ class CoroutineProcessManager(
                     yield()
                 }
             }
+            cleanupSurvivingDescendants(process, logger)
             joinReader(stdoutThread)
             joinReader(stderrThread)
             val exitCode = process.exitValue()
@@ -255,6 +326,20 @@ private fun destroyProcessTree(process: Process, logger: Logger) {
         .asReversed()
     descendants.forEach { handle ->
         if (handle.isAlive) {
+            runCatching { handle.destroy() }
+                .onFailure { logger.debug("Failed to request descendant process ${handle.pid()} termination", it) }
+        }
+    }
+    if (process.isAlive) {
+        runCatching { process.destroy() }
+            .onFailure { logger.debug("Failed to request process ${process.pid()} termination", it) }
+    }
+    waitForProcessHandles(descendants, PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS)
+    if (process.isAlive) {
+        runCatching { process.waitFor(PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+    }
+    descendants.forEach { handle ->
+        if (handle.isAlive) {
             runCatching { handle.destroyForcibly() }
                 .onFailure { logger.debug("Failed to destroy descendant process ${handle.pid()}", it) }
         }
@@ -263,10 +348,31 @@ private fun destroyProcessTree(process: Process, logger: Logger) {
         runCatching { process.destroyForcibly() }
             .onFailure { logger.debug("Failed to destroy process ${process.pid()}", it) }
     }
-    descendants.forEach { handle ->
-        runCatching { handle.onExit().get(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
-    }
+    waitForProcessHandles(descendants, PROCESS_TREE_JOIN_TIMEOUT_MS)
     runCatching { process.waitFor(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+}
+
+private fun cleanupSurvivingDescendants(process: Process, logger: Logger) {
+    val descendants = process.toHandle()
+        .descendants()
+        .toArray()
+        .filterIsInstance<ProcessHandle>()
+        .asReversed()
+        .filter { it.isAlive }
+    if (descendants.isEmpty()) {
+        return
+    }
+    descendants.forEach { handle ->
+        runCatching { handle.destroyForcibly() }
+            .onFailure { logger.debug("Failed to clean up surviving descendant process ${handle.pid()}", it) }
+    }
+    waitForProcessHandles(descendants, PROCESS_TREE_JOIN_TIMEOUT_MS)
+}
+
+private fun waitForProcessHandles(handles: List<ProcessHandle>, timeoutMs: Long) {
+    handles.forEach { handle ->
+        runCatching { handle.onExit().get(timeoutMs, TimeUnit.MILLISECONDS) }
+    }
 }
 
 private fun redactedCommandForLogs(command: List<String>): String {
@@ -286,6 +392,7 @@ private fun joinReader(thread: Thread) {
 }
 
 private const val READER_JOIN_TIMEOUT_MS = 250L
+private const val PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS = 250L
 private const val PROCESS_TREE_JOIN_TIMEOUT_MS = 500L
 
 private fun buildEffectivePath(

--- a/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/Commands.kt
@@ -488,7 +488,7 @@ pipelines:
         }
     }
 
-    private fun resolveStarterAgent(): StarterAgentSpec = resolveStarterAgentSpec()
+    private fun resolveStarterAgent(): StarterAgentSpec = safeLocalStarterAgentSpec()
 }
 
 /**

--- a/src/main/kotlin/com/cotor/presentation/cli/DoctorCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/DoctorCommand.kt
@@ -12,9 +12,12 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.mordant.rendering.TextColors.*
 import com.github.ajalt.mordant.rendering.TextStyles.*
 import com.github.ajalt.mordant.terminal.Terminal
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.streams.asSequence
 
 /**
  * Doctor command: checks environment readiness and gives quick tips
@@ -67,10 +70,29 @@ class DoctorCommand(
     }
 
     private fun checkJar(): Triple<String, Boolean, String?> {
-        val jarPath = projectRootProvider().resolve("build/libs/cotor-1.0.0-all.jar")
-        val ok = jarPath.exists()
-        val hint = if (ok) "빌드 결과 발견: ${jarPath.fileName}" else "shadowJar 실행 필요: ./gradlew shadowJar"
+        val jarPath = findCliJar(projectRootProvider())
+        val ok = jarPath != null
+        val hint = jarPath?.let { "빌드 결과 발견: ${it.fileName}" } ?: "shadowJar 실행 필요: ./gradlew shadowJar"
         return Triple("CLI JAR 존재 여부", ok, hint)
+    }
+
+    private fun findCliJar(projectRoot: Path): Path? {
+        val libsDir = projectRoot.resolve("build/libs")
+        if (!libsDir.exists()) {
+            return null
+        }
+        return runCatching {
+            Files.list(libsDir).use { stream ->
+                stream.asSequence()
+                    .filter { it.isRegularFile() }
+                    .filter { path ->
+                        val name = path.fileName.toString()
+                        name.startsWith("cotor-") && name.endsWith("-all.jar")
+                    }
+                    .sortedByDescending { it.toFile().lastModified() }
+                    .firstOrNull()
+            }
+        }.getOrNull()
     }
 
     private fun checkConfig(): Triple<String, Boolean, String?> {

--- a/src/main/kotlin/com/cotor/presentation/cli/StarterAgentResolver.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/StarterAgentResolver.kt
@@ -57,6 +57,12 @@ apiKeyEnv: OPENAI_API_KEY
     }
 }
 
+internal fun safeLocalStarterAgentSpec(): StarterAgentSpec = StarterAgentSpec(
+    name = "example-agent",
+    pluginClass = "com.cotor.data.plugin.EchoPlugin",
+    executable = "echo"
+)
+
 internal fun canUseRealAiStarter(
     hasCommand: (String) -> Boolean = ::hasStarterCommand,
     codexReady: () -> Boolean = ::isCodexReadyForStarter,

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -751,26 +751,24 @@ class DesktopAppServiceTest : FunSpec({
         stateStore.load().agentMessages.any { it.kind == "operator-answer" && it.body.contains("Builder") } shouldBe true
     }
 
-    test("operator chat uses LLM planner for vague status requests instead of canned status fallback") {
-        val appHome = Files.createTempDirectory("operator-chat-llm-status-home")
+    test("status operator chat routes through deterministic command without llm") {
+        val appHome = Files.createTempDirectory("operator-chat-status-det-home")
         val stateStore = DesktopStateStore { appHome }
         val service = DesktopAppService(
             stateStore = stateStore,
             gitWorkspaceService = mockk(relaxed = true),
             configRepository = mockk(relaxed = true),
-            agentExecutor = operatorChatLlmExecutor(
-                """{"reply":"제가 상태를 직접 확인해볼게요.","toolCalls":[{"tool":"inspect_runtime","reason":"The user asked whether agents are running.","args":{}}],"answerSourceHints":["company-summary"]}""",
-                "지금 회사 런타임은 멈춰 있고 실행 중인 에이전트는 없습니다. 막힌 이슈나 승인 대기는 없어 바로 목표를 넣고 시작할 수 있습니다."
-            )
+            agentExecutor = mockk(relaxed = true)
         )
-        val company = service.createCompany(name = "Operator Chat LLM", rootPath = appHome.toString())
+        val company = service.createCompany(name = "Operator Chat Status", rootPath = appHome.toString())
 
         val response = service.runOperatorChat(company.id, "에이전트들 잘 돌아가?")
 
+        response.message shouldContain "확인했습니다"
+        response.message shouldContain "런타임"
         response.message shouldContain "실행 중인 에이전트"
         response.message shouldNotContain "Runtime"
-        response.answerSources.any { it.type == "company-summary" } shouldBe true
-        response.actions.shouldBeEmpty()
+        response.actions.any { it.type == "status-check" } shouldBe true
         response.blockedActions.shouldBeEmpty()
     }
 
@@ -806,7 +804,7 @@ class DesktopAppServiceTest : FunSpec({
         )
         val company = service.createCompany(name = "Operator Chat Non JSON", rootPath = appHome.toString())
 
-        val response = service.runOperatorChat(company.id, "에이전트들 잘 돌아가?")
+        val response = service.runOperatorChat(company.id, "지금 에이전트 몇 개 실행 중이야?")
 
         response.message shouldContain "현재 런타임"
         response.message shouldContain "실행 중인 에이전트"
@@ -13931,6 +13929,471 @@ class DesktopAppServiceTest : FunSpec({
         summary.baseBranch shouldBe "master"
         summary.patch shouldBe ""
         summary.changedFiles.shouldBeEmpty()
+    }
+
+    test("manual runtime stop marks active qa issue as recoverable interrupted") {
+        val appHome = Files.createTempDirectory("qa-interrupted-home")
+        val repoRoot = Files.createTempDirectory("qa-interrupted-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = Company(
+            id = "co-qa-interrupted",
+            name = "QA Interrupted Co",
+            rootPath = repoRoot.toString(),
+            repositoryId = REPOSITORY_ID,
+            defaultBaseBranch = "master",
+            createdAt = 1L, updatedAt = 1L
+        )
+        val goal = CompanyGoal(
+            id = "goal-qa-interrupted",
+            companyId = company.id,
+            projectContextId = "proj-qa-int",
+            title = "QA interrupted",
+            description = "QA issue was running when runtime stopped",
+            status = GoalStatus.ACTIVE,
+            autonomyEnabled = false,
+            createdAt = 2L, updatedAt = 2L
+        )
+        val execIssue = CompanyIssue(
+            id = "issue-exec-qa-int",
+            companyId = company.id,
+            projectContextId = "proj-qa-int",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Implement feature",
+            description = "Write the code",
+            status = IssueStatus.DONE,
+            kind = "execution",
+            createdAt = 3L, updatedAt = 3L
+        )
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-int",
+            companyId = company.id,
+            projectContextId = "proj-qa-int",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Review feature branch",
+            description = "QA checks the implementation.",
+            status = IssueStatus.BLOCKED,
+            kind = "review",
+            dependsOn = listOf(execIssue.id),
+            sourceSignal = "qa-review:${execIssue.id}",
+            providerBlockReason = "Execution was interrupted because the app-server stopped before the run finished.",
+            transitionReason = "Runtime stopped while execution was in progress; the issue was returned to the queue.",
+            createdAt = 4L, updatedAt = 4L
+        )
+        val qaTask = AgentTask(
+            id = "task-qa-int",
+            workspaceId = WORKSPACE_ID,
+            issueId = qaIssue.id,
+            title = qaIssue.title,
+            prompt = qaIssue.description,
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.FAILED,
+            createdAt = 5L, updatedAt = 5L
+        )
+        val qaRun = AgentRun(
+            id = "run-qa-int",
+            taskId = qaTask.id,
+            workspaceId = WORKSPACE_ID,
+            repositoryId = REPOSITORY_ID,
+            agentName = "opencode",
+            branchName = "codex/cotor/qa-int/opencode",
+            worktreePath = repoRoot.toString(),
+            status = AgentRunStatus.FAILED,
+            error = "Execution was interrupted because the app-server stopped before the run finished.",
+            createdAt = 6L, updatedAt = 6L
+        )
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company),
+                repositories = listOf(
+                    ManagedRepository(
+                        id = REPOSITORY_ID, name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
+                        name = "repo · master", baseBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                projectContexts = listOf(
+                    CompanyProjectContext(
+                        id = "proj-qa-int",
+                        companyId = company.id,
+                        name = "QA Interrupted Co",
+                        slug = "qa-int-co",
+                        contextDocPath = appHome.resolve("project.md").toString(),
+                        lastUpdatedAt = 1L
+                    )
+                ),
+                goals = listOf(goal),
+                issues = listOf(execIssue, qaIssue),
+                tasks = listOf(qaTask),
+                runs = listOf(qaRun)
+            )
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+
+        val log = service.executionLog(company.id)
+        val qaEntry = log.first { it["issueId"] == qaIssue.id }
+
+        qaEntry["blockedReasonCode"] shouldBe BlockedReasonCode.RUNTIME_INTERRUPTED.name
+        qaEntry["blockedRetryable"] shouldBe true
+    }
+
+    test("runtime start requeues recoverable runtime interrupted review issue") {
+        val appHome = Files.createTempDirectory("qa-requeue-int-home")
+        val repoRoot = Files.createTempDirectory("qa-requeue-int-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = Company(
+            id = "co-qa-requeue-int",
+            name = "QA Requeue Interrupted Co",
+            rootPath = repoRoot.toString(),
+            repositoryId = REPOSITORY_ID,
+            defaultBaseBranch = "master",
+            createdAt = 1L, updatedAt = 1L
+        )
+        val goal = CompanyGoal(
+            id = "goal-qa-requeue-int",
+            companyId = company.id,
+            projectContextId = "proj-qa-req",
+            title = "QA requeue interrupted",
+            description = "Interrupted QA review should be retried on restart",
+            status = GoalStatus.ACTIVE,
+            autonomyEnabled = false,
+            createdAt = 2L, updatedAt = 2L
+        )
+        val execIssue = CompanyIssue(
+            id = "issue-exec-qa-req",
+            companyId = company.id,
+            projectContextId = "proj-qa-req",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Implement feature",
+            description = "Write the code",
+            status = IssueStatus.DONE,
+            kind = "execution",
+            createdAt = 3L, updatedAt = 3L
+        )
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-req",
+            companyId = company.id,
+            projectContextId = "proj-qa-req",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Review feature branch",
+            description = "QA checks the implementation.",
+            status = IssueStatus.BLOCKED,
+            kind = "review",
+            dependsOn = listOf(execIssue.id),
+            sourceSignal = "qa-review:${execIssue.id}",
+            providerBlockReason = "Execution was interrupted because the app-server stopped before the run finished.",
+            transitionReason = "Runtime stopped while execution was in progress; the issue was returned to the queue.",
+            createdAt = 4L, updatedAt = 4L
+        )
+        val qaTask = AgentTask(
+            id = "task-qa-req",
+            workspaceId = WORKSPACE_ID,
+            issueId = qaIssue.id,
+            title = qaIssue.title,
+            prompt = qaIssue.description,
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.FAILED,
+            createdAt = 5L, updatedAt = 5L
+        )
+        val qaRun = AgentRun(
+            id = "run-qa-req",
+            taskId = qaTask.id,
+            workspaceId = WORKSPACE_ID,
+            repositoryId = REPOSITORY_ID,
+            agentName = "opencode",
+            branchName = "codex/cotor/qa-req/opencode",
+            worktreePath = repoRoot.toString(),
+            status = AgentRunStatus.FAILED,
+            error = "Execution was interrupted because the app-server stopped before the run finished.",
+            createdAt = 6L, updatedAt = 6L
+        )
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company),
+                repositories = listOf(
+                    ManagedRepository(
+                        id = REPOSITORY_ID, name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
+                        name = "repo · master", baseBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                projectContexts = listOf(
+                    CompanyProjectContext(
+                        id = "proj-qa-req",
+                        companyId = company.id,
+                        name = "QA Requeue Interrupted Co",
+                        slug = "qa-req-co",
+                        contextDocPath = appHome.resolve("project.md").toString(),
+                        lastUpdatedAt = 1L
+                    )
+                ),
+                goals = listOf(goal),
+                issues = listOf(execIssue, qaIssue),
+                tasks = listOf(qaTask),
+                runs = listOf(qaRun)
+            )
+        )
+        val service = testService(
+            processManager = FakeGitProcessManager(
+                repoRoot = repoRoot,
+                remoteUrl = null,
+                defaultBranch = "master"
+            ),
+            stateStore = stateStore
+        )
+
+        service.companyDashboard(company.id)
+
+        withTimeout(5_000) {
+            while (true) {
+                service.companyDashboard(company.id)
+                val latestIssue = stateStore.load().issues.first { it.id == qaIssue.id }
+                if (latestIssue.status == IssueStatus.PLANNED || latestIssue.status == IssueStatus.IN_PROGRESS) {
+                    latestIssue.blockedBy.shouldBeEmpty()
+                    return@withTimeout
+                }
+                delay(25)
+            }
+        }
+    }
+
+    test("completed source issue stays done when qa review is interrupted") {
+        val appHome = Files.createTempDirectory("qa-src-done-home")
+        val repoRoot = Files.createTempDirectory("qa-src-done-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = Company(
+            id = "co-qa-src-done",
+            name = "QA Src Done Co",
+            rootPath = repoRoot.toString(),
+            repositoryId = REPOSITORY_ID,
+            defaultBaseBranch = "master",
+            createdAt = 1L, updatedAt = 1L
+        )
+        val goal = CompanyGoal(
+            id = "goal-qa-src-done",
+            companyId = company.id,
+            projectContextId = "proj-qa-src",
+            title = "Source stays done",
+            description = "Source issue should stay DONE when QA is interrupted",
+            status = GoalStatus.ACTIVE,
+            autonomyEnabled = false,
+            createdAt = 2L, updatedAt = 2L
+        )
+        val execIssue = CompanyIssue(
+            id = "issue-exec-src-done",
+            companyId = company.id,
+            projectContextId = "proj-qa-src",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Implement feature",
+            description = "Write the code",
+            status = IssueStatus.DONE,
+            kind = "execution",
+            createdAt = 3L, updatedAt = 3L
+        )
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-src-done",
+            companyId = company.id,
+            projectContextId = "proj-qa-src",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Review feature branch",
+            description = "QA checks the implementation.",
+            status = IssueStatus.BLOCKED,
+            kind = "review",
+            dependsOn = listOf(execIssue.id),
+            sourceSignal = "qa-review:${execIssue.id}",
+            providerBlockReason = "Execution was interrupted because the app-server stopped before the run finished.",
+            transitionReason = "Runtime stopped while execution was in progress; the issue was returned to the queue.",
+            createdAt = 4L, updatedAt = 4L
+        )
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company),
+                repositories = listOf(
+                    ManagedRepository(
+                        id = REPOSITORY_ID, name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
+                        name = "repo · master", baseBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                projectContexts = listOf(
+                    CompanyProjectContext(
+                        id = "proj-qa-src",
+                        companyId = company.id,
+                        name = "QA Src Done Co",
+                        slug = "qa-src-done-co",
+                        contextDocPath = appHome.resolve("project.md").toString(),
+                        lastUpdatedAt = 1L
+                    )
+                ),
+                goals = listOf(goal),
+                issues = listOf(execIssue, qaIssue)
+            )
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+
+        val log = service.executionLog(company.id)
+        val execEntry = log.first { it["issueId"] == execIssue.id }
+        val qaEntry = log.first { it["issueId"] == qaIssue.id }
+
+        execEntry["issueStatus"] shouldBe IssueStatus.DONE.name
+        qaEntry["blockedReasonCode"] shouldBe BlockedReasonCode.RUNTIME_INTERRUPTED.name
+    }
+
+    test("review queue remains awaiting qa when qa review is interrupted by stop") {
+        val appHome = Files.createTempDirectory("qa-rq-awaiting-home")
+        val repoRoot = Files.createTempDirectory("qa-rq-awaiting-repo")
+        val stateStore = DesktopStateStore { appHome }
+        val company = Company(
+            id = "co-qa-rq-await",
+            name = "QA RQ Awaiting Co",
+            rootPath = repoRoot.toString(),
+            repositoryId = REPOSITORY_ID,
+            defaultBaseBranch = "master",
+            createdAt = 1L, updatedAt = 1L
+        )
+        val goal = CompanyGoal(
+            id = "goal-qa-rq-await",
+            companyId = company.id,
+            projectContextId = "proj-qa-rq",
+            title = "RQ stays awaiting qa",
+            description = "ReviewQueue entry should remain AWAITING_QA after QA issue is interrupted",
+            status = GoalStatus.ACTIVE,
+            autonomyEnabled = false,
+            createdAt = 2L, updatedAt = 2L
+        )
+        val execIssue = CompanyIssue(
+            id = "issue-exec-rq-await",
+            companyId = company.id,
+            projectContextId = "proj-qa-rq",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Implement feature",
+            description = "Write the code",
+            status = IssueStatus.DONE,
+            kind = "execution",
+            createdAt = 3L, updatedAt = 3L
+        )
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-rq-await",
+            companyId = company.id,
+            projectContextId = "proj-qa-rq",
+            goalId = goal.id,
+            workspaceId = WORKSPACE_ID,
+            title = "Review feature branch",
+            description = "QA checks the implementation.",
+            status = IssueStatus.BLOCKED,
+            kind = "review",
+            dependsOn = listOf(execIssue.id),
+            sourceSignal = "qa-review:${execIssue.id}",
+            providerBlockReason = "Execution was interrupted because the app-server stopped before the run finished.",
+            transitionReason = "Runtime stopped while execution was in progress; the issue was returned to the queue.",
+            createdAt = 4L, updatedAt = 4L
+        )
+        val rqItem = ReviewQueueItem(
+            id = "rq-qa-await",
+            companyId = company.id,
+            issueId = execIssue.id,
+            runId = "run-exec-done",
+            status = ReviewQueueStatus.AWAITING_QA,
+            qaIssueId = qaIssue.id,
+            createdAt = 5L, updatedAt = 5L
+        )
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company),
+                repositories = listOf(
+                    ManagedRepository(
+                        id = REPOSITORY_ID, name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
+                        name = "repo · master", baseBranch = "master",
+                        createdAt = 1L, updatedAt = 1L
+                    )
+                ),
+                projectContexts = listOf(
+                    CompanyProjectContext(
+                        id = "proj-qa-rq",
+                        companyId = company.id,
+                        name = "QA RQ Awaiting Co",
+                        slug = "qa-rq-await-co",
+                        contextDocPath = appHome.resolve("project.md").toString(),
+                        lastUpdatedAt = 1L
+                    )
+                ),
+                goals = listOf(goal),
+                issues = listOf(execIssue, qaIssue),
+                reviewQueue = listOf(rqItem)
+            )
+        )
+        val service = testService(
+            processManager = FakeGitProcessManager(
+                repoRoot = repoRoot,
+                remoteUrl = null,
+                defaultBranch = "master"
+            ),
+            stateStore = stateStore
+        )
+
+        service.companyDashboard(company.id)
+
+        val state = stateStore.load()
+        val rqState = state.reviewQueue.first { it.id == rqItem.id }
+        val execState = state.issues.first { it.id == execIssue.id }
+
+        execState.status shouldBe IssueStatus.DONE
+        rqState.status shouldBe ReviewQueueStatus.AWAITING_QA
+        rqState.qaIssueId shouldBe qaIssue.id
     }
 })
 

--- a/src/test/kotlin/com/cotor/app/DesktopTuiSessionServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopTuiSessionServiceTest.kt
@@ -57,6 +57,107 @@ class DesktopTuiSessionServiceTest : FunSpec({
         service.shutdown()
     }
 
+    test("openSession reuses only same workspace session") {
+        val appHome = Files.createTempDirectory("desktop-tui-session-home")
+        val repoRoot = Files.createTempDirectory("desktop-tui-session-repo")
+        val stateStore = DesktopStateStore { appHome }
+        stateStore.save(
+            DesktopAppState(
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
+                        createdAt = 1, updatedAt = 1
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(id = "workspace-1", repositoryId = "repo-1", name = "repo · master", baseBranch = "master", createdAt = 1, updatedAt = 1),
+                    Workspace(id = "workspace-2", repositoryId = "repo-1", name = "repo · dev", baseBranch = "dev", createdAt = 2, updatedAt = 2)
+                )
+            )
+        )
+        val service = DesktopTuiSessionService(
+            stateStore = stateStore,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            yamlParser = YamlParser(),
+            logger = mockk(relaxed = true)
+        )
+
+        val first = service.openSession("workspace-1", preferredAgent = "echo")
+        val reused = service.openSession("workspace-1", preferredAgent = "echo")
+
+        reused.id shouldBe first.id
+
+        service.shutdown()
+    }
+
+    test("openSession creates new session for different workspace even when old session is alive") {
+        val appHome = Files.createTempDirectory("desktop-tui-session-home")
+        val repoRoot = Files.createTempDirectory("desktop-tui-session-repo")
+        val stateStore = DesktopStateStore { appHome }
+        stateStore.save(
+            DesktopAppState(
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
+                        createdAt = 1, updatedAt = 1
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(id = "workspace-1", repositoryId = "repo-1", name = "repo · master", baseBranch = "master", createdAt = 1, updatedAt = 1),
+                    Workspace(id = "workspace-2", repositoryId = "repo-1", name = "repo · dev", baseBranch = "dev", createdAt = 2, updatedAt = 2)
+                )
+            )
+        )
+        val service = DesktopTuiSessionService(
+            stateStore = stateStore,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            yamlParser = YamlParser(),
+            logger = mockk(relaxed = true)
+        )
+
+        val ws1Session = service.openSession("workspace-1", preferredAgent = "echo")
+        val ws2Session = service.openSession("workspace-2", preferredAgent = "echo")
+
+        ws2Session.id shouldNotBe ws1Session.id
+        ws2Session.workspaceId shouldBe "workspace-2"
+
+        service.shutdown()
+    }
+
+    test("session repositoryPath always matches requested workspace repository") {
+        val appHome = Files.createTempDirectory("desktop-tui-session-home")
+        val repoRoot = Files.createTempDirectory("desktop-tui-session-repo")
+        val stateStore = DesktopStateStore { appHome }
+        stateStore.save(
+            DesktopAppState(
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
+                        createdAt = 1, updatedAt = 1
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(id = "workspace-1", repositoryId = "repo-1", name = "repo · master", baseBranch = "master", createdAt = 1, updatedAt = 1)
+                )
+            )
+        )
+        val service = DesktopTuiSessionService(
+            stateStore = stateStore,
+            configRepository = mockk<ConfigRepository>(relaxed = true),
+            yamlParser = YamlParser(),
+            logger = mockk(relaxed = true)
+        )
+
+        val session = service.openSession("workspace-1", preferredAgent = "echo")
+
+        session.repositoryPath shouldBe repoRoot.toString()
+
+        service.shutdown()
+    }
+
     test("terminateSession returns an exited snapshot and removes the session") {
         val appHome = Files.createTempDirectory("desktop-tui-session-home")
         val repoRoot = Files.createTempDirectory("desktop-tui-session-repo")

--- a/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
@@ -766,12 +766,14 @@ class OpenCodePluginTest : FunSpec({
         }
     }
 
-    test("writes planning-only opencode agent config and passes agent flag") {
+    test("planning-only opencode uses isolated stdin prompt and config content") {
         val workDir = Files.createTempDirectory("cotor-test-opencode-config-")
         val plugin = OpenCodePlugin()
         var sawAgentFlag = false
-        var configExistedDuringRun = false
-        var configTextDuringRun = ""
+        var sawPureFlag = false
+        var capturedInputPath: Path? = null
+        var capturedInputText: String? = null
+        var capturedEnvironment: Map<String, String> = emptyMap()
         val processManager = object : ProcessManager {
             override suspend fun executeProcess(
                 command: List<String>,
@@ -789,9 +791,8 @@ class OpenCodePluginTest : FunSpec({
                 )
                 else -> {
                     sawAgentFlag = command.windowed(2).any { it == listOf("--agent", "cotor-plan") }
-                    val configPath = workDir.resolve(".opencode").resolve("opencode.json")
-                    configExistedDuringRun = Files.exists(configPath)
-                    configTextDuringRun = if (configExistedDuringRun) Files.readString(configPath) else ""
+                    sawPureFlag = "--pure" in command
+                    capturedEnvironment = environment
                     ProcessResult(
                         exitCode = 0,
                         stdout = """{"type":"text","text":"done"}""",
@@ -799,6 +800,30 @@ class OpenCodePluginTest : FunSpec({
                         isSuccess = true
                     )
                 }
+            }
+
+            override suspend fun executeProcessWithInputFile(
+                command: List<String>,
+                inputFile: Path,
+                environment: Map<String, String>,
+                timeout: Long,
+                workingDirectory: Path?,
+                onStart: ((Long) -> Unit)?,
+                onStdoutChunk: ((String) -> Unit)?,
+                onStderrChunk: ((String) -> Unit)?
+            ): ProcessResult {
+                capturedInputPath = inputFile
+                capturedInputText = Files.readString(inputFile)
+                return executeProcess(
+                    command = command,
+                    input = Files.readString(inputFile),
+                    environment = environment,
+                    timeout = timeout,
+                    workingDirectory = workingDirectory,
+                    onStart = onStart,
+                    onStdoutChunk = onStdoutChunk,
+                    onStderrChunk = onStderrChunk
+                )
             }
         }
 
@@ -820,13 +845,14 @@ class OpenCodePluginTest : FunSpec({
             )
 
             sawAgentFlag shouldBe true
-            configExistedDuringRun shouldBe true
-            configTextDuringRun.contains("cotor-plan") shouldBe true
-            configTextDuringRun.contains("\"external_directory\": \"deny\"") shouldBe true
-            configTextDuringRun.contains("\"question\": \"deny\"") shouldBe true
-            configTextDuringRun.contains("\"task\": false") shouldBe true
-            configTextDuringRun.contains("\"task\": \"deny\"") shouldBe true
-            configTextDuringRun.contains("\"read\": false") shouldBe true
+            sawPureFlag shouldBe true
+            capturedInputPath?.startsWith(workDir.resolve(".cotor/runtime/opencode-prompts")) shouldBe true
+            capturedInputText shouldBe "hello"
+            capturedEnvironment["OPENCODE_DISABLE_PROJECT_CONFIG"] shouldBe "true"
+            capturedEnvironment["OPENCODE_DISABLE_DEFAULT_PLUGINS"] shouldBe "true"
+            capturedEnvironment["OPENCODE_CONFIG_CONTENT"].orEmpty().contains("cotor-plan") shouldBe true
+            capturedEnvironment["OPENCODE_CONFIG_CONTENT"].orEmpty().contains("\"external_directory\": \"deny\"") shouldBe true
+            capturedEnvironment["OPENCODE_CONFIG_CONTENT"].orEmpty().contains("\"read\": false") shouldBe true
             Files.exists(workDir.resolve(".opencode").resolve("opencode.json")) shouldBe false
         } finally {
             workDir.toFile().deleteRecursively()

--- a/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
+++ b/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
@@ -162,6 +162,24 @@ class ProcessManagerTest : FunSpec({
         result.stdout shouldContain "line-19999"
     }
 
+    test("executeProcessWithInputFile redirects stdin from a real file") {
+        val processManager = CoroutineProcessManager(mockk<Logger>(relaxed = true))
+        val inputFile = Files.createTempFile("process-manager-input-", ".txt")
+        Files.writeString(inputFile, "file-backed-stdin")
+
+        val result = processManager.executeProcessWithInputFile(
+            command = listOf("/bin/sh", "-c", "cat"),
+            inputFile = inputFile,
+            environment = emptyMap(),
+            timeout = 5_000,
+            onStdoutChunk = null,
+            onStderrChunk = null
+        )
+
+        result.isSuccess shouldBe true
+        result.stdout shouldBe "file-backed-stdin"
+    }
+
     test("effectiveUserHome prefers HOME from the environment over user.home") {
         effectiveUserHome(
             environment = mapOf("HOME" to "/tmp/cotor-home"),

--- a/src/test/kotlin/com/cotor/presentation/cli/CliGoldenSnapshotTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/CliGoldenSnapshotTest.kt
@@ -151,7 +151,7 @@ class CliGoldenSnapshotTest : FunSpec({
 
 private fun createDoctorFixture(projectRoot: Path) {
     projectRoot.resolve("build/libs").createDirectories()
-    projectRoot.resolve("build/libs/cotor-1.0.0-all.jar").writeText("jar")
+    projectRoot.resolve("build/libs/cotor-1.0.6-all.jar").writeText("jar")
     projectRoot.resolve("cotor.yaml").writeText("version: \"1.0\"")
 
     projectRoot.resolve("examples").createDirectories()

--- a/src/test/kotlin/com/cotor/presentation/cli/InitCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/InitCommandTest.kt
@@ -58,6 +58,8 @@ class InitCommandTest : FunSpec({
             pipelineDocPath.exists() shouldBe true
 
             configText shouldContain "imports:\n  - \"pipelines/default.yaml\""
+            configText shouldContain "pluginClass: com.cotor.data.plugin.EchoPlugin"
+            configText shouldContain "allowedExecutables:\n    - echo"
             pipelinePath.readText() shouldContain "description: \"Starter workflow for ${root.fileName}\""
             readmePath.readText() shouldContain "Project: `${root.fileName}`"
             readmePath.readText() shouldContain "Default agent: `$agentName`"

--- a/src/test/resources/snapshots/cli/doctor.txt
+++ b/src/test/resources/snapshots/cli/doctor.txt
@@ -4,7 +4,7 @@
 [32m✓[39m Java 버전 확인
 [2m   Java 21.0.2[22m
 [32m✓[39m CLI JAR 존재 여부
-[2m   빌드 결과 발견: cotor-1.0.0-all.jar[22m
+[2m   빌드 결과 발견: cotor-1.0.6-all.jar[22m
 [32m✓[39m cotor.yaml 확인
 [2m   구성 파일 발견: cotor.yaml[22m
 [32m✓[39m 예제 번들 확인


### PR DESCRIPTION
## Summary

- **Operator chat fast path**: status keywords ("상태 확인", "잘 돌아가?", "health", etc.) bypass LLM planner entirely and return a deterministic Korean status message in <1s
- **TUI workspace fix**: `refreshTuiSessionList` no longer falls back to `sessions.first`; only adopts a session when `workspaceId` matches `selectedWorkspaceID`, preventing stale workspace overrides
- **Issue detail isolation**: `refreshTaskDetails` eagerly clears `runs`/`changes`/`files`/`ports`/`browserURL` before any async fetch so the inspector never flashes data from the previous issue
- **Runtime interrupted UX**: `BLOCKED` issues caused by manual stop now carry `blockedReasonCode=RUNTIME_INTERRUPTED` + `blockedRetryable=true`; UI can distinguish recoverable pause from real failure, and next runtime start requeues these issues automatically
- **Skill run card**: `runSkill` result is recorded in `recentSkillRunResults` for per-card status display; team tab button label clarified
- **QA/review flow**: interrupted QA issues preserve source issue as DONE and review queue as AWAITING_QA; QA issue is marked recoverable and requeued on next start

## Tests

**Kotlin (169 passing)**
- `status operator chat routes through deterministic command without llm`
- `operator chat recovers tool choice from non-json LLM planner output` (fixed routing)
- `manual runtime stop marks active qa issue as recoverable interrupted`
- `runtime start requeues recoverable runtime interrupted review issue`
- `completed source issue stays done when qa review is interrupted`
- `review queue remains awaiting qa when qa review is interrupted by stop`

**Swift (all passing)**
- `refreshTuiSessionListDoesNotOverwriteSelectedWorkspaceWithFirstSession`
- `refreshTuiSessionListSetsNilWhenNoSessionMatchesSelectedWorkspace`
- `selectingExplicitTuiSessionMovesWorkspaceAndRepositorySelection`
- `issueBlockedReasonCodeDecodesRuntimeInterruptedVariant`

## Test plan
- [x] `./gradlew test` — 169 tests, 0 failures
- [x] `cd macos && swift test` — all passing
- [x] `cd macos && swift build` — build complete
- [x] `graphify update .` — graph refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)