### PR TITLE
Fix desktop runtime, app-server state, and skill execution

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - cotor  (2026-05-19)
 
 ## Corpus Check
-- 363 files · ~617,596 words
+- 363 files · ~617,866 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4807 nodes · 6682 edges · 304 communities detected
+- 4808 nodes · 6683 edges · 305 communities detected
 - Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 797 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -218,7 +218,7 @@
 - [[_COMMUNITY_Community 205|Community 205]]
 - [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
-- [[_COMMUNITY_Community 209|Community 209]]
+- [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 210|Community 210]]
 - [[_COMMUNITY_Community 211|Community 211]]
 - [[_COMMUNITY_Community 212|Community 212]]
@@ -228,7 +228,7 @@
 - [[_COMMUNITY_Community 216|Community 216]]
 - [[_COMMUNITY_Community 217|Community 217]]
 - [[_COMMUNITY_Community 218|Community 218]]
-- [[_COMMUNITY_Community 220|Community 220]]
+- [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 221|Community 221]]
 - [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 223|Community 223]]
@@ -311,9 +311,10 @@
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
-- [[_COMMUNITY_Community 305|Community 305]]
-- [[_COMMUNITY_Community 307|Community 307]]
+- [[_COMMUNITY_Community 303|Community 303]]
+- [[_COMMUNITY_Community 306|Community 306]]
 - [[_COMMUNITY_Community 308|Community 308]]
+- [[_COMMUNITY_Community 309|Community 309]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DesktopStore` - 254 edges
@@ -351,7 +352,7 @@ Nodes (264): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, appr
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (163): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+155 more)
+Nodes (161): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+153 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
@@ -359,7 +360,7 @@ Nodes (18): CompanyMarketingDashboardProjection, availableAgentModels(), company
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (36): ActionStore, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, FakeHttpResponse, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data (+28 more)
+Nodes (33): ActionStore, FakeHttpResponse, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload (+25 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
@@ -371,7 +372,7 @@ Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgent
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+116 more)
+Nodes (125): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+117 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
@@ -402,28 +403,28 @@ Cohesion: 0.04
 Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (8): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, Color
+Cohesion: 0.05
+Nodes (51): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+43 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.05
-Nodes (50): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+42 more)
-
-### Community 17 - "Community 17"
 Cohesion: 0.1
 Nodes (5): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DesktopStoreTests
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.04
 Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.11
+Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
 
 ### Community 21 - "Community 21"
 Cohesion: 0.05
@@ -503,23 +504,23 @@ Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success
 
 ### Community 40 - "Community 40"
 Cohesion: 0.11
-Nodes (1): TemplateCommand
+Nodes (2): CoroutineProcessManager, ProcessManager
 
 ### Community 41 - "Community 41"
-Cohesion: 0.12
-Nodes (1): A2aRouter
+Cohesion: 0.11
+Nodes (1): TemplateCommand
 
 ### Community 42 - "Community 42"
 Cohesion: 0.12
-Nodes (1): DurableRuntimeService
+Nodes (1): A2aRouter
 
 ### Community 43 - "Community 43"
 Cohesion: 0.12
-Nodes (2): ConfigRepository, ParsedConfig
+Nodes (1): DurableRuntimeService
 
 ### Community 44 - "Community 44"
 Cohesion: 0.12
-Nodes (2): CoroutineProcessManager, ProcessManager
+Nodes (2): ConfigRepository, ParsedConfig
 
 ### Community 45 - "Community 45"
 Cohesion: 0.12
@@ -535,15 +536,15 @@ Nodes (1): AgentCapabilityGuard
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
-Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
+Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
 ### Community 49 - "Community 49"
 Cohesion: 0.12
-Nodes (1): StarterAgentSpec
+Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
 ### Community 50 - "Community 50"
-Cohesion: 0.13
-Nodes (1): Scanner
+Cohesion: 0.12
+Nodes (1): StarterAgentSpec
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
@@ -739,821 +740,825 @@ Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPla
 
 ### Community 99 - "Community 99"
 Cohesion: 0.22
-Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
+Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
 
 ### Community 100 - "Community 100"
 Cohesion: 0.22
-Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
+Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
 ### Community 101 - "Community 101"
 Cohesion: 0.22
-Nodes (1): LocalModelDefaults
+Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
 ### Community 102 - "Community 102"
 Cohesion: 0.22
-Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
+Nodes (1): LocalModelDefaults
 
 ### Community 103 - "Community 103"
 Cohesion: 0.22
-Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
+Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
 ### Community 104 - "Community 104"
 Cohesion: 0.22
-Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
+Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
 ### Community 105 - "Community 105"
-Cohesion: 0.25
-Nodes (1): BoardController
+Cohesion: 0.22
+Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
 ### Community 106 - "Community 106"
 Cohesion: 0.25
-Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
+Nodes (1): BoardController
 
 ### Community 107 - "Community 107"
 Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
 ### Community 108 - "Community 108"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 109 - "Community 109"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (1): CompanyIssueReadiness
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (1): ChatSession
 
 ### Community 111 - "Community 111"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (1): OpenCodeDefaults
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
+Nodes (2): JsonParser, YamlParser
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (2): Linter, LintResult
+Nodes (1): DiagramGenerator
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
+Nodes (2): Linter, LintResult
 
 ### Community 116 - "Community 116"
-Cohesion: 0.29
-Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
+Cohesion: 0.25
+Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
 ### Community 117 - "Community 117"
 Cohesion: 0.29
-Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
+Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
 ### Community 118 - "Community 118"
 Cohesion: 0.29
-Nodes (1): LocalModelPluginTest
+Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
 ### Community 119 - "Community 119"
 Cohesion: 0.29
-Nodes (1): DefaultResultAnalyzer
+Nodes (1): LocalModelPluginTest
 
 ### Community 120 - "Community 120"
 Cohesion: 0.29
-Nodes (2): A2aDedupeStore, StoredAck
+Nodes (1): DefaultResultAnalyzer
 
 ### Community 121 - "Community 121"
 Cohesion: 0.29
-Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
+Nodes (2): A2aDedupeStore, StoredAck
 
 ### Community 122 - "Community 122"
 Cohesion: 0.29
-Nodes (2): A2aSessionPersistenceStore, Snapshot
+Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
 ### Community 123 - "Community 123"
 Cohesion: 0.29
-Nodes (1): DurableResumeCoordinator
+Nodes (2): A2aSessionPersistenceStore, Snapshot
 
 ### Community 124 - "Community 124"
 Cohesion: 0.29
-Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
+Nodes (1): DurableResumeCoordinator
 
 ### Community 125 - "Community 125"
 Cohesion: 0.29
-Nodes (1): FileReaderPlugin
+Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
 ### Community 126 - "Community 126"
 Cohesion: 0.29
-Nodes (1): OpenAIPlugin
+Nodes (1): FileReaderPlugin
 
 ### Community 127 - "Community 127"
 Cohesion: 0.29
-Nodes (1): InteractiveCommandCompleter
+Nodes (1): OpenAIPlugin
 
 ### Community 128 - "Community 128"
 Cohesion: 0.29
-Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
+Nodes (1): InteractiveCommandCompleter
 
 ### Community 129 - "Community 129"
-Cohesion: 0.33
-Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
+Cohesion: 0.29
+Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
 ### Community 130 - "Community 130"
 Cohesion: 0.33
-Nodes (1): CompanyRuntimeBindingServiceTest
+Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
 ### Community 131 - "Community 131"
 Cohesion: 0.33
-Nodes (1): ProductionReliabilityBaselineTest
+Nodes (1): CompanyRuntimeBindingServiceTest
 
 ### Community 132 - "Community 132"
 Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
+Nodes (1): ProductionReliabilityBaselineTest
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (1): GitHubControlPlaneService
 
 ### Community 135 - "Community 135"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (1): QaVerificationPlugin
 
 ### Community 136 - "Community 136"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (1): CommandPlugin
 
 ### Community 137 - "Community 137"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 138 - "Community 138"
 Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): CodexDashboardCommand
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 140 - "Community 140"
-Cohesion: 0.4
-Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 141 - "Community 141"
 Cohesion: 0.4
-Nodes (1): OpenCodePluginTest
+Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
-Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
+Nodes (1): OpenCodePluginTest
 
 ### Community 143 - "Community 143"
 Cohesion: 0.4
-Nodes (1): CliGoldenSnapshotTest
+Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
 ### Community 144 - "Community 144"
 Cohesion: 0.4
-Nodes (2): CompanyVerificationDecision, CompanyVerifierService
+Nodes (1): CliGoldenSnapshotTest
 
 ### Community 145 - "Community 145"
 Cohesion: 0.4
-Nodes (1): DesktopEndpointPolicy
+Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
 ### Community 146 - "Community 146"
 Cohesion: 0.4
-Nodes (1): LocalPlaywrightMarketingBrowserRunner
+Nodes (1): DesktopEndpointPolicy
 
 ### Community 147 - "Community 147"
 Cohesion: 0.4
-Nodes (1): EvidencePathPolicy
+Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
 ### Community 148 - "Community 148"
 Cohesion: 0.4
-Nodes (1): CompanyRuntimeMachine
+Nodes (1): EvidencePathPolicy
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (1): WorkQueue
+Nodes (1): CompanyRuntimeMachine
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
-Nodes (1): NetworkEndpointPolicy
+Nodes (1): WorkQueue
 
 ### Community 151 - "Community 151"
 Cohesion: 0.4
-Nodes (1): CheckpointGraphStore
+Nodes (1): NetworkEndpointPolicy
 
 ### Community 152 - "Community 152"
 Cohesion: 0.4
-Nodes (1): SideEffectJournalStore
+Nodes (1): CheckpointGraphStore
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
-Nodes (1): ProvenanceStore
+Nodes (1): SideEffectJournalStore
 
 ### Community 154 - "Community 154"
 Cohesion: 0.4
-Nodes (1): CodexDefaults
+Nodes (1): ProvenanceStore
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
-Nodes (1): CotorHttpClients
+Nodes (1): CodexDefaults
 
 ### Community 156 - "Community 156"
 Cohesion: 0.4
-Nodes (2): StuckDetector, StuckSignal
+Nodes (1): CotorHttpClients
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (1): AppServerCommand
+Nodes (2): StuckDetector, StuckSignal
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
-Nodes (2): SyntaxValidationResult, SyntaxValidator
+Nodes (1): AppServerCommand
 
 ### Community 159 - "Community 159"
-Cohesion: 0.5
-Nodes (1): findPrimes()
+Cohesion: 0.4
+Nodes (2): SyntaxValidationResult, SyntaxValidator
 
 ### Community 160 - "Community 160"
 Cohesion: 0.5
-Nodes (1): BoardServiceApplicationTests
+Nodes (1): findPrimes()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.67
-Nodes (2): BoardServiceApplication, main()
+Cohesion: 0.5
+Nodes (1): BoardServiceApplicationTests
 
 ### Community 162 - "Community 162"
 Cohesion: 0.67
-Nodes (2): fromEntity(), PostDetailResponse
+Nodes (2): BoardServiceApplication, main()
 
 ### Community 163 - "Community 163"
 Cohesion: 0.67
-Nodes (2): fromEntity(), PostSummaryResponse
+Nodes (2): fromEntity(), PostDetailResponse
 
 ### Community 164 - "Community 164"
-Cohesion: 0.5
-Nodes (1): PostRepository
+Cohesion: 0.67
+Nodes (2): fromEntity(), PostSummaryResponse
 
 ### Community 165 - "Community 165"
 Cohesion: 0.5
-Nodes (1): Post
+Nodes (1): PostRepository
 
 ### Community 166 - "Community 166"
 Cohesion: 0.5
-Nodes (1): AgentCapabilityGuardTest
+Nodes (1): Post
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceOwnershipTest
+Nodes (1): AgentCapabilityGuardTest
 
 ### Community 168 - "Community 168"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceAgentModelNormalizationTest
+Nodes (1): DesktopAppServiceOwnershipTest
 
 ### Community 169 - "Community 169"
 Cohesion: 0.5
-Nodes (2): CapturingProcessManager, QaVerificationPluginTest
+Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
 ### Community 170 - "Community 170"
 Cohesion: 0.5
-Nodes (2): CommandPluginTest, RecordingProcessManager
+Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
 ### Community 171 - "Community 171"
 Cohesion: 0.5
-Nodes (2): FileReaderPluginTest, NoopProcessManager
+Nodes (2): CommandPluginTest, RecordingProcessManager
 
 ### Community 172 - "Community 172"
 Cohesion: 0.5
-Nodes (1): PipelineOrchestratorPropertyTest
+Nodes (2): FileReaderPluginTest, NoopProcessManager
 
 ### Community 173 - "Community 173"
 Cohesion: 0.5
-Nodes (2): ProviderCatalogEntry, ProviderScanResult
+Nodes (1): PipelineOrchestratorPropertyTest
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
-Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
+Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
 ### Community 175 - "Community 175"
 Cohesion: 0.5
-Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
+Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
 ### Community 176 - "Community 176"
 Cohesion: 0.5
-Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
+Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
 ### Community 177 - "Community 177"
 Cohesion: 0.5
-Nodes (1): StateRepository
+Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
 
 ### Community 178 - "Community 178"
 Cohesion: 0.5
-Nodes (3): ChatMessage, ChatMode, ChatRole
+Nodes (1): StateRepository
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
-Nodes (1): DurableRuntimeFlags
+Nodes (3): ChatMessage, ChatMode, ChatRole
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
-Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
+Nodes (1): DurableRuntimeFlags
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
+Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
 ### Community 182 - "Community 182"
 Cohesion: 0.5
-Nodes (2): TimelineCollector, TimelineResult
+Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
-Nodes (1): StageConflictDetector
+Nodes (2): TimelineCollector, TimelineResult
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (1): SimpleCLI
+Nodes (1): StageConflictDetector
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
-Nodes (2): OutputValidator, StageValidationOutcome
+Nodes (1): SimpleCLI
 
 ### Community 186 - "Community 186"
-Cohesion: 0.67
-Nodes (1): PostCreateRequest
+Cohesion: 0.5
+Nodes (2): OutputValidator, StageValidationOutcome
 
 ### Community 187 - "Community 187"
 Cohesion: 0.67
-Nodes (1): PostUpdateRequest
+Nodes (1): PostCreateRequest
 
 ### Community 188 - "Community 188"
 Cohesion: 0.67
-Nodes (1): VersionConflictException
+Nodes (1): PostUpdateRequest
 
 ### Community 189 - "Community 189"
 Cohesion: 0.67
-Nodes (1): PostNotFoundException
+Nodes (1): VersionConflictException
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): PermissionDeniedException
+Nodes (1): PostNotFoundException
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
+Nodes (1): PermissionDeniedException
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
+Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIntegrationHarness
+Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
+Nodes (1): DesktopAppServiceIntegrationHarness
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceExecutionMemoryTest
+Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
+Nodes (1): DesktopAppServiceExecutionMemoryTest
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): CheckpointFixtureProcess
+Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): CheckpointResumeIntegrationTest
+Nodes (1): CheckpointFixtureProcess
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): RuntimeConstructorConsistencyTest
+Nodes (1): CheckpointResumeIntegrationTest
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): PipelineOrchestratorMapTest
+Nodes (1): RuntimeConstructorConsistencyTest
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): TemplateCommandTest
+Nodes (1): PipelineOrchestratorMapTest
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): InitCommandTest
+Nodes (1): TemplateCommandTest
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (1): ValidateCommandTest
+Nodes (1): InitCommandTest
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): DesktopLifecycleCommandTest
+Nodes (1): ValidateCommandTest
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): ResultAnalyzer
+Nodes (1): DesktopLifecycleCommandTest
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
+Nodes (1): ResultAnalyzer
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (2): VideoPlanRequest, VideoPlanResult
+Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.67
-Nodes (1): DurableRuntimeContext
+Nodes (2): VideoPlanRequest, VideoPlanResult
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (1): HelloCommand
+Nodes (1): DurableRuntimeContext
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (1): WebCommand
+Nodes (1): HelloCommand
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (1): LintCommand
+Nodes (1): WebCommand
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
-Nodes (1): ExplainCommand
+Nodes (1): LintCommand
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
-Nodes (1): CheckpointGCCommand
+Nodes (1): ExplainCommand
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (2): StageTimelineEntry, StageTimelineState
+Nodes (1): CheckpointGCCommand
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (1): PipelineTemplateValidator
+Nodes (2): StageTimelineEntry, StageTimelineState
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): DefaultOutputValidator
+Nodes (1): PipelineTemplateValidator
 
 ### Community 218 - "Community 218"
+Cohesion: 0.67
+Nodes (1): DefaultOutputValidator
+
+### Community 219 - "Community 219"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 1.0
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceMergeConfirmationTest
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreTest
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): AutonomousDiscoveryServiceTest
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (1): SkillModelsTest
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 1.0
 Nodes (1): CompanyRuntimeMachineTest
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 1.0
 Nodes (1): ChatTranscriptWriterTest
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (1): ChatSessionTest
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 1.0
 Nodes (1): NetworkEndpointPolicyTest
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 1.0
 Nodes (1): SecurityValidatorTest
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 1.0
 Nodes (1): A2aArtifactStoreTest
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 1.0
 Nodes (1): A2aApiTest
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 1.0
 Nodes (1): A2aSessionStoreTest
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 1.0
 Nodes (1): A2aDedupeStoreTest
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 1.0
 Nodes (1): RecoveryExecutorTest
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (1): GitHubControlPlaneServiceTest
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (1): StoreConcurrencyTest
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (1): DurableRuntimeServiceTest
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 1.0
 Nodes (1): DurableResumeCoordinatorTest
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 1.0
 Nodes (1): ActionExecutionServiceTest
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 1.0
 Nodes (1): LinearClientEndpointPolicyTest
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (1): VerificationBundleServiceTest
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (1): KnowledgeServiceTest
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (1): LocalModelDefaultsTest
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 1.0
 Nodes (1): ObservabilityServiceTest
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 1.0
 Nodes (1): FileConfigRepositoryTest
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 1.0
 Nodes (1): QaTestGenerationFixtureTest
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (1): ConfigRepositoryImportTest
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 1.0
 Nodes (1): ExampleConfigSmokeTest
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 1.0
 Nodes (1): YamlParserTest
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 1.0
 Nodes (1): CodexPluginTest
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (1): CotorHttpClientsTest
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 1.0
 Nodes (1): ProcessManagerTest
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 1.0
 Nodes (1): ErrorHelperTest
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (1): ResultAggregatorTest
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 1.0
 Nodes (1): ConditionEvaluatorTest
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 1.0
 Nodes (1): AgentExecutorTest
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 1.0
 Nodes (1): StuckDetectorTest
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (1): PipelineGuardServiceTest
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorDagValidationTest
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 1.0
 Nodes (1): StageConflictDetectorTest
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorTemplatingTest
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 1.0
 Nodes (1): CoroutineEventBusTest
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (1): WebServerTest
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 1.0
 Nodes (1): CompletionCommandTest
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 1.0
 Nodes (1): HelpCommandTest
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 1.0
 Nodes (1): AppServerCommandTest
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 1.0
 Nodes (1): StarterAgentResolverTest
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandCompleterTest
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 1.0
 Nodes (1): AgentCommandTest
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 1.0
 Nodes (1): PluginCommandTest
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 1.0
 Nodes (1): AuthCommandTest
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 1.0
 Nodes (1): HelloCommandTest
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 1.0
 Nodes (1): LintCommandTest
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 1.0
 Nodes (1): CompanyCommandTest
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandTest
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 1.0
 Nodes (1): StatsCommandTest
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 1.0
 Nodes (1): CodexDashboardCommandTest
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 1.0
 Nodes (1): StatsManagerTest
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorTest
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorExtTest
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 1.0
 Nodes (1): LinterTest
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 1.0
 Nodes (1): DefaultOutputValidatorTest
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 1.0
 Nodes (1): PolicyEngineTest
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
@@ -1568,21 +1573,19 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 32`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 40`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 41`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 42`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 43`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (17 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `waitForProcessHandles()`, `ProcessManager.kt`
+- **Thin community `Community 44`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 47`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
+- **Thin community `Community 50`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 52`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1624,397 +1627,399 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 95`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 99`** (9 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `AutonomousDiscoveryService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 102`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 106`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 108`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 107`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 109`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 110`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 111`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 112`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 113`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 114`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 115`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 118`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 119`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 120`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 121`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 122`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 123`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 124`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 126`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 127`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 128`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 130`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 131`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 132`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 133`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 134`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 135`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 136`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 137`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 138`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 139`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 140`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 141`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 142`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 143`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (5 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 144`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 145`** (5 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 146`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 147`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 148`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 149`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 150`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 151`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 152`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 153`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 154`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 155`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 156`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 157`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 158`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 159`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 160`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 161`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 162`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 165`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 166`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 167`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 168`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 169`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 170`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 171`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 172`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 173`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 174`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 175`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 177`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 178`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 180`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 183`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 184`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 185`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 186`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 187`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 188`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 189`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 190`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 191`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 192`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 193`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 194`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 197`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 198`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 199`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 200`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 201`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 202`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 203`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 204`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 205`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 206`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 207`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 208`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 210`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 211`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 212`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 213`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 215`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 216`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 217`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 218`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 219`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 221`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 222`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 223`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 224`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 225`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 226`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 227`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 230`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 231`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 232`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 233`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 234`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 235`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 236`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 237`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 238`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 240`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 241`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 242`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 243`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 244`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 245`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 246`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 247`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 248`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 249`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 250`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 251`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 252`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 253`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 254`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 255`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 256`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 257`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 258`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 259`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 260`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 261`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 262`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 263`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 264`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 265`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 267`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 268`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 269`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 270`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 271`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 272`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 273`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 274`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 275`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 276`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 277`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 278`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 279`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 280`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 281`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 282`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 283`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 284`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 285`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 286`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 287`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 288`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 289`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 290`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 291`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 296`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 297`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 298`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 299`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 300`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 301`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 302`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 303`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+- **Thin community `Community 306`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 308`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 309`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 9`, `Community 14`, `Community 16`, `Community 17`, `Community 20`?**
+- **Why does `DesktopStore` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 9`, `Community 14`, `Community 15`, `Community 16`, `Community 19`?**
   _High betweenness centrality (0.093) - this node is a cross-community bridge._
 - **Why does `DesktopTextKey` connect `Community 5` to `Community 3`?**
   _High betweenness centrality (0.026) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 3` to `Community 1`, `Community 2`, `Community 5`, `Community 15`?**
+- **Why does `language` connect `Community 3` to `Community 1`, `Community 2`, `Community 20`, `Community 5`?**
   _High betweenness centrality (0.024) - this node is a cross-community bridge._
 - **Are the 36 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
   _`DesktopStore` has 36 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - cotor  (2026-05-19)
 
 ## Corpus Check
-- 362 files · ~611,788 words
+- 363 files · ~617,506 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4759 nodes · 6573 edges · 306 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 760 edges (avg confidence: 0.8)
+- 4804 nodes · 6668 edges · 306 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 793 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -314,20 +314,20 @@
 - [[_COMMUNITY_Community 303|Community 303]]
 - [[_COMMUNITY_Community 304|Community 304]]
 - [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 310|Community 310]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 247 edges
+1. `DesktopStore` - 254 edges
 2. `DesktopTextKey` - 128 edges
-3. `DesktopAPI` - 97 edges
-4. `CodingKeys` - 95 edges
+3. `CodingKeys` - 106 edges
+4. `DesktopAPI` - 98 edges
 5. `GitWorkspaceService` - 78 edges
-6. `DesktopStoreTests` - 60 edges
+6. `DesktopStoreTests` - 65 edges
 7. `language` - 57 edges
-8. `ModelsTests` - 32 edges
-9. `Data` - 30 edges
-10. `MeetingRoomProjectionTests` - 27 edges
+8. `ModelsTests` - 34 edges
+9. `Data` - 32 edges
+10. `DesktopStateStore` - 30 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `language` --calls--> `userFacingIssueKind()`  [INFERRED]
@@ -345,146 +345,146 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.0
-Nodes (53): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+45 more)
+Nodes (50): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+42 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (185): App, ButtonStyle, CaseIterable, Commands, AgentSkillCardView, AgentWorkSummaryRow, BrowserView, CenterPaneView (+177 more)
+Cohesion: 0.02
+Nodes (26): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+18 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (208): settings(), Codable, AgentSkillCardRecord, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled (+200 more)
+Cohesion: 0.01
+Nodes (166): App, ButtonStyle, CaseIterable, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+158 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (17): CompanyMarketingDashboardProjection, availableAgentModels(), runIssue(), startCompanyRuntime(), stopCompanyRuntime(), updateGoal(), TuiSession, Array (+9 more)
+Nodes (189): Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope (+181 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (35): ActionStore, ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, AppLogger, CompanySidebarDisclosureState (+27 more)
-
-### Community 5 - "Community 5"
 Cohesion: 0.01
 Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
-### Community 6 - "Community 6"
+### Community 5 - "Community 5"
 Cohesion: 0.02
 Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
-### Community 7 - "Community 7"
+### Community 6 - "Community 6"
 Cohesion: 0.02
-Nodes (38): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+30 more)
+Nodes (40): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+32 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.03
+Nodes (18): Scanner, AppLogger, CompanySidebarDisclosureState, Data, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher, isBackendRuntimeJar(), isOwnedEmbeddedBackendHealthData() (+10 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.02
-Nodes (113): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+105 more)
+Cohesion: 0.04
+Nodes (13): ActionStore, ConfigureGitHubOriginPayload, DesktopAPI, EmptyPayload, nonEmpty(), TestBackendPayload, UpdateBackendSettingsPayload, UpdateCompanyBackendPayload (+5 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Nodes (99): AppShellMode, company, tui, ChatAgentProposal, ChatBackendAction, restart, start, stop (+91 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+Nodes (104): CodingKeys, action, activeGoalCount, activeIssueCount, activity, adaptiveTickMs, agentCapabilityProfiles, agentContextEntries (+96 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.02
-Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.03
-Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
+Nodes (35): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step, CodingKey (+27 more)
 
 ### Community 13 - "Community 13"
+Cohesion: 0.02
+Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.02
+Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.03
+Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
+
+### Community 16 - "Community 16"
 Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
-### Community 14 - "Community 14"
-Cohesion: 0.05
-Nodes (54): AppShellMode, company, tui, ChatAgentProposal, ChatBackendAction, restart, start, stop (+46 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.09
-Nodes (5): MeetingRoomBrainGraph, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, Color
-
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.04
 Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
+Cohesion: 0.11
+Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
+
+### Community 21 - "Community 21"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (7): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
-
-### Community 22 - "Community 22"
-Cohesion: 0.06
-Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
-
 ### Community 23 - "Community 23"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (2): CachedState, DesktopStateStore
 
 ### Community 24 - "Community 24"
-Cohesion: 0.07
-Nodes (2): DesktopTuiSessionService, RuntimeSession
+Cohesion: 0.06
+Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
 ### Community 25 - "Community 25"
 Cohesion: 0.07
-Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
+Nodes (2): DesktopTuiSessionService, RuntimeSession
 
 ### Community 26 - "Community 26"
 Cohesion: 0.07
-Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
+Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
 ### Community 27 - "Community 27"
 Cohesion: 0.07
-Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
+Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
 
 ### Community 28 - "Community 28"
+Cohesion: 0.07
+Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
+
+### Community 29 - "Community 29"
 Cohesion: 0.08
 Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 34 - "Community 34"
-Cohesion: 0.1
-Nodes (19): MeetingRoomSceneKeyframeKind, a2aMessage, agentTyping, blockedJump, costPaused, issueAssigned, issueCreated, mergeCompleted (+11 more)
-
 ### Community 35 - "Community 35"
-Cohesion: 0.11
+Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
 ### Community 36 - "Community 36"
@@ -545,23 +545,23 @@ Nodes (1): StarterAgentSpec
 
 ### Community 50 - "Community 50"
 Cohesion: 0.13
-Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
+Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
-Nodes (1): RecoveryExecutor
+Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
 ### Community 52 - "Community 52"
 Cohesion: 0.13
-Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
+Nodes (1): RecoveryExecutor
 
 ### Community 53 - "Community 53"
 Cohesion: 0.13
-Nodes (1): ConditionEvaluator
+Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
 ### Community 54 - "Community 54"
 Cohesion: 0.13
-Nodes (1): Scanner
+Nodes (1): ConditionEvaluator
 
 ### Community 55 - "Community 55"
 Cohesion: 0.14
@@ -604,8 +604,8 @@ Cohesion: 0.15
 Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
 ### Community 65 - "Community 65"
-Cohesion: 0.17
-Nodes (12): MeetingRoomInteractionKind, approvalGranted, blockedEscalation, ceoApprovalRequested, changesRequested, costPaused, handoff, issueAssigned (+4 more)
+Cohesion: 0.15
+Nodes (5): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand
 
 ### Community 66 - "Community 66"
 Cohesion: 0.17
@@ -737,51 +737,51 @@ Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager,
 
 ### Community 98 - "Community 98"
 Cohesion: 0.22
-Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
+Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
 ### Community 99 - "Community 99"
 Cohesion: 0.22
-Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
+Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
 ### Community 100 - "Community 100"
 Cohesion: 0.22
-Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
+Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
 ### Community 101 - "Community 101"
 Cohesion: 0.22
-Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
+Nodes (1): LocalModelDefaults
 
 ### Community 102 - "Community 102"
 Cohesion: 0.22
-Nodes (1): LocalModelDefaults
+Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
 ### Community 103 - "Community 103"
 Cohesion: 0.22
-Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
+Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
 ### Community 104 - "Community 104"
 Cohesion: 0.22
-Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
-
-### Community 105 - "Community 105"
-Cohesion: 0.22
 Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.25
 Nodes (1): A2aArtifactStore
 
-### Community 107 - "Community 107"
+### Community 106 - "Community 106"
 Cohesion: 0.25
 Nodes (1): BoardController
 
-### Community 108 - "Community 108"
+### Community 107 - "Community 107"
 Cohesion: 0.25
 Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.25
 Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+
+### Community 109 - "Community 109"
+Cohesion: 0.25
+Nodes (6): SkillCatalogEntry, SkillRunEvidence, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
@@ -817,103 +817,103 @@ Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyE
 
 ### Community 118 - "Community 118"
 Cohesion: 0.29
-Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
+Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
 ### Community 119 - "Community 119"
 Cohesion: 0.29
-Nodes (1): LocalModelPluginTest
+Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
 ### Community 120 - "Community 120"
 Cohesion: 0.29
-Nodes (1): DefaultResultAnalyzer
+Nodes (1): LocalModelPluginTest
 
 ### Community 121 - "Community 121"
 Cohesion: 0.29
-Nodes (2): A2aDedupeStore, StoredAck
+Nodes (1): DefaultResultAnalyzer
 
 ### Community 122 - "Community 122"
 Cohesion: 0.29
-Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
+Nodes (2): A2aDedupeStore, StoredAck
 
 ### Community 123 - "Community 123"
 Cohesion: 0.29
-Nodes (2): A2aSessionPersistenceStore, Snapshot
+Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
 ### Community 124 - "Community 124"
 Cohesion: 0.29
-Nodes (1): DurableResumeCoordinator
+Nodes (2): A2aSessionPersistenceStore, Snapshot
 
 ### Community 125 - "Community 125"
 Cohesion: 0.29
-Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
+Nodes (1): DurableResumeCoordinator
 
 ### Community 126 - "Community 126"
 Cohesion: 0.29
-Nodes (1): FileReaderPlugin
+Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
 ### Community 127 - "Community 127"
 Cohesion: 0.29
-Nodes (1): OpenAIPlugin
+Nodes (1): FileReaderPlugin
 
 ### Community 128 - "Community 128"
 Cohesion: 0.29
-Nodes (1): InteractiveCommandCompleter
+Nodes (1): OpenAIPlugin
 
 ### Community 129 - "Community 129"
 Cohesion: 0.29
-Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
+Nodes (1): InteractiveCommandCompleter
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
+Cohesion: 0.29
+Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
 ### Community 131 - "Community 131"
 Cohesion: 0.33
-Nodes (1): CompanyRuntimeBindingServiceTest
+Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
 ### Community 132 - "Community 132"
 Cohesion: 0.33
-Nodes (1): ProductionReliabilityBaselineTest
+Nodes (1): CompanyRuntimeBindingServiceTest
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
+Nodes (1): ProductionReliabilityBaselineTest
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 135 - "Community 135"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (1): GitHubControlPlaneService
 
 ### Community 136 - "Community 136"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (1): QaVerificationPlugin
 
 ### Community 137 - "Community 137"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (1): CommandPlugin
 
 ### Community 138 - "Community 138"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): CodexDashboardCommand
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 141 - "Community 141"
-Cohesion: 0.4
-Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 142 - "Community 142"
 Cohesion: 0.4
-Nodes (2): DesktopAppServiceMarketingTest, RecordingMarketingBrowserRunner
+Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
 
 ### Community 143 - "Community 143"
 Cohesion: 0.4
@@ -1021,111 +1021,111 @@ Nodes (1): AgentCapabilityGuardTest
 
 ### Community 169 - "Community 169"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceAgentModelNormalizationTest
+Nodes (1): DesktopAppServiceOwnershipTest
 
 ### Community 170 - "Community 170"
 Cohesion: 0.5
-Nodes (2): CapturingProcessManager, QaVerificationPluginTest
+Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
 ### Community 171 - "Community 171"
 Cohesion: 0.5
-Nodes (2): CommandPluginTest, RecordingProcessManager
+Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
 ### Community 172 - "Community 172"
 Cohesion: 0.5
-Nodes (2): FileReaderPluginTest, NoopProcessManager
+Nodes (2): CommandPluginTest, RecordingProcessManager
 
 ### Community 173 - "Community 173"
 Cohesion: 0.5
-Nodes (1): PipelineOrchestratorPropertyTest
+Nodes (2): FileReaderPluginTest, NoopProcessManager
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
-Nodes (2): ProviderCatalogEntry, ProviderScanResult
+Nodes (1): PipelineOrchestratorPropertyTest
 
 ### Community 175 - "Community 175"
 Cohesion: 0.5
-Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
+Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
 ### Community 176 - "Community 176"
 Cohesion: 0.5
-Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
+Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
 ### Community 177 - "Community 177"
 Cohesion: 0.5
-Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
+Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
 ### Community 178 - "Community 178"
 Cohesion: 0.5
-Nodes (1): StateRepository
+Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
-Nodes (3): ChatMessage, ChatMode, ChatRole
+Nodes (1): StateRepository
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
-Nodes (1): DurableRuntimeFlags
+Nodes (3): ChatMessage, ChatMode, ChatRole
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
+Nodes (1): DurableRuntimeFlags
 
 ### Community 182 - "Community 182"
 Cohesion: 0.5
-Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
+Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
-Nodes (2): TimelineCollector, TimelineResult
+Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (1): StageConflictDetector
+Nodes (2): TimelineCollector, TimelineResult
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
-Nodes (1): SimpleCLI
+Nodes (1): StageConflictDetector
 
 ### Community 186 - "Community 186"
 Cohesion: 0.5
-Nodes (2): OutputValidator, StageValidationOutcome
+Nodes (1): SimpleCLI
 
 ### Community 187 - "Community 187"
-Cohesion: 0.67
-Nodes (1): PostCreateRequest
+Cohesion: 0.5
+Nodes (2): OutputValidator, StageValidationOutcome
 
 ### Community 188 - "Community 188"
 Cohesion: 0.67
-Nodes (1): PostUpdateRequest
+Nodes (1): PostCreateRequest
 
 ### Community 189 - "Community 189"
 Cohesion: 0.67
-Nodes (1): VersionConflictException
+Nodes (1): PostUpdateRequest
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): PostNotFoundException
+Nodes (1): VersionConflictException
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (1): PermissionDeniedException
+Nodes (1): PostNotFoundException
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
+Nodes (1): PermissionDeniedException
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
+Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIntegrationHarness
+Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceOwnershipTest
+Nodes (1): DesktopAppServiceIntegrationHarness
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
@@ -1559,24 +1559,24 @@ Nodes (1): RiskApprovalInterceptorTest
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **988 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+983 more)
+- **1000 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+995 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 23`** (30 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `DesktopStateStore.kt`
+- **Thin community `Community 23`** (34 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 24`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 25`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 27`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 28`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 38`** (18 nodes): `Parser`, `.advance()`, `.and()`, `.check()`, `.comparison()`, `.consume()`, `.equality()`, `.expression()`, `.isAtEnd()`, `.match()`, `.or()`, `.parse()`, `.peek()`, `.previous()`, `.primary()`, `.term()`, `.unary()`, `Parser.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1594,11 +1594,9 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 52`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
+- **Thin community `Community 54`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 55`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1636,13 +1634,13 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 96`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 102`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 106`** (8 nodes): `A2aArtifactStore`, `.append()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `A2aArtifactStore.kt`
+- **Thin community `Community 105`** (8 nodes): `A2aArtifactStore`, `.append()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `A2aArtifactStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 107`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 108`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 107`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 110`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1658,51 +1656,49 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 116`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 119`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 120`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 121`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 122`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 123`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 124`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 125`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 127`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 128`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 129`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 131`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 132`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 133`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 134`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 135`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 136`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 137`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 138`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 139`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 140`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 141`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (5 nodes): `DesktopAppServiceMarketingTest`, `marketingService()`, `RecordingMarketingBrowserRunner`, `.execute()`, `DesktopAppServiceMarketingTest.kt`
+- **Thin community `Community 142`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 143`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1756,51 +1752,51 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 168`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 169`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 170`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 171`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 172`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 173`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 174`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 175`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 176`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 178`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 179`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 181`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 184`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 185`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 186`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 187`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 188`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 189`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 190`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 191`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 192`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 193`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 194`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 195`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 196`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2018,25 +2014,25 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 307`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+- **Thin community `Community 309`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 310`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 7`, `Community 14`, `Community 18`?**
-  _High betweenness centrality (0.091) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 3` to `Community 1`, `Community 2`, `Community 5`, `Community 15`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
-- **Why does `call_linear()` connect `Community 7` to `Community 4`?**
-  _High betweenness centrality (0.025) - this node is a cross-community bridge._
-- **Are the 32 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
-  _`DesktopStore` has 32 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 5 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
-  _`DesktopAPI` has 5 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 19`?**
+  _High betweenness centrality (0.092) - this node is a cross-community bridge._
+- **Why does `TuiSession` connect `Community 1` to `Community 13`?**
+  _High betweenness centrality (0.024) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 4` to `Community 1`?**
+  _High betweenness centrality (0.023) - this node is a cross-community bridge._
+- **Are the 36 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
+  _`DesktopStore` has 36 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
-  _988 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _1000 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
+- **Should `Community 1` be split into smaller, more focused modules?**
+  _Cohesion score 0.02 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - cotor  (2026-05-19)
 
 ## Corpus Check
-- 363 files · ~617,506 words
+- 363 files · ~617,569 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4804 nodes · 6668 edges · 306 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 793 edges (avg confidence: 0.8)
+- 4807 nodes · 6682 edges · 304 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 797 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -218,8 +218,8 @@
 - [[_COMMUNITY_Community 205|Community 205]]
 - [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
-- [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
+- [[_COMMUNITY_Community 210|Community 210]]
 - [[_COMMUNITY_Community 211|Community 211]]
 - [[_COMMUNITY_Community 212|Community 212]]
 - [[_COMMUNITY_Community 213|Community 213]]
@@ -228,8 +228,8 @@
 - [[_COMMUNITY_Community 216|Community 216]]
 - [[_COMMUNITY_Community 217|Community 217]]
 - [[_COMMUNITY_Community 218|Community 218]]
-- [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
+- [[_COMMUNITY_Community 221|Community 221]]
 - [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 223|Community 223]]
 - [[_COMMUNITY_Community 224|Community 224]]
@@ -311,11 +311,9 @@
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
-- [[_COMMUNITY_Community 303|Community 303]]
-- [[_COMMUNITY_Community 304|Community 304]]
+- [[_COMMUNITY_Community 305|Community 305]]
 - [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 309|Community 309]]
-- [[_COMMUNITY_Community 310|Community 310]]
+- [[_COMMUNITY_Community 308|Community 308]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DesktopStore` - 254 edges
@@ -336,10 +334,10 @@
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
 - `language` --calls--> `localizedSourceKind()`  [INFERRED]
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `preparedBrandMark()` --calls--> `Data`  [INFERRED]
-  macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+- `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]
+  macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/Models.swift
 
 ## Communities
 
@@ -348,84 +346,84 @@ Cohesion: 0.0
 Nodes (50): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+42 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (26): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+18 more)
+Cohesion: 0.01
+Nodes (264): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+256 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (166): App, ButtonStyle, CaseIterable, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+158 more)
+Nodes (163): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+155 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (189): Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope (+181 more)
+Nodes (18): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+10 more)
 
 ### Community 4 - "Community 4"
+Cohesion: 0.02
+Nodes (36): ActionStore, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, FakeHttpResponse, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data (+28 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.01
 Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.02
 Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
-### Community 6 - "Community 6"
-Cohesion: 0.02
-Nodes (40): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+32 more)
-
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (18): Scanner, AppLogger, CompanySidebarDisclosureState, Data, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher, isBackendRuntimeJar(), isOwnedEmbeddedBackendHealthData() (+10 more)
+Cohesion: 0.02
+Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+116 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (13): ActionStore, ConfigureGitHubOriginPayload, DesktopAPI, EmptyPayload, nonEmpty(), TestBackendPayload, UpdateBackendSettingsPayload, UpdateCompanyBackendPayload (+5 more)
-
-### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (99): AppShellMode, company, tui, ChatAgentProposal, ChatBackendAction, restart, start, stop (+91 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.02
-Nodes (104): CodingKeys, action, activeGoalCount, activeIssueCount, activity, adaptiveTickMs, agentCapabilityProfiles, agentContextEntries (+96 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.02
 Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
-### Community 12 - "Community 12"
-Cohesion: 0.03
-Nodes (35): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step, CodingKey (+27 more)
+### Community 9 - "Community 9"
+Cohesion: 0.04
+Nodes (18): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+10 more)
 
-### Community 13 - "Community 13"
+### Community 10 - "Community 10"
 Cohesion: 0.02
 Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
 
-### Community 14 - "Community 14"
+### Community 11 - "Community 11"
 Cohesion: 0.02
 Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
 
-### Community 15 - "Community 15"
+### Community 12 - "Community 12"
 Cohesion: 0.03
 Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
 
-### Community 16 - "Community 16"
+### Community 13 - "Community 13"
 Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
-### Community 17 - "Community 17"
+### Community 14 - "Community 14"
 Cohesion: 0.04
-Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
+Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
+
+### Community 15 - "Community 15"
+Cohesion: 0.07
+Nodes (8): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, Color
+
+### Community 16 - "Community 16"
+Cohesion: 0.05
+Nodes (50): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+42 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.1
+Nodes (5): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DesktopStoreTests
 
 ### Community 18 - "Community 18"
 Cohesion: 0.04
-Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
+Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.07
-Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
+Cohesion: 0.04
+Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.11
-Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
+Cohesion: 0.07
+Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.05
@@ -461,79 +459,79 @@ Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
 ### Community 29 - "Community 29"
 Cohesion: 0.08
-Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
+Nodes (4): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel
 
 ### Community 30 - "Community 30"
+Cohesion: 0.08
+Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
+
+### Community 31 - "Community 31"
 Cohesion: 0.15
 Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
+Cohesion: 0.08
+Nodes (6): FakeHttpClient, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
+
+### Community 34 - "Community 34"
 Cohesion: 0.09
 Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
 
-### Community 33 - "Community 33"
+### Community 35 - "Community 35"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
-### Community 36 - "Community 36"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, StageExecution, StageStats, StatsDetails, StatsManager (+1 more)
 
-### Community 37 - "Community 37"
+### Community 39 - "Community 39"
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
 
-### Community 38 - "Community 38"
-Cohesion: 0.11
-Nodes (1): Parser
-
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (1): A2aRouter
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (1): DurableRuntimeService
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (2): CoroutineProcessManager, ProcessManager
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
-### Community 46 - "Community 46"
-Cohesion: 0.12
-Nodes (1): AgentCapabilityGuard
-
 ### Community 47 - "Community 47"
 Cohesion: 0.12
-Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
+Nodes (1): AgentCapabilityGuard
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
@@ -545,7 +543,7 @@ Nodes (1): StarterAgentSpec
 
 ### Community 50 - "Community 50"
 Cohesion: 0.13
-Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
+Nodes (1): Scanner
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
@@ -604,136 +602,136 @@ Cohesion: 0.15
 Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
 ### Community 65 - "Community 65"
-Cohesion: 0.15
-Nodes (5): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand
-
-### Community 66 - "Community 66"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.17
 Nodes (1): GoalDrivenTaskPlannerTest
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.17
 Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.17
 Nodes (11): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionRequest, ActionResult (+3 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.17
 Nodes (4): PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.17
 Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.18
 Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (1): BoardServiceTest
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.18
 Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.18
 Nodes (1): VerificationBundleService
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.18
 Nodes (1): ProvenanceService
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.18
 Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.18
 Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.18
 Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.18
 Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.18
 Nodes (2): ErrorMessages, UserFriendlyError
 
-### Community 84 - "Community 84"
+### Community 83 - "Community 83"
 Cohesion: 0.18
 Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
-### Community 85 - "Community 85"
+### Community 84 - "Community 84"
 Cohesion: 0.18
 Nodes (1): StatsCommand
 
-### Community 86 - "Community 86"
+### Community 85 - "Community 85"
 Cohesion: 0.18
 Nodes (1): DoctorCommand
 
-### Community 87 - "Community 87"
+### Community 86 - "Community 86"
 Cohesion: 0.2
 Nodes (1): TemplateEngineTest
 
-### Community 88 - "Community 88"
+### Community 87 - "Community 87"
 Cohesion: 0.2
 Nodes (1): ChatTranscriptWriter
 
-### Community 89 - "Community 89"
+### Community 88 - "Community 88"
 Cohesion: 0.2
 Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
-### Community 90 - "Community 90"
+### Community 89 - "Community 89"
 Cohesion: 0.2
 Nodes (1): VerificationStore
 
-### Community 91 - "Community 91"
+### Community 90 - "Community 90"
 Cohesion: 0.2
 Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
-### Community 92 - "Community 92"
+### Community 91 - "Community 91"
 Cohesion: 0.2
 Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
-### Community 93 - "Community 93"
+### Community 92 - "Community 92"
 Cohesion: 0.2
 Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
 
-### Community 94 - "Community 94"
+### Community 93 - "Community 93"
 Cohesion: 0.2
 Nodes (1): PolicyStore
 
-### Community 95 - "Community 95"
+### Community 94 - "Community 94"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 96 - "Community 96"
+### Community 95 - "Community 95"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
+
+### Community 97 - "Community 97"
+Cohesion: 0.22
+Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
 ### Community 98 - "Community 98"
 Cohesion: 0.22
@@ -765,805 +763,797 @@ Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallC
 
 ### Community 105 - "Community 105"
 Cohesion: 0.25
-Nodes (1): A2aArtifactStore
+Nodes (1): BoardController
 
 ### Community 106 - "Community 106"
 Cohesion: 0.25
-Nodes (1): BoardController
+Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
 ### Community 107 - "Community 107"
 Cohesion: 0.25
-Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 108 - "Community 108"
 Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+Nodes (1): CompanyIssueReadiness
 
 ### Community 109 - "Community 109"
 Cohesion: 0.25
-Nodes (6): SkillCatalogEntry, SkillRunEvidence, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
+Nodes (1): ChatSession
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 111 - "Community 111"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (1): OpenCodeDefaults
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (2): JsonParser, YamlParser
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (1): DiagramGenerator
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (2): Linter, LintResult
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
-
-### Community 116 - "Community 116"
-Cohesion: 0.25
-Nodes (2): Linter, LintResult
-
-### Community 117 - "Community 117"
-Cohesion: 0.25
 Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
-### Community 118 - "Community 118"
+### Community 116 - "Community 116"
 Cohesion: 0.29
 Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
-### Community 119 - "Community 119"
+### Community 117 - "Community 117"
 Cohesion: 0.29
 Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
-### Community 120 - "Community 120"
+### Community 118 - "Community 118"
 Cohesion: 0.29
 Nodes (1): LocalModelPluginTest
 
-### Community 121 - "Community 121"
+### Community 119 - "Community 119"
 Cohesion: 0.29
 Nodes (1): DefaultResultAnalyzer
 
-### Community 122 - "Community 122"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (2): A2aDedupeStore, StoredAck
 
-### Community 123 - "Community 123"
+### Community 121 - "Community 121"
 Cohesion: 0.29
 Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
-### Community 124 - "Community 124"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (2): A2aSessionPersistenceStore, Snapshot
 
-### Community 125 - "Community 125"
+### Community 123 - "Community 123"
 Cohesion: 0.29
 Nodes (1): DurableResumeCoordinator
 
-### Community 126 - "Community 126"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
-### Community 127 - "Community 127"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (1): FileReaderPlugin
 
-### Community 128 - "Community 128"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (1): OpenAIPlugin
 
-### Community 129 - "Community 129"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (1): InteractiveCommandCompleter
 
-### Community 130 - "Community 130"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
-### Community 131 - "Community 131"
+### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
-### Community 132 - "Community 132"
+### Community 130 - "Community 130"
 Cohesion: 0.33
 Nodes (1): CompanyRuntimeBindingServiceTest
 
-### Community 133 - "Community 133"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (1): ProductionReliabilityBaselineTest
 
-### Community 134 - "Community 134"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
-### Community 135 - "Community 135"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (1): GitHubControlPlaneService
 
-### Community 136 - "Community 136"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (1): QaVerificationPlugin
 
-### Community 137 - "Community 137"
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (1): CommandPlugin
 
-### Community 138 - "Community 138"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (2): DefaultResultAggregator, ResultAggregator
 
-### Community 139 - "Community 139"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (1): CodexDashboardCommand
 
-### Community 140 - "Community 140"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (2): PluginCommand, PluginInitCommand
 
-### Community 141 - "Community 141"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (1): PolicyEngine
 
-### Community 142 - "Community 142"
+### Community 140 - "Community 140"
 Cohesion: 0.4
 Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
 
-### Community 143 - "Community 143"
+### Community 141 - "Community 141"
 Cohesion: 0.4
 Nodes (1): OpenCodePluginTest
 
-### Community 144 - "Community 144"
+### Community 142 - "Community 142"
 Cohesion: 0.4
 Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
-### Community 145 - "Community 145"
+### Community 143 - "Community 143"
 Cohesion: 0.4
 Nodes (1): CliGoldenSnapshotTest
 
-### Community 146 - "Community 146"
+### Community 144 - "Community 144"
 Cohesion: 0.4
 Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
-### Community 147 - "Community 147"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (1): DesktopEndpointPolicy
 
-### Community 148 - "Community 148"
+### Community 146 - "Community 146"
 Cohesion: 0.4
 Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
-### Community 149 - "Community 149"
+### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (1): EvidencePathPolicy
 
-### Community 150 - "Community 150"
+### Community 148 - "Community 148"
 Cohesion: 0.4
 Nodes (1): CompanyRuntimeMachine
 
-### Community 151 - "Community 151"
+### Community 149 - "Community 149"
 Cohesion: 0.4
 Nodes (1): WorkQueue
 
-### Community 152 - "Community 152"
+### Community 150 - "Community 150"
 Cohesion: 0.4
 Nodes (1): NetworkEndpointPolicy
 
-### Community 153 - "Community 153"
+### Community 151 - "Community 151"
 Cohesion: 0.4
 Nodes (1): CheckpointGraphStore
 
-### Community 154 - "Community 154"
+### Community 152 - "Community 152"
 Cohesion: 0.4
 Nodes (1): SideEffectJournalStore
 
-### Community 155 - "Community 155"
+### Community 153 - "Community 153"
 Cohesion: 0.4
 Nodes (1): ProvenanceStore
 
-### Community 156 - "Community 156"
+### Community 154 - "Community 154"
 Cohesion: 0.4
 Nodes (1): CodexDefaults
 
-### Community 157 - "Community 157"
+### Community 155 - "Community 155"
 Cohesion: 0.4
 Nodes (1): CotorHttpClients
 
-### Community 158 - "Community 158"
+### Community 156 - "Community 156"
 Cohesion: 0.4
 Nodes (2): StuckDetector, StuckSignal
 
-### Community 159 - "Community 159"
+### Community 157 - "Community 157"
 Cohesion: 0.4
 Nodes (1): AppServerCommand
 
-### Community 160 - "Community 160"
+### Community 158 - "Community 158"
 Cohesion: 0.4
 Nodes (2): SyntaxValidationResult, SyntaxValidator
 
-### Community 161 - "Community 161"
+### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (1): findPrimes()
 
-### Community 162 - "Community 162"
+### Community 160 - "Community 160"
 Cohesion: 0.5
 Nodes (1): BoardServiceApplicationTests
 
-### Community 163 - "Community 163"
+### Community 161 - "Community 161"
 Cohesion: 0.67
 Nodes (2): BoardServiceApplication, main()
 
-### Community 164 - "Community 164"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostDetailResponse
 
-### Community 165 - "Community 165"
+### Community 163 - "Community 163"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostSummaryResponse
 
-### Community 166 - "Community 166"
+### Community 164 - "Community 164"
 Cohesion: 0.5
 Nodes (1): PostRepository
 
-### Community 167 - "Community 167"
+### Community 165 - "Community 165"
 Cohesion: 0.5
 Nodes (1): Post
 
-### Community 168 - "Community 168"
+### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (1): AgentCapabilityGuardTest
 
-### Community 169 - "Community 169"
+### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceOwnershipTest
 
-### Community 170 - "Community 170"
+### Community 168 - "Community 168"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
-### Community 171 - "Community 171"
+### Community 169 - "Community 169"
 Cohesion: 0.5
 Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
-### Community 172 - "Community 172"
+### Community 170 - "Community 170"
 Cohesion: 0.5
 Nodes (2): CommandPluginTest, RecordingProcessManager
 
-### Community 173 - "Community 173"
+### Community 171 - "Community 171"
 Cohesion: 0.5
 Nodes (2): FileReaderPluginTest, NoopProcessManager
 
-### Community 174 - "Community 174"
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (1): PipelineOrchestratorPropertyTest
 
-### Community 175 - "Community 175"
+### Community 173 - "Community 173"
 Cohesion: 0.5
 Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
-### Community 176 - "Community 176"
+### Community 174 - "Community 174"
 Cohesion: 0.5
 Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
-### Community 177 - "Community 177"
+### Community 175 - "Community 175"
 Cohesion: 0.5
 Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
-### Community 178 - "Community 178"
+### Community 176 - "Community 176"
 Cohesion: 0.5
 Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
 
-### Community 179 - "Community 179"
+### Community 177 - "Community 177"
 Cohesion: 0.5
 Nodes (1): StateRepository
 
-### Community 180 - "Community 180"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (3): ChatMessage, ChatMode, ChatRole
 
-### Community 181 - "Community 181"
+### Community 179 - "Community 179"
 Cohesion: 0.5
 Nodes (1): DurableRuntimeFlags
 
-### Community 182 - "Community 182"
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
-### Community 183 - "Community 183"
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
-### Community 184 - "Community 184"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (2): TimelineCollector, TimelineResult
 
-### Community 185 - "Community 185"
+### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (1): StageConflictDetector
 
-### Community 186 - "Community 186"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (1): SimpleCLI
 
-### Community 187 - "Community 187"
+### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (2): OutputValidator, StageValidationOutcome
 
-### Community 188 - "Community 188"
+### Community 186 - "Community 186"
 Cohesion: 0.67
 Nodes (1): PostCreateRequest
 
-### Community 189 - "Community 189"
+### Community 187 - "Community 187"
 Cohesion: 0.67
 Nodes (1): PostUpdateRequest
 
-### Community 190 - "Community 190"
+### Community 188 - "Community 188"
 Cohesion: 0.67
 Nodes (1): VersionConflictException
 
-### Community 191 - "Community 191"
+### Community 189 - "Community 189"
 Cohesion: 0.67
 Nodes (1): PostNotFoundException
 
-### Community 192 - "Community 192"
+### Community 190 - "Community 190"
 Cohesion: 0.67
 Nodes (1): PermissionDeniedException
 
-### Community 193 - "Community 193"
+### Community 191 - "Community 191"
 Cohesion: 0.67
 Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
-### Community 194 - "Community 194"
+### Community 192 - "Community 192"
 Cohesion: 0.67
 Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
-### Community 195 - "Community 195"
+### Community 193 - "Community 193"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIntegrationHarness
 
-### Community 196 - "Community 196"
+### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
-### Community 197 - "Community 197"
+### Community 195 - "Community 195"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceExecutionMemoryTest
 
-### Community 198 - "Community 198"
+### Community 196 - "Community 196"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
-### Community 199 - "Community 199"
+### Community 197 - "Community 197"
 Cohesion: 0.67
 Nodes (1): CheckpointFixtureProcess
 
-### Community 200 - "Community 200"
+### Community 198 - "Community 198"
 Cohesion: 0.67
 Nodes (1): CheckpointResumeIntegrationTest
 
-### Community 201 - "Community 201"
+### Community 199 - "Community 199"
 Cohesion: 0.67
 Nodes (1): RuntimeConstructorConsistencyTest
 
-### Community 202 - "Community 202"
+### Community 200 - "Community 200"
 Cohesion: 0.67
 Nodes (1): PipelineOrchestratorMapTest
 
-### Community 203 - "Community 203"
+### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (1): TemplateCommandTest
 
-### Community 204 - "Community 204"
+### Community 202 - "Community 202"
 Cohesion: 0.67
 Nodes (1): InitCommandTest
 
-### Community 205 - "Community 205"
+### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (1): ValidateCommandTest
 
-### Community 206 - "Community 206"
+### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (1): DesktopLifecycleCommandTest
 
-### Community 207 - "Community 207"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (1): ResultAnalyzer
 
-### Community 208 - "Community 208"
+### Community 206 - "Community 206"
 Cohesion: 0.67
 Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 209 - "Community 209"
+### Community 207 - "Community 207"
 Cohesion: 0.67
 Nodes (2): VideoPlanRequest, VideoPlanResult
 
-### Community 211 - "Community 211"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (1): DurableRuntimeContext
 
-### Community 212 - "Community 212"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (1): HelloCommand
 
-### Community 213 - "Community 213"
+### Community 211 - "Community 211"
 Cohesion: 0.67
 Nodes (1): WebCommand
 
-### Community 214 - "Community 214"
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (1): LintCommand
 
-### Community 215 - "Community 215"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (1): ExplainCommand
 
-### Community 216 - "Community 216"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (1): CheckpointGCCommand
 
-### Community 217 - "Community 217"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (2): StageTimelineEntry, StageTimelineState
 
-### Community 218 - "Community 218"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (1): PipelineTemplateValidator
 
-### Community 219 - "Community 219"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (1): DefaultOutputValidator
 
-### Community 220 - "Community 220"
+### Community 218 - "Community 218"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 222 - "Community 222"
+### Community 220 - "Community 220"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 223 - "Community 223"
+### Community 221 - "Community 221"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 224 - "Community 224"
+### Community 222 - "Community 222"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 225 - "Community 225"
+### Community 223 - "Community 223"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 226 - "Community 226"
+### Community 224 - "Community 224"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 227 - "Community 227"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 228 - "Community 228"
+### Community 226 - "Community 226"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 229 - "Community 229"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 230 - "Community 230"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 231 - "Community 231"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 232 - "Community 232"
+### Community 230 - "Community 230"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 233 - "Community 233"
+### Community 231 - "Community 231"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 234 - "Community 234"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 235 - "Community 235"
+### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 236 - "Community 236"
+### Community 234 - "Community 234"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 237 - "Community 237"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 238 - "Community 238"
+### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 239 - "Community 239"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 240 - "Community 240"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceMergeConfirmationTest
 
-### Community 241 - "Community 241"
+### Community 239 - "Community 239"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreTest
 
-### Community 242 - "Community 242"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
-### Community 243 - "Community 243"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): AutonomousDiscoveryServiceTest
 
-### Community 244 - "Community 244"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): SkillModelsTest
 
-### Community 245 - "Community 245"
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (1): CompanyRuntimeMachineTest
 
-### Community 246 - "Community 246"
+### Community 244 - "Community 244"
 Cohesion: 1.0
 Nodes (1): ChatTranscriptWriterTest
 
-### Community 247 - "Community 247"
+### Community 245 - "Community 245"
 Cohesion: 1.0
 Nodes (1): ChatSessionTest
 
-### Community 248 - "Community 248"
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (1): NetworkEndpointPolicyTest
 
-### Community 249 - "Community 249"
+### Community 247 - "Community 247"
 Cohesion: 1.0
 Nodes (1): SecurityValidatorTest
 
-### Community 250 - "Community 250"
+### Community 248 - "Community 248"
 Cohesion: 1.0
 Nodes (1): A2aArtifactStoreTest
 
-### Community 251 - "Community 251"
+### Community 249 - "Community 249"
 Cohesion: 1.0
 Nodes (1): A2aApiTest
 
-### Community 252 - "Community 252"
+### Community 250 - "Community 250"
 Cohesion: 1.0
 Nodes (1): A2aSessionStoreTest
 
-### Community 253 - "Community 253"
+### Community 251 - "Community 251"
 Cohesion: 1.0
 Nodes (1): A2aDedupeStoreTest
 
-### Community 254 - "Community 254"
+### Community 252 - "Community 252"
 Cohesion: 1.0
 Nodes (1): RecoveryExecutorTest
 
-### Community 255 - "Community 255"
+### Community 253 - "Community 253"
 Cohesion: 1.0
 Nodes (1): GitHubControlPlaneServiceTest
 
-### Community 256 - "Community 256"
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (1): StoreConcurrencyTest
 
-### Community 257 - "Community 257"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (1): DurableRuntimeServiceTest
 
-### Community 258 - "Community 258"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (1): DurableResumeCoordinatorTest
 
-### Community 259 - "Community 259"
+### Community 257 - "Community 257"
 Cohesion: 1.0
 Nodes (1): ActionExecutionServiceTest
 
-### Community 260 - "Community 260"
+### Community 258 - "Community 258"
 Cohesion: 1.0
 Nodes (1): LinearClientEndpointPolicyTest
 
-### Community 261 - "Community 261"
+### Community 259 - "Community 259"
 Cohesion: 1.0
 Nodes (1): VerificationBundleServiceTest
 
-### Community 262 - "Community 262"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (1): KnowledgeServiceTest
 
-### Community 263 - "Community 263"
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (1): LocalModelDefaultsTest
 
-### Community 264 - "Community 264"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (1): ObservabilityServiceTest
 
-### Community 265 - "Community 265"
+### Community 263 - "Community 263"
 Cohesion: 1.0
 Nodes (1): FileConfigRepositoryTest
 
-### Community 266 - "Community 266"
+### Community 264 - "Community 264"
 Cohesion: 1.0
 Nodes (1): QaTestGenerationFixtureTest
 
-### Community 267 - "Community 267"
+### Community 265 - "Community 265"
 Cohesion: 1.0
 Nodes (1): ConfigRepositoryImportTest
 
-### Community 268 - "Community 268"
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (1): ExampleConfigSmokeTest
 
-### Community 269 - "Community 269"
+### Community 267 - "Community 267"
 Cohesion: 1.0
 Nodes (1): YamlParserTest
 
-### Community 270 - "Community 270"
+### Community 268 - "Community 268"
 Cohesion: 1.0
 Nodes (1): CodexPluginTest
 
-### Community 271 - "Community 271"
+### Community 269 - "Community 269"
 Cohesion: 1.0
 Nodes (1): CotorHttpClientsTest
 
-### Community 272 - "Community 272"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (1): ProcessManagerTest
 
-### Community 273 - "Community 273"
+### Community 271 - "Community 271"
 Cohesion: 1.0
 Nodes (1): ErrorHelperTest
 
-### Community 274 - "Community 274"
+### Community 272 - "Community 272"
 Cohesion: 1.0
 Nodes (1): ResultAggregatorTest
 
-### Community 275 - "Community 275"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (1): ConditionEvaluatorTest
 
-### Community 276 - "Community 276"
+### Community 274 - "Community 274"
 Cohesion: 1.0
 Nodes (1): AgentExecutorTest
 
-### Community 277 - "Community 277"
+### Community 275 - "Community 275"
 Cohesion: 1.0
 Nodes (1): StuckDetectorTest
 
-### Community 278 - "Community 278"
+### Community 276 - "Community 276"
 Cohesion: 1.0
 Nodes (1): PipelineGuardServiceTest
 
-### Community 279 - "Community 279"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorDagValidationTest
 
-### Community 280 - "Community 280"
+### Community 278 - "Community 278"
 Cohesion: 1.0
 Nodes (1): StageConflictDetectorTest
 
-### Community 281 - "Community 281"
+### Community 279 - "Community 279"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorTemplatingTest
 
-### Community 282 - "Community 282"
+### Community 280 - "Community 280"
 Cohesion: 1.0
 Nodes (1): CoroutineEventBusTest
 
-### Community 283 - "Community 283"
+### Community 281 - "Community 281"
 Cohesion: 1.0
 Nodes (1): WebServerTest
 
-### Community 284 - "Community 284"
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (1): CompletionCommandTest
 
-### Community 285 - "Community 285"
+### Community 283 - "Community 283"
 Cohesion: 1.0
 Nodes (1): HelpCommandTest
 
-### Community 286 - "Community 286"
+### Community 284 - "Community 284"
 Cohesion: 1.0
 Nodes (1): AppServerCommandTest
 
-### Community 287 - "Community 287"
+### Community 285 - "Community 285"
 Cohesion: 1.0
 Nodes (1): StarterAgentResolverTest
 
-### Community 288 - "Community 288"
+### Community 286 - "Community 286"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandCompleterTest
 
-### Community 289 - "Community 289"
+### Community 287 - "Community 287"
 Cohesion: 1.0
 Nodes (1): AgentCommandTest
 
-### Community 290 - "Community 290"
+### Community 288 - "Community 288"
 Cohesion: 1.0
 Nodes (1): PluginCommandTest
 
-### Community 291 - "Community 291"
+### Community 289 - "Community 289"
 Cohesion: 1.0
 Nodes (1): AuthCommandTest
 
-### Community 292 - "Community 292"
+### Community 290 - "Community 290"
 Cohesion: 1.0
 Nodes (1): HelloCommandTest
 
-### Community 293 - "Community 293"
+### Community 291 - "Community 291"
 Cohesion: 1.0
 Nodes (1): LintCommandTest
 
-### Community 294 - "Community 294"
+### Community 292 - "Community 292"
 Cohesion: 1.0
 Nodes (1): CompanyCommandTest
 
-### Community 295 - "Community 295"
+### Community 293 - "Community 293"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandTest
 
-### Community 296 - "Community 296"
+### Community 294 - "Community 294"
 Cohesion: 1.0
 Nodes (1): StatsCommandTest
 
-### Community 297 - "Community 297"
+### Community 295 - "Community 295"
 Cohesion: 1.0
 Nodes (1): CodexDashboardCommandTest
 
-### Community 298 - "Community 298"
+### Community 296 - "Community 296"
 Cohesion: 1.0
 Nodes (1): StatsManagerTest
 
-### Community 299 - "Community 299"
+### Community 297 - "Community 297"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorTest
 
-### Community 300 - "Community 300"
+### Community 298 - "Community 298"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorExtTest
 
-### Community 301 - "Community 301"
+### Community 299 - "Community 299"
 Cohesion: 1.0
 Nodes (1): LinterTest
 
-### Community 302 - "Community 302"
+### Community 300 - "Community 300"
 Cohesion: 1.0
 Nodes (1): DefaultOutputValidatorTest
 
-### Community 303 - "Community 303"
+### Community 301 - "Community 301"
 Cohesion: 1.0
 Nodes (1): PolicyEngineTest
 
-### Community 304 - "Community 304"
+### Community 302 - "Community 302"
 Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
-### Community 307 - "Community 307"
+### Community 305 - "Community 305"
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 309 - "Community 309"
+### Community 307 - "Community 307"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 310 - "Community 310"
+### Community 308 - "Community 308"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
@@ -1576,23 +1566,23 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 28`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 32`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (18 nodes): `Parser`, `.advance()`, `.and()`, `.check()`, `.comparison()`, `.consume()`, `.equality()`, `.expression()`, `.isAtEnd()`, `.match()`, `.or()`, `.parse()`, `.peek()`, `.previous()`, `.primary()`, `.term()`, `.unary()`, `Parser.kt`
+- **Thin community `Community 40`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 41`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 42`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 44`** (17 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (17 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `waitForProcessHandles()`, `ProcessManager.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 47`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 50`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 52`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1606,428 +1596,426 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 64`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 67`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 73`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 74`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 76`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 77`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 82`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 84`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 85`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 86`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 87`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 90`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 89`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 94`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 93`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 95`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
+- **Thin community `Community 94`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 96`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
+- **Thin community `Community 95`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (8 nodes): `A2aArtifactStore`, `.append()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `A2aArtifactStore.kt`
+- **Thin community `Community 105`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 106`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 107`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 108`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 109`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 110`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 111`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 112`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 113`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 114`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 117`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 118`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 119`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 120`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 121`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 122`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 123`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 125`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 126`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 127`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 129`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 130`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 131`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 132`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 133`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 134`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 135`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 136`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 137`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 138`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 139`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 140`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 141`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 142`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 143`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 144`** (5 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 145`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 146`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 147`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 148`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 149`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 150`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 151`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 152`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 153`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 154`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 155`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 156`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 157`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 158`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 159`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 160`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 161`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 162`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 164`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 165`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 166`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 167`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 168`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 169`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 170`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 171`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 172`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 173`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 174`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 176`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 177`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 179`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 182`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 183`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 184`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 185`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 186`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 187`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 188`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 189`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 190`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 191`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 192`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 193`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 194`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 197`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 198`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 199`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 200`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 201`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 202`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 203`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 204`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 205`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 206`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 207`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 209`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 210`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 211`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 212`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 213`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 215`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 216`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 217`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 218`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 220`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 221`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 222`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 223`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 224`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 225`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 226`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 227`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 230`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 231`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 232`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 233`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 234`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 235`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 236`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 237`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 238`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 240`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 241`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 242`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 243`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 244`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 245`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 246`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 247`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 248`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 249`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 250`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 251`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 252`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 253`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 254`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 255`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 256`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 257`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 258`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 259`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 260`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 261`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 262`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 263`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 264`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 265`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 267`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 268`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 269`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 270`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 271`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 272`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 273`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 274`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 275`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 276`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 277`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 278`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 279`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 280`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 281`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 282`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 283`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 284`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 285`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 286`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 287`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 288`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 289`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 290`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 291`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 296`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 297`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 298`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 299`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 300`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 301`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 302`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 305`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 307`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 308`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 19`?**
-  _High betweenness centrality (0.092) - this node is a cross-community bridge._
-- **Why does `TuiSession` connect `Community 1` to `Community 13`?**
+- **Why does `DesktopStore` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 9`, `Community 14`, `Community 16`, `Community 17`, `Community 20`?**
+  _High betweenness centrality (0.093) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 5` to `Community 3`?**
+  _High betweenness centrality (0.026) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 3` to `Community 1`, `Community 2`, `Community 5`, `Community 15`?**
   _High betweenness centrality (0.024) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 4` to `Community 1`?**
-  _High betweenness centrality (0.023) - this node is a cross-community bridge._
 - **Are the 36 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
   _`DesktopStore` has 36 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
@@ -2035,4 +2023,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-05-19)
 
 ## Corpus Check
-- 363 files · ~617,569 words
+- 363 files · ~617,596 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/macos/Packaging/CotorDesktopLauncher.sh.template
+++ b/macos/Packaging/CotorDesktopLauncher.sh.template
@@ -94,6 +94,12 @@ is_port_listening() {
     [[ -n "$port" ]] && lsof -iTCP:"$port" -sTCP:LISTEN -n -P >/dev/null 2>&1
 }
 
+is_backend_healthy() {
+    local url="$1"
+    [[ -n "$url" ]] || return 1
+    curl -fsS --connect-timeout 1 --max-time 2 "$url/health" >/dev/null 2>&1
+}
+
 find_free_port() {
     /usr/bin/python3 - <<'PY'
 import socket
@@ -109,7 +115,7 @@ wait_for_backend() {
     local url="$1"
     local attempts=0
     while (( attempts < 40 )); do
-        if curl -fsS "$url/health" >/dev/null 2>&1; then
+        if is_backend_healthy "$url"; then
             return 0
         fi
         attempts=$((attempts + 1))
@@ -137,12 +143,28 @@ clear_backend_runtime_files() {
     if [[ -n "$BACKEND_RUNTIME_JAR" ]]; then
         rm -f "$BACKEND_RUNTIME_JAR" >/dev/null 2>&1 || true
     fi
+    cleanup_stale_backend_runtime_jars
 }
 
 stage_backend_runtime_jar() {
+    cleanup_stale_backend_runtime_jars
     BACKEND_RUNTIME_JAR="$BACKEND_RUNTIME_DIR/cotor-backend-runtime-$$.jar"
     mkdir -p "$BACKEND_RUNTIME_DIR"
     cp "$BACKEND_JAR" "$BACKEND_RUNTIME_JAR"
+}
+
+cleanup_stale_backend_runtime_jars() {
+    [[ -d "$BACKEND_RUNTIME_DIR" ]] || return 0
+
+    local runtime_jar
+    for runtime_jar in "$BACKEND_RUNTIME_DIR"/cotor-backend-runtime-*.jar "$BACKEND_RUNTIME_DIR"/cotor-app-server-*.jar; do
+        [[ -e "$runtime_jar" ]] || continue
+        [[ -n "$BACKEND_RUNTIME_JAR" && "$runtime_jar" == "$BACKEND_RUNTIME_JAR" ]] && continue
+        if ps -axo args= | grep -F -- "$runtime_jar" | grep -F -- " app-server" >/dev/null 2>&1; then
+            continue
+        fi
+        rm -f "$runtime_jar" >/dev/null 2>&1 || true
+    done
 }
 
 read_existing_instance_pid() {
@@ -230,26 +252,74 @@ terminate_stale_bundled_backends() {
     fi
 }
 
+terminate_existing_desktop_instances() {
+    local existing_pids=()
+    local pid args
+
+    while read -r pid args; do
+        [[ -n "$pid" ]] || continue
+        [[ "$pid" == "$$" ]] && continue
+        [[ "$args" == *"$BINARY_PATH"* || "$args" == *"$SCRIPT_DIR/CotorDesktopLauncher"* ]] || continue
+        existing_pids+=("$pid")
+    done < <(ps -axo pid=,args=)
+
+    if (( ${#existing_pids[@]} == 0 )); then
+        return 0
+    fi
+
+    log_launcher "Terminating existing desktop app instances: ${existing_pids[*]}"
+    for pid in "${existing_pids[@]}"; do
+        kill "$pid" >/dev/null 2>&1 || true
+    done
+    sleep 1
+
+    local survivors=()
+    for pid in "${existing_pids[@]}"; do
+        if is_pid_alive "$pid"; then
+            survivors+=("$pid")
+        fi
+    done
+
+    if (( ${#survivors[@]} > 0 )); then
+        log_launcher "Escalating desktop app instance termination to SIGKILL: ${survivors[*]}"
+        for pid in "${survivors[@]}"; do
+            kill -9 "$pid" >/dev/null 2>&1 || true
+        done
+        sleep 0.3
+    fi
+}
+
 start_managed_backend() {
+    local show_failure_alert="${1:-1}"
     local java_bin
     java_bin="$(find_java)"
 
     if [[ -z "$java_bin" ]]; then
-        show_alert "Java 17 or newer is required to run the bundled Cotor app server."
+        if [[ "$show_failure_alert" == "1" ]]; then
+            show_alert "Java 17 or newer is required to run the bundled Cotor app server."
+        fi
         return 1
     fi
 
     if [[ ! -f "$BACKEND_JAR" ]]; then
-        show_alert "The bundled Cotor backend could not be found inside the app."
+        if [[ "$show_failure_alert" == "1" ]]; then
+            show_alert "The bundled Cotor backend could not be found inside the app."
+        fi
         return 1
     fi
     if ! stage_backend_runtime_jar; then
-        show_alert "Cotor Desktop could not stage its bundled backend for execution."
+        if [[ "$show_failure_alert" == "1" ]]; then
+            show_alert "Cotor Desktop could not stage its bundled backend for execution."
+        fi
         return 1
     fi
 
-    SERVER_PORT="$(find_free_port)"
-    SERVER_TOKEN="$(/usr/bin/uuidgen | /usr/bin/tr '[:upper:]' '[:lower:]')"
+    if [[ -z "$SERVER_PORT" ]]; then
+        SERVER_PORT="$(find_free_port)"
+    fi
+    if [[ -z "$SERVER_TOKEN" ]]; then
+        SERVER_TOKEN="$(/usr/bin/uuidgen | /usr/bin/tr '[:upper:]' '[:lower:]')"
+    fi
     SERVER_URL="http://127.0.0.1:$SERVER_PORT"
     local java_home
     java_home="$(cd "$(dirname "$java_bin")/.." && pwd)"
@@ -289,9 +359,29 @@ start_managed_backend() {
 
     if ! wait_for_backend "$SERVER_URL"; then
         stop_managed_backend || true
-        show_alert "Cotor Desktop could not start its bundled app server."
+        if [[ "$show_failure_alert" == "1" ]]; then
+            show_alert "Cotor Desktop could not start its bundled app server."
+        fi
         return 1
     fi
+}
+
+restart_managed_backend() {
+    if [[ -z "$SERVER_PORT" || -z "$SERVER_TOKEN" ]]; then
+        log_launcher "Cannot restart managed backend because port or token state is missing."
+        return 1
+    fi
+
+    MANAGED_BACKEND_STARTED=0
+    MANAGED_BACKEND_PID=""
+    rm -f "$PID_FILE" >/dev/null 2>&1 || true
+    if [[ -n "$BACKEND_RUNTIME_JAR" ]]; then
+        rm -f "$BACKEND_RUNTIME_JAR" >/dev/null 2>&1 || true
+        BACKEND_RUNTIME_JAR=""
+    fi
+
+    log_launcher "Managed backend is not running. Restarting on preserved port $SERVER_PORT."
+    start_managed_backend 0
 }
 
 stop_managed_backend() {
@@ -300,7 +390,7 @@ stop_managed_backend() {
     fi
 
     local backend_pid="$MANAGED_BACKEND_PID"
-    if [[ -z "$backend_pid" && -f "$PID_FILE" ]]; then
+    if [[ -f "$PID_FILE" ]] && { [[ -z "$backend_pid" ]] || ! is_pid_alive "$backend_pid"; }; then
         backend_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
     fi
 
@@ -345,6 +435,19 @@ launcher_cleanup() {
     stop_managed_backend || true
 }
 
+monitor_managed_backend() {
+    local app_pid="$1"
+
+    while is_pid_alive "$app_pid"; do
+        if (( MANAGED_BACKEND_STARTED != 0 )); then
+            if [[ -z "$MANAGED_BACKEND_PID" ]] || ! is_pid_alive "$MANAGED_BACKEND_PID" || ! is_port_listening "$SERVER_PORT" || ! is_backend_healthy "$SERVER_URL"; then
+                restart_managed_backend || log_launcher "Managed backend restart failed on preserved port $SERVER_PORT."
+            fi
+        fi
+        sleep 2
+    done
+}
+
 ensure_backend() {
     if [[ -n "$SERVER_URL" ]]; then
         SERVER_PORT="$(printf '%s' "$SERVER_URL" | sed -E 's#^https?://[^:/]+:([0-9]+).*$#\1#')"
@@ -374,16 +477,25 @@ ensure_backend() {
     start_managed_backend
 }
 
-ensure_backend
+if [[ "${COTOR_DESKTOP_LAUNCHER_SOURCE_ONLY:-0}" == "1" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 trap launcher_cleanup EXIT INT TERM HUP
+terminate_existing_desktop_instances
+ensure_backend
 
 export COTOR_APP_SERVER_URL="$SERVER_URL"
 export COTOR_APP_TOKEN="$SERVER_TOKEN"
 
 "$BINARY_PATH" "$@" &
 APP_BINARY_PID=$!
+monitor_managed_backend "$APP_BINARY_PID" &
+BACKEND_MONITOR_PID=$!
 set +e
 wait "$APP_BINARY_PID"
 APP_EXIT_CODE=$?
 set -e
+kill "$BACKEND_MONITOR_PID" >/dev/null 2>&1 || true
+wait "$BACKEND_MONITOR_PID" >/dev/null 2>&1 || true
 exit "$APP_EXIT_CODE"

--- a/macos/Sources/CotorDesktopApp/AgentSkillCards.swift
+++ b/macos/Sources/CotorDesktopApp/AgentSkillCards.swift
@@ -117,7 +117,7 @@ struct AgentSkillCardRecord: Identifiable, Hashable {
             if skillRunPolicy == .auto {
                 let blockedCap = reqs.first { cap in
                     let norm = Self.normalizedCapability(cap)
-                    guard let s = settings[norm] else { return false }
+                    guard let s = settings[norm] else { return true }
                     return Self.policy(for: s) != .auto
                 }
                 if let cap = blockedCap {

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -1081,6 +1081,7 @@ private struct SidebarView: View {
                             company: company,
                             runtime: store.companyRuntimes.first(where: { $0.companyId == company.id }),
                             language: l,
+                            isOffline: store.isOffline,
                             isSelected: store.selectedCompanyID == company.id
                         ) {
                             Task { await store.selectCompany(company) }
@@ -1297,10 +1298,27 @@ private struct SidebarView: View {
                 ShellTag(text: status.policy == "REQUIRE_GITHUB_PR" ? l("PR mode", "PR 모드") : l("local git", "로컬 git"), tint: ShellPalette.accent)
             }
 
-            TextField(l("https://github.com/owner/repo.git", "https://github.com/owner/repo.git"), text: $store.companyGitHubOriginInput)
-                .textFieldStyle(.roundedBorder)
-                .lineLimit(1)
-                .accessibilityIdentifier("github-origin-quick-input")
+            HStack(spacing: 6) {
+                TextField(l("https://github.com/owner/repo.git", "https://github.com/owner/repo.git"), text: $store.companyGitHubOriginInput)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("github-origin-quick-input")
+
+                Button {
+                    Task { await store.saveSelectedCompanyGitHubOrigin() }
+                } label: {
+                    Image(systemName: "link")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(ShellPalette.text)
+                        .frame(width: 28, height: 24)
+                }
+                .buttonStyle(.plain)
+                .background(store.companyGitHubOriginInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? ShellPalette.panelRaised.opacity(0.5) : ShellPalette.accent)
+                .clipShape(RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous))
+                .disabled(store.companyGitHubOriginInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityLabel(l("Connect origin", "origin 연결"))
+                .help(l("Connect origin", "origin 연결"))
+            }
 
             if let message = store.companyGitHubStatusMessage, !message.isEmpty {
                 Text(message)
@@ -1334,15 +1352,6 @@ private struct SidebarView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(ShellTopBarButtonStyle(prominent: false))
-
-                Button {
-                    Task { await store.saveSelectedCompanyGitHubOrigin() }
-                } label: {
-                    Label(l("Connect", "연결"), systemImage: "link")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(ShellTopBarButtonStyle(prominent: true))
-                .disabled(store.companyGitHubOriginInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
         .accessibilityElement(children: .contain)
@@ -3788,9 +3797,17 @@ private struct OrgChartNode: View {
 private struct AgentSkillCardView: View {
     let card: AgentSkillCardRecord
     let language: AppLanguage
-    let isRunning: Bool
-    let onRun: () -> Void
+    let runningSkillID: String?
+    let onRun: (AgentSkillChipRecord) -> Void
     let onEdit: () -> Void
+
+    private var canRunSkill: Bool {
+        card.enabled && card.primaryRunnableSkill != nil
+    }
+
+    private var isRunning: Bool {
+        runningSkillID != nil
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
@@ -3865,29 +3882,31 @@ private struct AgentSkillCardView: View {
                         .lineLimit(1)
                 }
                 Spacer(minLength: 6)
-                Button(action: onRun) {
-                    HStack(spacing: 5) {
-                        if isRunning {
-                            ProgressView()
-                                .controlSize(.small)
-                                .scaleEffect(0.55)
-                                .frame(width: 12, height: 12)
-                        } else {
-                            Image(systemName: "play.fill")
-                                .font(.system(size: 8, weight: .bold))
+                if card.runnableSkills.count > 1 {
+                    Menu {
+                        ForEach(card.runnableSkills) { skill in
+                            Button(skill.displayName) {
+                                onRun(skill)
+                            }
                         }
-                        Text(isRunning ? language("Running", "실행 중") : language("Skill Test", "스킬 테스트"))
-                            .font(.system(size: 10, weight: .semibold))
+                    } label: {
+                        runButtonLabel
                     }
-                    .foregroundStyle(ShellPalette.text)
-                    .padding(.horizontal, 8)
-                    .frame(height: 24)
-                    .background(ShellPalette.panelRaised)
-                    .clipShape(RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous))
+                    .menuStyle(.button)
+                    .buttonStyle(.plain)
+                    .disabled(isRunning || !canRunSkill)
+                    .opacity(canRunSkill ? 1 : 0.45)
+                } else {
+                    Button {
+                        guard let skill = card.primaryRunnableSkill else { return }
+                        onRun(skill)
+                    } label: {
+                        runButtonLabel
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isRunning || !canRunSkill)
+                    .opacity(canRunSkill ? 1 : 0.45)
                 }
-                .buttonStyle(.plain)
-                .disabled(isRunning || card.selectedSkills.isEmpty)
-                .opacity(card.selectedSkills.isEmpty ? 0.45 : 1)
             }
         }
         .frame(maxWidth: .infinity, minHeight: 190, alignment: .topLeading)
@@ -3923,6 +3942,41 @@ private struct AgentSkillCardView: View {
     private var recentRunTitle: String {
         guard let run = card.recentRun else { return language("No skill run yet", "아직 실행 없음") }
         return "\(run.skill) · \(run.status)"
+    }
+
+    private var runButtonTitle: String {
+        if isRunning {
+            return language("Running", "실행 중")
+        }
+        if card.runnableSkills.count > 1 {
+            return language("Run Skill", "스킬 실행")
+        }
+        if let skill = card.primaryRunnableSkill {
+            return language("Run \(skill.displayName)", "\(skill.displayName) 실행")
+        }
+        return language("Blocked", "실행 불가")
+    }
+
+    private var runButtonLabel: some View {
+        HStack(spacing: 5) {
+            if isRunning {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.55)
+                    .frame(width: 12, height: 12)
+            } else {
+                Image(systemName: card.runnableSkills.count > 1 ? "chevron.down.circle.fill" : "play.fill")
+                    .font(.system(size: 8, weight: .bold))
+            }
+            Text(runButtonTitle)
+                .font(.system(size: 10, weight: .semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(ShellPalette.text)
+        .padding(.horizontal, 8)
+        .frame(height: 24)
+        .background(ShellPalette.panelRaised)
+        .clipShape(RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous))
     }
 
     private var recentRunDetail: String {
@@ -5021,6 +5075,9 @@ private struct CenterPaneView: View {
         if runtime.lastError?.isEmpty == false {
             return l("Needs attention", "확인 필요")
         }
+        if (store.isOffline && runtime.status.uppercased() == "RUNNING") || runtime.isDetachedLocalBackend {
+            return l("Backend offline", "백엔드 오프라인")
+        }
         if runtime.isManuallyStopped {
             return l("Paused", "멈춤")
         }
@@ -5035,6 +5092,9 @@ private struct CenterPaneView: View {
 
     private func companyRuntimeHeadlineTint(_ runtime: CompanyRuntimeSnapshotRecord) -> Color {
         if runtime.lastError?.isEmpty == false {
+            return ShellPalette.danger
+        }
+        if (store.isOffline && runtime.status.uppercased() == "RUNNING") || runtime.isDetachedLocalBackend {
             return ShellPalette.danger
         }
         if runtime.isBudgetPaused || runtime.isManuallyStopped {
@@ -6342,9 +6402,10 @@ private struct CenterPaneView: View {
                     AgentSkillCardView(
                         card: card,
                         language: l,
-                        isRunning: store.runningSkillRunKeys.contains("\(card.id):\(card.selectedSkills.first?.id ?? "")"),
-                        onRun: {
-                            guard let skill = card.selectedSkills.first else { return }
+                        runningSkillID: card.runnableSkills.first {
+                            store.runningSkillRunKeys.contains("\(card.id):\($0.id)")
+                        }?.id,
+                        onRun: { skill in
                             Task {
                                 await store.runSkill(
                                     skillName: skill.id,
@@ -7232,6 +7293,7 @@ private struct CompanyCard: View {
     let company: CompanyRecord
     let runtime: CompanyRuntimeSnapshotRecord?
     let language: AppLanguage
+    let isOffline: Bool
     let isSelected: Bool
     let action: () -> Void
 
@@ -7252,8 +7314,8 @@ private struct CompanyCard: View {
                 HStack(spacing: 8) {
                     if let runtime {
                         ShellTag(
-                            text: companyCardRuntimeLabel(runtime, language: language),
-                            tint: companyCardRuntimeTint(runtime)
+                            text: companyCardRuntimeLabel(runtime, language: language, isOffline: isOffline),
+                            tint: companyCardRuntimeTint(runtime, isOffline: isOffline)
                         )
                     } else {
                         ShellTag(text: language("Not started", "시작 전"), tint: ShellPalette.panelRaised)
@@ -7286,9 +7348,12 @@ private struct CompanyCard: View {
     }
 }
 
-private func companyCardRuntimeLabel(_ runtime: CompanyRuntimeSnapshotRecord, language: AppLanguage) -> String {
+private func companyCardRuntimeLabel(_ runtime: CompanyRuntimeSnapshotRecord, language: AppLanguage, isOffline: Bool) -> String {
     if runtime.lastError?.isEmpty == false {
         return language("Needs attention", "확인 필요")
+    }
+    if (isOffline && runtime.status.uppercased() == "RUNNING") || runtime.isDetachedLocalBackend {
+        return language("Backend offline", "백엔드 오프라인")
     }
     if runtime.isManuallyStopped {
         return language("Paused", "멈춤")
@@ -7302,8 +7367,11 @@ private func companyCardRuntimeLabel(_ runtime: CompanyRuntimeSnapshotRecord, la
     return language.status(runtime.status)
 }
 
-private func companyCardRuntimeTint(_ runtime: CompanyRuntimeSnapshotRecord) -> Color {
+private func companyCardRuntimeTint(_ runtime: CompanyRuntimeSnapshotRecord, isOffline: Bool) -> Color {
     if runtime.lastError?.isEmpty == false {
+        return ShellPalette.danger
+    }
+    if (isOffline && runtime.status.uppercased() == "RUNNING") || runtime.isDetachedLocalBackend {
         return ShellPalette.danger
     }
     if runtime.isBudgetPaused || runtime.isManuallyStopped {

--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -140,6 +140,9 @@ struct DesktopAPI {
     }
 
     private static func isLoopbackAppServerURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+            return false
+        }
         let host = url.host?.lowercased() ?? ""
         return host == "127.0.0.1" || host == "localhost" || host == "::1"
     }

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -1965,12 +1965,16 @@ final class DesktopStore: ObservableObject {
     func chatGoalProposal(from draft: String) -> ChatGoalProposal? {
         let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedDraft.isEmpty else { return nil }
-        let firstLine = trimmedDraft
+        let normalizedDraft = strippedLeadingSlashCommand(
+            from: strippedLeadingListPrefix(from: trimmedDraft),
+            commands: ["goal", "objective", "목표"]
+        )
+        let firstLine = normalizedDraft
             .split(whereSeparator: \.isNewline)
             .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
 
-        let rawTitle = firstLine ?? String(trimmedDraft.prefix(80))
+        let rawTitle = firstLine ?? String(normalizedDraft.prefix(80))
         let normalizedTitle = rawTitle
             .replacingOccurrences(
                 of: #"^([\-*•]\s+|\d+[.)]\s+)"#,
@@ -1983,13 +1987,13 @@ final class DesktopStore: ObservableObject {
                 options: [.regularExpression, .caseInsensitive]
             )
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let fallbackTitle = trimmedDraft
+        let fallbackTitle = normalizedDraft
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let title = normalizedTitle.isEmpty ? String(fallbackTitle.prefix(80)) : normalizedTitle
         guard !title.isEmpty else { return nil }
 
-        return ChatGoalProposal(title: title, description: trimmedDraft)
+        return ChatGoalProposal(title: title, description: normalizedDraft)
     }
 
     func chatCompanyRequestProposal(from draft: String) -> ChatCompanyRequestProposal? {
@@ -3694,9 +3698,48 @@ final class DesktopStore: ObservableObject {
     }
 
     private func cleanedCreationPrompt(_ message: String) -> String {
+        var cleaned = strippedLeadingSlashCommand(
+            from: strippedLeadingListPrefix(from: message),
+            commands: ["goal", "objective", "issue", "task", "ticket", "목표", "이슈", "태스크", "작업"]
+        )
+        cleaned = cleaned
+            .replacingOccurrences(
+                of: #"(?i)^\s*(create|make|add)\s+(a\s+|an\s+)?(goal|objective|issue|task|ticket)\s*[:：\-]?\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"^\s*(목표|이슈|태스크|작업)\s*(생성|만들기|만들어|추가)?\s*[:：\-]?\s*"#,
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"\s*(만들어|만들어줘|만들어 줘|생성|생성해줘|생성해 줘|추가|추가해줘|추가해 줘|해줘|해 줘|해주세요)\s*$"#,
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned
+    }
+
+    private func strippedLeadingListPrefix(from message: String) -> String {
         message
-            .replacingOccurrences(of: #"(?i)\b(create|make|add)\b"#, with: "", options: .regularExpression)
-            .replacingOccurrences(of: #"(목표|이슈|태스크|만들어|생성|추가|해줘)"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(
+                of: #"^([\-*•]\s+|\d+[.)]\s+)"#,
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func strippedLeadingSlashCommand(from message: String, commands: [String]) -> String {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/") else { return trimmed }
+        let escapedCommands = commands.map { NSRegularExpression.escapedPattern(for: $0) }.joined(separator: "|")
+        let pattern = #"(?i)^\s*/("# + escapedCommands + #")(?=$|[:：\-\s])\s*[:：\-]?\s*"#
+        return trimmed
+            .replacingOccurrences(of: pattern, with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -3763,11 +3806,23 @@ final class DesktopStore: ObservableObject {
     }
 
     private func looksLikeGoalCreationChatRequest(_ text: String) -> Bool {
-        (text.contains("목표") || text.contains("goal")) && containsAny(text, ["생성", "만들", "추가", "create", "add"])
+        isSlashCommand(text, commands: ["goal", "objective", "목표"]) ||
+            ((text.contains("목표") || text.contains("goal")) && containsAny(text, ["생성", "만들", "추가", "create", "add"]))
     }
 
     private func looksLikeIssueCreationChatRequest(_ text: String) -> Bool {
-        (text.contains("이슈") || text.contains("issue") || text.contains("task")) && containsAny(text, ["생성", "만들", "추가", "create", "add"])
+        isSlashCommand(text, commands: ["issue", "task", "ticket", "이슈", "태스크", "작업"]) ||
+            ((text.contains("이슈") || text.contains("issue") || text.contains("task")) && containsAny(text, ["생성", "만들", "추가", "create", "add"]))
+    }
+
+    private func isSlashCommand(_ text: String, commands: [String]) -> Bool {
+        let trimmed = strippedLeadingListPrefix(from: text)
+        guard trimmed.hasPrefix("/") else { return false }
+        let escapedCommands = commands.map { NSRegularExpression.escapedPattern(for: $0) }.joined(separator: "|")
+        return trimmed.range(
+            of: #"(?i)^/("# + escapedCommands + #")(?=$|[:：\-\s])"#,
+            options: .regularExpression
+        ) != nil
     }
 
     private func looksLikeGoalDecompositionChatRequest(_ text: String) -> Bool {

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -3451,10 +3451,6 @@ final class DesktopStore: ObservableObject {
             return await runOperatorCommandAsChatReply(message: message)
         }
 
-        if let response = await runCompanyOperatorChat(message: message) {
-            return operatorAssistantText(for: response)
-        }
-
         if selectedOperatorAutomationMode.uppercased() == "ASK_ME",
            looksLikeHrStaffingChatRequest(normalized) {
             appendOperatorChatMessage(

--- a/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
+++ b/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
@@ -484,10 +484,33 @@ internal func staleRuntimeJarsToClean(in runtimeDir: URL, liveCommandLines: Set<
         at: runtimeDir, includingPropertiesForKeys: nil
     ) else { return [] }
     return files.filter { file in
-        file.lastPathComponent.hasPrefix("cotor-backend-runtime-") &&
+        let pathAliases = runtimeJarPathAliases(for: file)
+        return isBackendRuntimeJar(file.lastPathComponent) &&
         file.pathExtension == "jar" &&
-        !liveCommandLines.contains(where: { $0.contains(file.path) })
+        !liveCommandLines.contains(where: { line in
+            pathAliases.contains(where: { line.contains($0) })
+        })
     }
+    .sorted { $0.lastPathComponent < $1.lastPathComponent }
+}
+
+private func isBackendRuntimeJar(_ fileName: String) -> Bool {
+    fileName.hasPrefix("cotor-backend-runtime-") || fileName.hasPrefix("cotor-app-server-")
+}
+
+private func runtimeJarPathAliases(for file: URL) -> Set<String> {
+    let raw = file.path
+    let standardized = file.standardizedFileURL.path
+    let resolved = file.resolvingSymlinksInPath().path
+    var aliases = Set([raw, standardized, resolved])
+    for path in Array(aliases) {
+        if path.hasPrefix("/private/var/") || path.hasPrefix("/private/tmp/") {
+            aliases.insert(String(path.dropFirst("/private".count)))
+        } else if path.hasPrefix("/var/") || path.hasPrefix("/tmp/") {
+            aliases.insert("/private\(path)")
+        }
+    }
+    return aliases
 }
 
 internal func sanitizedEmbeddedBackendEnvironment(

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -426,6 +426,7 @@ struct UpsertMarketingDelegationPolicyPayload: Codable {
 
 struct MarketingActionRecord: Codable, Identifiable, Hashable {
     let id: String
+    let runId: String?
     let channel: String
     let action: String
     let targetUrl: String
@@ -438,6 +439,41 @@ struct MarketingActionRecord: Codable, Identifiable, Hashable {
     let createdAt: Int64
     let updatedAt: Int64
     let error: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case runId
+        case channel
+        case action
+        case targetUrl
+        case inputSummary
+        case postedUrl
+        case screenshotPath
+        case utm
+        case status
+        case idempotencyKey
+        case createdAt
+        case updatedAt
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        runId = try container.decodeIfPresent(String.self, forKey: .runId)
+        channel = try container.decode(String.self, forKey: .channel)
+        action = try container.decodeValue(String.self, forKey: .action, default: channel)
+        targetUrl = try container.decode(String.self, forKey: .targetUrl)
+        inputSummary = try container.decode(String.self, forKey: .inputSummary)
+        postedUrl = try container.decodeIfPresent(String.self, forKey: .postedUrl)
+        screenshotPath = try container.decodeIfPresent(String.self, forKey: .screenshotPath)
+        utm = try container.decodeIfPresent(String.self, forKey: .utm)
+        status = try container.decode(String.self, forKey: .status)
+        idempotencyKey = try container.decode(String.self, forKey: .idempotencyKey)
+        createdAt = try container.decode(Int64.self, forKey: .createdAt)
+        updatedAt = try container.decode(Int64.self, forKey: .updatedAt)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+    }
 }
 
 struct MarketingRunRecord: Codable, Identifiable, Hashable {
@@ -1071,6 +1107,15 @@ struct CompanyRuntimeSnapshotRecord: Codable, Hashable {
 
     var isBudgetPaused: Bool {
         budgetPausedAt != nil
+    }
+
+    var isDetachedLocalBackend: Bool {
+        guard backendKind.uppercased() == "LOCAL_COTOR", status.uppercased() == "RUNNING" else {
+            return false
+        }
+        let health = backendHealth.lowercased()
+        let lifecycle = backendLifecycleState.uppercased()
+        return health == "offline" || lifecycle == "STOPPED"
     }
 }
 

--- a/macos/Sources/CotorDesktopApp/Resources/Terminal/terminal.html
+++ b/macos/Sources/CotorDesktopApp/Resources/Terminal/terminal.html
@@ -161,7 +161,8 @@
 
       function setStatus(message, tone = 'muted') {
         const el = document.createElement('strong');
-        el.className = tone;
+        const allowedTones = new Set(['muted', 'good', 'warn', 'bad']);
+        el.className = allowedTones.has(tone) ? tone : 'muted';
         el.textContent = message;
         statusLeft.textContent = '';
         statusLeft.appendChild(el);

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -686,6 +686,141 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func chatGoalProposalStripsSlashGoalCommand() {
+        let store = DesktopStore()
+
+        let proposal = store.chatGoalProposal(from: "/goal Stabilize the company runtime\nKeep the work scoped to app-server startup.")
+
+        #expect(proposal == ChatGoalProposal(
+            title: "Stabilize the company runtime",
+            description: "Stabilize the company runtime\nKeep the work scoped to app-server startup."
+        ))
+    }
+
+    @Test
+    func chatGoalProposalStripsListPrefixedSlashGoalCommand() {
+        let store = DesktopStore()
+
+        let proposal = store.chatGoalProposal(from: "- /goal Stabilize the company runtime")
+
+        #expect(proposal == ChatGoalProposal(
+            title: "Stabilize the company runtime",
+            description: "Stabilize the company runtime"
+        ))
+    }
+
+    @Test
+    func listPrefixedSlashGoalCommandRoutesThroughChatGoalCreation() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
+        let api = DesktopAPI(
+            baseURL: URL(string: "http://desktop.test")!,
+            token: "test-token",
+            session: URLSession(configuration: configuration)
+        )
+        let store = DesktopStore(api: api)
+        let company = company(id: "company", repositoryId: "repo", name: "Company")
+        store.selectedCompanyID = company.id
+        store.dashboard = DashboardPayload(
+            repositories: [],
+            workspaces: [],
+            tasks: [],
+            settings: DashboardPayload.empty.settings,
+            companies: [company],
+            companyAgentDefinitions: [],
+            agentCapabilityProfiles: [],
+            projectContexts: [],
+            goals: [],
+            issues: [],
+            reviewQueue: [],
+            orgProfiles: [],
+            workflowTopologies: [],
+            goalDecisions: [],
+            runningAgentSessions: [],
+            backendStatuses: [],
+            opsMetrics: DashboardPayload.empty.opsMetrics,
+            activity: [],
+            companyRuntimes: [],
+            agentContextEntries: [],
+            agentMessages: [],
+            agentPerformance: []
+        )
+
+        let capturedPayloads = Locked<[CreateGoalPayload]>([])
+        let createdGoal = goal(
+            id: "goal",
+            companyId: company.id,
+            title: "Stabilize the company runtime",
+            status: "ACTIVE"
+        )
+        let dashboardAfterCreate = DashboardPayload(
+            repositories: [],
+            workspaces: [],
+            tasks: [],
+            settings: DashboardPayload.empty.settings,
+            companies: [company],
+            companyAgentDefinitions: [],
+            agentCapabilityProfiles: [],
+            projectContexts: [],
+            goals: [createdGoal],
+            issues: [],
+            reviewQueue: [],
+            orgProfiles: [],
+            workflowTopologies: [],
+            goalDecisions: [],
+            runningAgentSessions: [],
+            backendStatuses: [],
+            opsMetrics: DashboardPayload.empty.opsMetrics,
+            activity: [],
+            companyRuntimes: [],
+            agentContextEntries: [],
+            agentMessages: [],
+            agentPerformance: []
+        )
+        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+            let encoder = JSONEncoder()
+            let path = request.url?.path ?? ""
+            let data: Data
+            if path == "/api/app/companies/company/goals", request.httpMethod == "POST" {
+                let body = try #require(requestBodyData(from: request))
+                let payload = try JSONDecoder().decode(CreateGoalPayload.self, from: body)
+                capturedPayloads.withLock { $0.append(payload) }
+                data = try encoder.encode(createdGoal)
+            } else if path == "/api/app/dashboard" {
+                data = try encoder.encode(dashboardAfterCreate)
+            } else if path == "/api/app/skills" {
+                data = try encoder.encode([SkillCatalogEntryRecord]())
+            } else {
+                data = Data("{}".utf8)
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, data)
+        }
+        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+
+        await store.submitOperatorChatMessage("- /goal Stabilize the company runtime")
+
+        #expect(capturedPayloads.withLock { $0.map(\.title) } == ["Stabilize the company runtime"])
+        #expect(store.operatorChatMessages.last?.text == "Created goal: Stabilize the company runtime")
+        #expect(store.selectedGoalID == "goal")
+    }
+
+    @Test
+    func chatGoalProposalStripsKoreanSlashGoalCommand() {
+        let store = DesktopStore()
+
+        let proposal = store.chatGoalProposal(from: "/목표 마케팅 스킬 첫 실행 안정화")
+
+        #expect(proposal?.title == "마케팅 스킬 첫 실행 안정화")
+        #expect(proposal?.description == "마케팅 스킬 첫 실행 안정화")
+    }
+
+    @Test
     func chatCompanyRequestProposalTurnsVagueDraftIntoCeoIntake() {
         let store = DesktopStore()
 
@@ -1349,6 +1484,25 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func skillBlockedByMissingRequiredCapabilityIsNotRunnable() {
+        let agent = agentDefinition(id: "agent-op", title: "Operator", roleSummary: "marketing")
+        let profile = capabilityProfile(agentId: agent.id, settings: [
+            "SKILL_RUN": AgentCapabilitySettingRecord(enabled: true, mode: "AUTO", skillAllowlist: ["browser-smoke"])
+        ])
+        let card = AgentSkillCardRecord(
+            agent: agent,
+            profile: profile,
+            skillCatalog: [
+                skillEntry(name: "browser-smoke", displayName: "Browser Tester", requiredCapabilities: ["BROWSER_READ"])
+            ]
+        )
+
+        #expect(card.runnableSkills.isEmpty)
+        #expect(card.primaryRunnableSkill == nil)
+        #expect(card.blockedSkillReasons["browser-smoke"]?.contains("BROWSER_READ") == true)
+    }
+
+    @Test
     func refreshTuiSessionListDoesNotOverwriteSelectedWorkspaceWithFirstSession() async throws {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
@@ -1631,4 +1785,43 @@ final class DesktopStoreCapturingURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+}
+
+final class Locked<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func withLock<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+}
+
+private func requestBodyData(from request: URLRequest) -> Data? {
+    if let body = request.httpBody {
+        return body
+    }
+    guard let stream = request.httpBodyStream else {
+        return nil
+    }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while stream.hasBytesAvailable {
+        let read = stream.read(&buffer, maxLength: buffer.count)
+        if read < 0 {
+            return nil
+        }
+        if read == 0 {
+            break
+        }
+        data.append(buffer, count: read)
+    }
+    return data
 }

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -711,10 +711,11 @@ struct DesktopStoreTests {
 
     @Test
     func listPrefixedSlashGoalCommandRoutesThroughChatGoalCreation() async throws {
+        let host = "desktop-goal.test"
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
         let api = DesktopAPI(
-            baseURL: URL(string: "http://desktop.test")!,
+            baseURL: URL(string: "http://\(host)")!,
             token: "test-token",
             session: URLSession(configuration: configuration)
         )
@@ -777,7 +778,7 @@ struct DesktopStoreTests {
             agentMessages: [],
             agentPerformance: []
         )
-        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+        DesktopStoreCapturingURLProtocol.setRequestHandler(forHost: host) { request in
             let encoder = JSONEncoder()
             let path = request.url?.path ?? ""
             let data: Data
@@ -801,7 +802,7 @@ struct DesktopStoreTests {
             )!
             return (response, data)
         }
-        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        defer { DesktopStoreCapturingURLProtocol.removeRequestHandler(forHost: host) }
 
         await store.submitOperatorChatMessage("- /goal Stabilize the company runtime")
 
@@ -1262,10 +1263,11 @@ struct DesktopStoreTests {
 
     @Test
     func staleCompanyAsyncResponsesDoNotOverwriteSelectedCompanyState() async throws {
+        let host = "desktop-stale-company.test"
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
         let session = URLSession(configuration: configuration)
-        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+        DesktopStoreCapturingURLProtocol.setRequestHandler(forHost: host) { request in
             let path = request.url?.path ?? ""
             if path.contains("/github/status") {
                 Thread.sleep(forTimeInterval: 0.1)
@@ -1341,10 +1343,10 @@ struct DesktopStoreTests {
             )!
             return (response, Data(body.utf8))
         }
-        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        defer { DesktopStoreCapturingURLProtocol.removeRequestHandler(forHost: host) }
         let store = DesktopStore(
             api: DesktopAPI(
-                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                baseURL: try #require(URL(string: "http://\(host)")),
                 token: nil,
                 session: session
             )
@@ -1504,10 +1506,11 @@ struct DesktopStoreTests {
 
     @Test
     func refreshTuiSessionListDoesNotOverwriteSelectedWorkspaceWithFirstSession() async throws {
+        let host = "desktop-tui-first.test"
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
         let session = URLSession(configuration: configuration)
-        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+        DesktopStoreCapturingURLProtocol.setRequestHandler(forHost: host) { request in
             let path = request.url?.path ?? ""
             let body: String
             if path.contains("/tui/sessions") {
@@ -1524,10 +1527,10 @@ struct DesktopStoreTests {
             let response = HTTPURLResponse(url: try #require(request.url), statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
             return (response, Data(body.utf8))
         }
-        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        defer { DesktopStoreCapturingURLProtocol.removeRequestHandler(forHost: host) }
         let store = DesktopStore(
             api: DesktopAPI(
-                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                baseURL: try #require(URL(string: "http://\(host)")),
                 token: nil,
                 session: session
             )
@@ -1544,10 +1547,11 @@ struct DesktopStoreTests {
 
     @Test
     func refreshTuiSessionListSetsNilWhenNoSessionMatchesSelectedWorkspace() async throws {
+        let host = "desktop-tui-none.test"
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
         let session = URLSession(configuration: configuration)
-        DesktopStoreCapturingURLProtocol.requestHandler = { request in
+        DesktopStoreCapturingURLProtocol.setRequestHandler(forHost: host) { request in
             let path = request.url?.path ?? ""
             let body: String
             if path.contains("/tui/sessions") {
@@ -1562,10 +1566,10 @@ struct DesktopStoreTests {
             let response = HTTPURLResponse(url: try #require(request.url), statusCode: 200, httpVersion: nil, headerFields: ["Content-Type": "application/json"])!
             return (response, Data(body.utf8))
         }
-        defer { DesktopStoreCapturingURLProtocol.requestHandler = nil }
+        defer { DesktopStoreCapturingURLProtocol.removeRequestHandler(forHost: host) }
         let store = DesktopStore(
             api: DesktopAPI(
-                baseURL: try #require(URL(string: "http://127.0.0.1:8787")),
+                baseURL: try #require(URL(string: "http://\(host)")),
                 token: nil,
                 session: session
             )
@@ -1760,7 +1764,22 @@ struct DesktopStoreTests {
 }
 
 final class DesktopStoreCapturingURLProtocol: URLProtocol, @unchecked Sendable {
-    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    typealias RequestHandler = (URLRequest) throws -> (HTTPURLResponse, Data)
+
+    private static let handlerLock = NSLock()
+    nonisolated(unsafe) private static var requestHandlersByHost: [String: RequestHandler] = [:]
+
+    static func setRequestHandler(forHost host: String, handler: @escaping RequestHandler) {
+        handlerLock.lock()
+        requestHandlersByHost[host] = handler
+        handlerLock.unlock()
+    }
+
+    static func removeRequestHandler(forHost host: String) {
+        handlerLock.lock()
+        requestHandlersByHost.removeValue(forKey: host)
+        handlerLock.unlock()
+    }
 
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -1772,7 +1791,7 @@ final class DesktopStoreCapturingURLProtocol: URLProtocol, @unchecked Sendable {
 
     override func startLoading() {
         do {
-            let (response, data) = try Self.requestHandler?(request) ?? {
+            let (response, data) = try Self.requestHandler(for: request)?(request) ?? {
                 let response = HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
                 return (response, Data())
             }()
@@ -1785,6 +1804,14 @@ final class DesktopStoreCapturingURLProtocol: URLProtocol, @unchecked Sendable {
     }
 
     override func stopLoading() {}
+
+    private static func requestHandler(for request: URLRequest) -> RequestHandler? {
+        let host = request.url?.host ?? ""
+        handlerLock.lock()
+        let handler = requestHandlersByHost[host]
+        handlerLock.unlock()
+        return handler
+    }
 }
 
 final class Locked<Value>: @unchecked Sendable {

--- a/macos/Tests/CotorDesktopAppTests/EmbeddedBackendLauncherTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/EmbeddedBackendLauncherTests.swift
@@ -11,17 +11,18 @@ struct EmbeddedBackendLauncherTests {
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         let staleJar = tmpDir.appendingPathComponent("cotor-backend-runtime-999.jar")
+        let staleAppServerJar = tmpDir.appendingPathComponent("cotor-app-server-999.jar")
         let liveJar = tmpDir.appendingPathComponent("cotor-backend-runtime-1234.jar")
         let unrelated = tmpDir.appendingPathComponent("something-else.jar")
         FileManager.default.createFile(atPath: staleJar.path, contents: nil)
+        FileManager.default.createFile(atPath: staleAppServerJar.path, contents: nil)
         FileManager.default.createFile(atPath: liveJar.path, contents: nil)
         FileManager.default.createFile(atPath: unrelated.path, contents: nil)
 
         let liveCommandLines: Set<String> = ["/usr/bin/java -jar \(liveJar.path) app-server --port 8787"]
         let toClean = staleRuntimeJarsToClean(in: tmpDir, liveCommandLines: liveCommandLines)
 
-        #expect(toClean.count == 1)
-        #expect(toClean.first?.lastPathComponent == "cotor-backend-runtime-999.jar")
+        #expect(toClean.map(\.lastPathComponent) == ["cotor-app-server-999.jar", "cotor-backend-runtime-999.jar"])
     }
 
     @Test
@@ -32,6 +33,22 @@ struct EmbeddedBackendLauncherTests {
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         let liveJar = tmpDir.appendingPathComponent("cotor-backend-runtime-42.jar")
+        FileManager.default.createFile(atPath: liveJar.path, contents: nil)
+
+        let liveCommandLines: Set<String> = ["/usr/bin/java -jar \(liveJar.path) app-server --port 8787"]
+        let toClean = staleRuntimeJarsToClean(in: tmpDir, liveCommandLines: liveCommandLines)
+
+        #expect(toClean.isEmpty)
+    }
+
+    @Test
+    func liveAppServerJarIsNotMarkedStale() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cotor-app-server-live-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let liveJar = tmpDir.appendingPathComponent("cotor-app-server-42.jar")
         FileManager.default.createFile(atPath: liveJar.path, contents: nil)
 
         let liveCommandLines: Set<String> = ["/usr/bin/java -jar \(liveJar.path) app-server --port 8787"]

--- a/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
@@ -208,7 +208,23 @@ struct ModelsTests {
               "channels": ["web"],
               "delegationPolicyId": "policy-1",
               "status": "COMPLETED",
-              "actions": [],
+              "actions": [
+                {
+                  "id": "action-1",
+                  "runId": "run-1",
+                  "channel": "web",
+                  "targetUrl": "http://127.0.0.1:8787/health",
+                  "inputSummary": "web: no editable field; no publish button",
+                  "postedUrl": "http://127.0.0.1:8787/health?utm_source=cotor",
+                  "screenshotPath": "/tmp/cotor-marketing.png",
+                  "utm": "utm_source=cotor",
+                  "status": "SUCCEEDED",
+                  "idempotencyKey": "key-1",
+                  "error": null,
+                  "createdAt": 1,
+                  "updatedAt": 2
+                }
+              ],
               "message": "done",
               "error": null,
               "createdAt": 1,
@@ -222,6 +238,8 @@ struct ModelsTests {
 
         #expect(dashboard.marketingDelegationPolicies.map(\.id) == ["policy-1"])
         #expect(dashboard.marketingRuns.map(\.id) == ["run-1"])
+        #expect(dashboard.marketingRuns.first?.actions.first?.runId == "run-1")
+        #expect(dashboard.marketingRuns.first?.actions.first?.action == "web")
     }
 
     @Test
@@ -617,6 +635,32 @@ struct ModelsTests {
         let fallback = URL(string: "http://127.0.0.1:8787")!
         let (url, _) = DesktopAPI.validatedAppServerConfiguration(
             envURL: "https://remote.cotor.io:8787",
+            envAllowRemote: nil,
+            envToken: "some-token",
+            fallbackURL: fallback,
+            appToken: "app-token"
+        )
+        #expect(url.absoluteString == fallback.absoluteString)
+    }
+
+    @Test
+    func appServerConfigDeceptiveLoopbackHostFallsBackToLoopback() {
+        let fallback = URL(string: "http://127.0.0.1:8787")!
+        let (url, _) = DesktopAPI.validatedAppServerConfiguration(
+            envURL: "http://localhost.evil.test:8787",
+            envAllowRemote: nil,
+            envToken: "some-token",
+            fallbackURL: fallback,
+            appToken: "app-token"
+        )
+        #expect(url.absoluteString == fallback.absoluteString)
+    }
+
+    @Test
+    func appServerConfigNonHttpLoopbackURLFallsBackToLoopback() {
+        let fallback = URL(string: "http://127.0.0.1:8787")!
+        let (url, _) = DesktopAPI.validatedAppServerConfiguration(
+            envURL: "ftp://localhost:8787",
             envAllowRemote: nil,
             envToken: "some-token",
             fallbackURL: fallback,

--- a/shell/test-desktop-launcher-runtime.sh
+++ b/shell/test-desktop-launcher-runtime.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$PROJECT_ROOT/macos/Packaging/CotorDesktopLauncher.sh.template"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "launcher template not found: $TEMPLATE"
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+HOME="$WORK_DIR/home"
+mkdir -p "$HOME"
+
+COTOR_DESKTOP_LAUNCHER_SOURCE_ONLY=1 source "$TEMPLATE"
+
+BACKEND_RUNTIME_JAR="$WORK_DIR/runtime/cotor-backend-runtime-old.jar"
+mkdir -p "$(dirname "$BACKEND_RUNTIME_JAR")" "$RUNTIME_DIR"
+touch "$BACKEND_RUNTIME_JAR"
+
+SERVER_PORT="55123"
+SERVER_TOKEN="token-123"
+PID_FILE="$WORK_DIR/app-server.pid"
+PORT_FILE="$WORK_DIR/app-server.port"
+TOKEN_FILE="$WORK_DIR/app-server.token"
+MANAGED_BACKEND_PID="111"
+MANAGED_BACKEND_STARTED=1
+echo "222" > "$PID_FILE"
+
+restart_calls=0
+start_managed_backend() {
+  local show_failure_alert="${1:-1}"
+  if [[ "$show_failure_alert" != "0" ]]; then
+    echo "restart should suppress user-facing alerts"
+    exit 1
+  fi
+  if [[ "$SERVER_PORT" != "55123" || "$SERVER_TOKEN" != "token-123" ]]; then
+    echo "restart did not preserve backend port/token"
+    exit 1
+  fi
+  restart_calls=$((restart_calls + 1))
+}
+
+restart_managed_backend
+
+if [[ "$restart_calls" != "1" ]]; then
+  echo "restart_managed_backend did not call start_managed_backend once"
+  exit 1
+fi
+if [[ -e "$PID_FILE" || -e "$BACKEND_RUNTIME_JAR" ]]; then
+  echo "restart_managed_backend did not clear stale pid/runtime jar"
+  exit 1
+fi
+
+BACKEND_RUNTIME_DIR="$WORK_DIR/runtime/backend"
+mkdir -p "$BACKEND_RUNTIME_DIR"
+BACKEND_RUNTIME_JAR="$BACKEND_RUNTIME_DIR/cotor-backend-runtime-current.jar"
+STALE_RUNTIME_JAR="$BACKEND_RUNTIME_DIR/cotor-backend-runtime-stale.jar"
+STALE_APP_SERVER_JAR="$BACKEND_RUNTIME_DIR/cotor-app-server-stale.jar"
+touch "$BACKEND_RUNTIME_JAR" "$STALE_RUNTIME_JAR" "$STALE_APP_SERVER_JAR"
+
+cleanup_stale_backend_runtime_jars
+
+if [[ ! -e "$BACKEND_RUNTIME_JAR" ]]; then
+  echo "cleanup_stale_backend_runtime_jars removed current runtime jar"
+  exit 1
+fi
+if [[ -e "$STALE_RUNTIME_JAR" || -e "$STALE_APP_SERVER_JAR" ]]; then
+  echo "cleanup_stale_backend_runtime_jars did not remove stale runtime jars"
+  exit 1
+fi
+
+SCRIPT_DIR="/Applications/Cotor Desktop.app/Contents/MacOS"
+BINARY_PATH="$SCRIPT_DIR/CotorDesktopBinary"
+terminated_instances=""
+ps() {
+  if [[ "$*" == "-axo pid=,args=" ]]; then
+    printf '%s\n' \
+      "123 $BINARY_PATH" \
+      "124 /bin/bash $SCRIPT_DIR/CotorDesktopLauncher" \
+      "125 /usr/bin/other-process"
+    return 0
+  fi
+  command ps "$@"
+}
+kill() {
+  terminated_instances="$terminated_instances ${*: -1}"
+  return 0
+}
+is_pid_alive() {
+  return 1
+}
+sleep() {
+  return 0
+}
+
+terminate_existing_desktop_instances
+
+if [[ "$terminated_instances" != *"123"* || "$terminated_instances" != *"124"* || "$terminated_instances" == *"125"* ]]; then
+  echo "terminate_existing_desktop_instances did not target only old desktop instances"
+  exit 1
+fi
+
+MANAGED_BACKEND_PID="111"
+MANAGED_BACKEND_STARTED=1
+echo "222" > "$PID_FILE"
+killed_pid=""
+cleared=0
+after_kill=0
+
+is_pid_alive() {
+  [[ "$1" == "222" && "$after_kill" == "0" ]]
+}
+
+request_backend_shutdown() {
+  return 1
+}
+
+kill() {
+  killed_pid="${*: -1}"
+  after_kill=1
+  return 0
+}
+
+sleep() {
+  return 0
+}
+
+clear_backend_runtime_files() {
+  cleared=1
+}
+
+stop_managed_backend
+
+if [[ "$killed_pid" != "222" || "$cleared" != "1" ]]; then
+  echo "stop_managed_backend did not fall back to pid file for monitor-restarted backend"
+  exit 1
+fi
+
+MANAGED_BACKEND_STARTED=1
+MANAGED_BACKEND_PID="333"
+SERVER_PORT="55123"
+SERVER_URL="http://127.0.0.1:55123"
+restart_calls=0
+monitor_app_checks=0
+is_pid_alive() {
+  if [[ "$1" == "999" ]]; then
+    monitor_app_checks=$((monitor_app_checks + 1))
+    [[ "$monitor_app_checks" == "1" ]]
+    return
+  fi
+  [[ "$1" == "333" ]]
+}
+is_port_listening() {
+  return 0
+}
+is_backend_healthy() {
+  return 1
+}
+restart_managed_backend() {
+  restart_calls=$((restart_calls + 1))
+  MANAGED_BACKEND_STARTED=0
+}
+sleep() {
+  return 0
+}
+
+monitor_managed_backend "999"
+
+if [[ "$restart_calls" != "1" ]]; then
+  echo "monitor_managed_backend did not restart a listening but unhealthy backend"
+  exit 1
+fi
+
+echo "desktop launcher runtime tests passed"

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -62,6 +62,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
 import java.nio.channels.OverlappingFileLockException
@@ -263,7 +265,13 @@ internal class DesktopAppServerInstanceGuard(
 
 internal val desktopAppServerInstanceGuard = DesktopAppServerInstanceGuard()
 
-internal fun readDesktopAppServerInstanceStatus(appHome: Path): DesktopAppServerInstanceStatus {
+internal fun readDesktopAppServerInstanceStatus(
+    appHome: Path,
+    processAliveChecker: (Long) -> Boolean = { pid ->
+        ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)
+    },
+    endpointReachableChecker: (String, Int) -> Boolean = ::isDesktopAppServerEndpointReachable
+): DesktopAppServerInstanceStatus {
     val metadataPath = appHome.resolve("runtime").resolve("backend").resolve("app-server.instance.json")
     if (!Files.exists(metadataPath)) {
         return DesktopAppServerInstanceStatus(active = false)
@@ -272,8 +280,23 @@ internal fun readDesktopAppServerInstanceStatus(appHome: Path): DesktopAppServer
     val metadata = runCatching {
         json.decodeFromString(DesktopAppServerInstanceMetadata.serializer(), Files.readString(metadataPath))
     }.getOrNull() ?: return DesktopAppServerInstanceStatus(active = false)
-    val active = ProcessHandle.of(metadata.pid).map(ProcessHandle::isAlive).orElse(false)
+    val active = processAliveChecker(metadata.pid) && endpointReachableChecker(metadata.host, metadata.port)
     return DesktopAppServerInstanceStatus(active = active, metadata = metadata.takeIf { active })
+}
+
+private fun isDesktopAppServerEndpointReachable(host: String, port: Int): Boolean {
+    if (port <= 0) {
+        return false
+    }
+    val probeHost = when (host.trim()) {
+        "", "0.0.0.0", "::" -> "127.0.0.1"
+        else -> host.trim()
+    }
+    return runCatching {
+        Socket().use { socket ->
+            socket.connect(InetSocketAddress(probeHost, port), 250)
+        }
+    }.isSuccess
 }
 
 internal fun appServerTokenPath(appHome: Path = defaultDesktopAppHome()): Path {
@@ -342,6 +365,7 @@ internal fun Application.cotorAppModule(
     install(CORS) {
         allowHost("127.0.0.1", schemes = listOf("http"))
         allowHost("localhost", schemes = listOf("http"))
+        allowOrigins { origin -> origin == "null" }
         allowHeader(HttpHeaders.Authorization)
         allowHeader(HttpHeaders.ContentType)
     }
@@ -653,7 +677,9 @@ internal fun Application.cotorAppModule(
                 post("/clone") {
                     if (!requireToken(token)) return@post
                     val request = call.receive<CloneRepositoryRequest>()
-                    call.respond(desktopService.cloneRepository(request.url))
+                    respondDesktopRequest {
+                        desktopService.cloneRepository(request.url)
+                    }
                 }
             }
 

--- a/src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt
+++ b/src/main/kotlin/com/cotor/app/CompanyRuntimeRetention.kt
@@ -71,7 +71,7 @@ class CompanyRuntimeRetention(
         terminalRetentionDays: Int,
         orphanRetentionDays: Int
     ): RuntimeCleanupCandidate? {
-        val normalized = path.toAbsolutePath().normalize().toString()
+        val normalized = canonicalPath(path).toString()
         val refs = referencesForPath(state, normalized, scope)
         if (!scope.includes(refs.companyId)) {
             return null
@@ -189,7 +189,7 @@ class CompanyRuntimeRetention(
         state.reviewQueue
             .filter { scope.includes(it.companyId) }
             .mapNotNullTo(roots) { repositoryWorktreeRootFor(it.worktreePath) }
-        return roots.map { it.toAbsolutePath().normalize() }.distinct()
+        return roots.map(::canonicalPath).distinct()
     }
 
     private fun candidateWorktrees(root: Path): List<Path> {
@@ -263,10 +263,19 @@ class CompanyRuntimeRetention(
     }
 
     private fun safePath(raw: String?): Path? =
-        raw?.takeIf { it.isNotBlank() }?.let { runCatching { Path.of(it).toAbsolutePath().normalize() }.getOrNull() }
+        raw?.takeIf { it.isNotBlank() }?.let { runCatching { canonicalPath(Path.of(it)) }.getOrNull() }
 
     private fun String?.normalizedPath(): String? =
         safePath(this)?.toString()
+
+    private fun canonicalPath(path: Path): Path {
+        val absolute = path.toAbsolutePath().normalize()
+        return if (Files.exists(absolute)) {
+            runCatching { absolute.toRealPath() }.getOrDefault(absolute)
+        } else {
+            absolute
+        }
+    }
 
     private fun candidate(
         kind: String,

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -1601,6 +1601,7 @@ class DesktopAppService(
                 tasks = updatedTasks,
                 runs = updatedRuns
             )
+            val interruptedIssueIds = activeTasks.mapNotNullTo(linkedSetOf()) { it.issueId }
             activeTasks.forEach { task ->
                 val issue = task.issueId?.let(issuesById::get) ?: return@forEach
                 if (issue.status == IssueStatus.DONE || issue.status == IssueStatus.CANCELED) {
@@ -1627,6 +1628,10 @@ class DesktopAppService(
                         if (existing.id == issue.id) {
                             existing.copy(
                                 status = reopenedStatus,
+                                durableRunId = latestRun?.id ?: existing.durableRunId,
+                                approvalPauseId = null,
+                                providerBlockReason = null,
+                                runtimeDisposition = "runtime-interrupted-retryable",
                                 transitionReason = INTERRUPTED_ISSUE_REASON,
                                 updatedAt = now
                             )
@@ -1642,6 +1647,23 @@ class DesktopAppService(
                     severity = "warning",
                     goalId = issue.goalId,
                     issueId = issue.id
+                )
+            }
+            if (interruptedIssueIds.isNotEmpty()) {
+                nextState = nextState.copy(
+                    companyRuntimeWorkItems = nextState.companyRuntimeWorkItems.map { workItem ->
+                        if (workItem.issueId in interruptedIssueIds) {
+                            workItem.copy(
+                                status = CompanyRuntimeWorkItemStatus.READY,
+                                activeTaskId = null,
+                                durableRunId = null,
+                                reason = INTERRUPTED_ISSUE_REASON,
+                                updatedAt = now
+                            )
+                        } else {
+                            workItem
+                        }
+                    }
                 )
             }
             nextState = nextState.recordSignal(
@@ -1671,7 +1693,10 @@ class DesktopAppService(
                 .groupBy { it.taskId }
                 .mapValues { (_, runs) -> runs.maxByOrNull { it.updatedAt }!! }
             val issuesToReopen = state.issues.mapNotNull { issue ->
-                if (issue.companyId != companyId || issue.status != IssueStatus.BLOCKED) {
+                if (
+                    issue.companyId != companyId ||
+                    issue.status !in setOf(IssueStatus.BLOCKED, IssueStatus.PLANNED, IssueStatus.DELEGATED, IssueStatus.IN_PROGRESS)
+                ) {
                     return@mapNotNull null
                 }
                 if (issue.pullRequestNumber != null || issue.pullRequestUrl != null) {
@@ -1682,15 +1707,24 @@ class DesktopAppService(
                 }
                 val latestTask = latestTasksByIssueId[issue.id] ?: return@mapNotNull null
                 val latestRun = latestRunsByTaskId[latestTask.id] ?: return@mapNotNull null
+                val interruptedRunError = latestRun.error?.let(::isInterruptedRunError) == true
+                val explicitAppServerInterruption = latestRun.error?.contains(INTERRUPTED_RUN_ERROR, ignoreCase = true) == true
+                val legacyInterruptionBeforeRestart =
+                    latestRun.error?.contains("Agent process exited before Cotor recorded a final result", ignoreCase = true) == true &&
+                        latestTask.updatedAt < interruptionBoundary
+                val alreadyQueued =
+                    issue.status in setOf(IssueStatus.PLANNED, IssueStatus.DELEGATED) &&
+                        issue.transitionReason == INTERRUPTED_ISSUE_REASON &&
+                        interruptedRunError
+                if (alreadyQueued) {
+                    return@mapNotNull null
+                }
                 val interruptedByRestart =
                     latestTask.status in setOf(DesktopTaskStatus.FAILED, DesktopTaskStatus.PARTIAL) &&
-                        latestTask.updatedAt < interruptionBoundary &&
+                        (explicitAppServerInterruption || legacyInterruptionBeforeRestart) &&
                         latestRun.status == AgentRunStatus.FAILED &&
                         latestRun.publish == null &&
-                        latestRun.error?.contains(
-                            "Agent process exited before Cotor recorded a final result",
-                            ignoreCase = true
-                        ) == true
+                        interruptedRunError
                 if (!interruptedByRestart) {
                     return@mapNotNull null
                 }
@@ -1702,7 +1736,7 @@ class DesktopAppService(
             val taskIds = issuesToReopen.mapTo(linkedSetOf()) { it.second.first.id }
             val updatedRuns = state.runs.map { run ->
                 if (run.taskId in taskIds && run.status == AgentRunStatus.FAILED &&
-                    run.error?.contains("Agent process exited before Cotor recorded a final result", ignoreCase = true) == true
+                    run.error?.let(::isInterruptedRunError) == true
                 ) {
                     run.copy(
                         error = INTERRUPTED_RUN_ERROR,
@@ -1738,6 +1772,10 @@ class DesktopAppService(
                         if (existing.id == issue.id) {
                             existing.copy(
                                 status = reopenedStatus,
+                                durableRunId = latestRun.id,
+                                approvalPauseId = null,
+                                providerBlockReason = null,
+                                runtimeDisposition = "runtime-interrupted-retryable",
                                 transitionReason = INTERRUPTED_ISSUE_REASON,
                                 updatedAt = now
                             )
@@ -1766,6 +1804,10 @@ class DesktopAppService(
         traceEvents.forEach(::appendCompanyAutomationTrace)
         return reopenedCount
     }
+
+    private fun isInterruptedRunError(error: String): Boolean =
+        error.contains("Agent process exited before Cotor recorded a final result", ignoreCase = true) ||
+            error.contains(INTERRUPTED_RUN_ERROR, ignoreCase = true)
 
     private fun isTaskIntentionallyInterrupted(taskId: String): Boolean =
         taskId in intentionallyInterruptedTaskIds
@@ -2557,6 +2599,19 @@ class DesktopAppService(
             SkillRunEvidence(type = "file", path = reportPath.toString(), title = "${skill.displayName} report")
         )
         val actions = mutableListOf("summarized ${runs.size} marketing run(s)")
+        if (runs.isEmpty()) {
+            return@withContext SkillRunResult(
+                skill = skill.name,
+                status = "FAILED_SETUP",
+                capability = baseCapability,
+                runId = runId,
+                actions = actions,
+                evidence = evidence,
+                summary = "${skill.displayName} could not summarize marketing performance because no MarketingRun evidence exists.",
+                output = report.take(8_000),
+                error = "No MarketingRun evidence is available yet."
+            )
+        }
         val url = parameters["url"]?.trim()?.takeIf { it.isNotBlank() }
         if (url != null) {
             val screenshotCheck = checkSkillCapability(
@@ -3186,6 +3241,7 @@ class DesktopAppService(
                 marketingBrowserRunner.execute(command)
             }.fold(
                 onSuccess = { result ->
+                    val noOpReason = marketingNoOpBrowserResultReason(result)
                     MarketingActionRecord(
                         runId = run.id,
                         channel = channel,
@@ -3194,8 +3250,9 @@ class DesktopAppService(
                         postedUrl = result.postedUrl,
                         screenshotPath = result.screenshotPath,
                         utm = "utm_source=cotor&utm_medium=organic&utm_campaign=${run.id}&utm_content=$channel",
-                        status = MarketingActionStatus.SUCCEEDED,
-                        idempotencyKey = idempotencyKey
+                        status = if (noOpReason == null) MarketingActionStatus.SUCCEEDED else MarketingActionStatus.FAILED,
+                        idempotencyKey = idempotencyKey,
+                        error = noOpReason
                     )
                 },
                 onFailure = { error ->
@@ -3219,6 +3276,18 @@ class DesktopAppService(
         }
         val error = actions.firstOrNull { it.status == MarketingActionStatus.DENIED || it.status == MarketingActionStatus.FAILED }?.error
         return finishMarketingRun(run, status, actions, error)
+    }
+
+    private fun marketingNoOpBrowserResultReason(result: MarketingBrowserResult): String? {
+        val summary = result.inputSummary.lowercase()
+        val hasNoEditableField = summary.contains("no editable field")
+        val hasNoPublishButton = summary.contains("no publish button")
+        val postedChanged = !result.postedUrl.isNullOrBlank() && result.postedUrl != result.targetUrl
+        return if (hasNoEditableField && hasNoPublishButton && !postedChanged) {
+            "Marketing target did not expose an editable field or publish action; screenshot-only navigation is not a successful marketing publish."
+        } else {
+            null
+        }
     }
 
     private suspend fun marketingCapabilityChecks(
@@ -3916,7 +3985,6 @@ class DesktopAppService(
                 .filter { it.status == ReviewQueueStatus.MERGED && !it.approvalIssueId.isNullOrBlank() }
                 .mapNotNull { it.approvalIssueId }
                 .toSet()
-            val settledReviewQueue = updatedReviewQueue.filterNot { it.status == ReviewQueueStatus.MERGED }
             val issuesWithApprovalSettled = updatedIssues.map { issue ->
                 if (issue.id in approvalIssuesToComplete) {
                     issue.copy(
@@ -3966,7 +4034,7 @@ class DesktopAppService(
 
             var nextState = state.copy(
                 issues = issuesWithApprovalSettled,
-                reviewQueue = settledReviewQueue
+                reviewQueue = updatedReviewQueue
             )
             if (mergedIssueIds.isNotEmpty()) {
                 nextState = nextState.recordCompanyActivity(
@@ -4998,6 +5066,13 @@ class DesktopAppService(
                 it.issueId in deletedIssueIds || it.dependsOnIssueId in deletedIssueIds
             },
             orgProfiles = state.orgProfiles.filterNot { it.companyId == companyId },
+            agentCapabilityProfiles = state.agentCapabilityProfiles.filterNot { it.companyId == companyId },
+            goalDecisions = state.goalDecisions.filterNot { decision ->
+                decision.companyId == companyId ||
+                    decision.goalId in deletedGoalIds ||
+                    decision.issueId in deletedIssueIds ||
+                    decision.createdIssues.any { it in deletedIssueIds }
+            },
             reviewQueue = state.reviewQueue.filterNot {
                 it.companyId == companyId || it.issueId in deletedIssueIds || it.runId in deletedRunIds
             },
@@ -5009,7 +5084,12 @@ class DesktopAppService(
             runtime = if (state.runtime.companyId == companyId) CompanyRuntimeSnapshot() else state.runtime,
             workflowPipelines = state.workflowPipelines.filterNot { it.companyId == companyId },
             agentContextEntries = state.agentContextEntries.filterNot { it.companyId == companyId },
-            agentMessages = state.agentMessages.filterNot { it.companyId == companyId }
+            agentMessages = state.agentMessages.filterNot { it.companyId == companyId },
+            companyRuntimeWorkItems = state.companyRuntimeWorkItems.filterNot { it.companyId == companyId },
+            problemSignals = state.problemSignals.filterNot { it.companyId == companyId },
+            marketingDelegationPolicies = state.marketingDelegationPolicies.filterNot { it.companyId == companyId },
+            marketingRuns = state.marketingRuns.filterNot { it.companyId == companyId },
+            skillRuns = state.skillRuns.filterNot { it.companyId == companyId }
         ).withDerivedMetrics()
         stateStore.save(nextState)
         deleteDirectoryRecursively(companyContextRoot(company))
@@ -8277,12 +8357,14 @@ class DesktopAppService(
                 workspaceState.projectContexts + projectContext
             }
             val profiles = ensureOrgProfiles(workspaceState.orgProfiles, companyDefinitions, nextCompanies)
+            val normalizedTitle = normalizeDirectGoalInputText(title).ifBlank { "New Goal" }
+            val normalizedDescription = normalizeDirectGoalInputText(description)
             val goal = CompanyGoal(
                 id = UUID.randomUUID().toString(),
                 companyId = company.id,
                 projectContextId = projectContext.id,
-                title = title.trim().ifEmpty { "New Goal" },
-                description = description.trim(),
+                title = normalizedTitle,
+                description = normalizedDescription,
                 status = GoalStatus.ACTIVE,
                 priority = priority,
                 successMetrics = successMetrics.filter { it.isNotBlank() },
@@ -8354,8 +8436,8 @@ class DesktopAppService(
             val current = state.goals.firstOrNull { it.id == goalId }
                 ?: throw IllegalArgumentException("Goal not found: $goalId")
             val updated = current.copy(
-                title = title?.trim()?.takeIf { it.isNotBlank() } ?: current.title,
-                description = description?.trim()?.takeIf { it.isNotBlank() } ?: current.description,
+                title = title?.let(::normalizeDirectGoalInputText)?.takeIf { it.isNotBlank() } ?: current.title,
+                description = description?.let(::normalizeDirectGoalInputText)?.takeIf { it.isNotBlank() } ?: current.description,
                 successMetrics = successMetrics ?: current.successMetrics,
                 autonomyEnabled = autonomyEnabled ?: current.autonomyEnabled,
                 updatedAt = System.currentTimeMillis()
@@ -8381,6 +8463,12 @@ class DesktopAppService(
         queueGoalPostUpdateWork(updated, startRuntimeIfNeeded)
         return updated
     }
+
+    private fun normalizeDirectGoalInputText(value: String): String =
+        value.trim()
+            .replace(Regex("""^([\-*•]\s+|\d+[.)]\s+)"""), "")
+            .replace(Regex("""(?i)^/(goal|objective|목표)(?=$|[:：\-\s])\s*[:：\-]?\s*"""), "")
+            .trim()
 
     private fun queueGoalPostCreateWork(goal: CompanyGoal, startRuntimeIfNeeded: Boolean) {
         serviceScope.launch {
@@ -8417,7 +8505,14 @@ class DesktopAppService(
             runs = state.runs.filterNot { it.id in deletedRunIds },
             reviewQueue = state.reviewQueue.filterNot { it.issueId in deletedIssueIds || it.runId in deletedRunIds },
             companyActivity = state.companyActivity.filterNot { it.goalId == goalId || it.issueId in deletedIssueIds },
-            signals = state.signals.filterNot { it.goalId == goalId || it.issueId in deletedIssueIds }
+            signals = state.signals.filterNot { it.goalId == goalId || it.issueId in deletedIssueIds },
+            goalDecisions = state.goalDecisions.filterNot { decision ->
+                decision.goalId == goalId ||
+                    decision.issueId in deletedIssueIds ||
+                    decision.createdIssues.any { it in deletedIssueIds }
+            },
+            agentMessages = state.agentMessages.filterNot { it.goalId == goalId || it.issueId in deletedIssueIds },
+            companyRuntimeWorkItems = state.companyRuntimeWorkItems.filterNot { it.issueId in deletedIssueIds }
         ).recordCompanyActivity(
             companyId = goal.companyId,
             projectContextId = goal.projectContextId,
@@ -8492,8 +8587,9 @@ class DesktopAppService(
         val workspace = workspaceResolution.second
         val projectContext = ensureProjectContext(workspaceState, company, now)
         val profiles = ensureOrgProfiles(workspaceState.orgProfiles, workspaceState.companyAgentDefinitions, workspaceState.companies)
+        val normalizedTitle = normalizeGeneratedIssueTitle(title.trim().ifEmpty { "New Issue" })
         val assignee = suggestProfileForCustomIssue(
-            title = title,
+            title = normalizedTitle,
             description = description,
             kind = kind,
             profiles = profiles.filter { it.companyId == companyId }
@@ -8504,7 +8600,7 @@ class DesktopAppService(
             projectContextId = projectContext.id,
             goalId = goal.id,
             workspaceId = workspace.id,
-            title = title.trim().ifEmpty { "New Issue" },
+            title = normalizedTitle,
             description = description.trim(),
             status = if (assignee == null) IssueStatus.PLANNED else IssueStatus.DELEGATED,
             priority = priority.coerceIn(1, 4),
@@ -13224,6 +13320,59 @@ class DesktopAppService(
                     val executionIssue = issuesById[queueItem.issueId] ?: return@forEach
                     val latestExecutionTask = latestTask(executionIssue.id)
                     val latestExecutionRun = latestExecutionTask?.let { latestRun(it.id) }
+                    val queueAlreadyMerged =
+                        queueItem.pullRequestState.equals("MERGED", ignoreCase = true) ||
+                            queueItem.mergeCommitSha != null ||
+                            queueItem.mergedAt != null ||
+                            executionIssue.pullRequestState.equals("MERGED", ignoreCase = true) ||
+                            executionIssue.mergeResult.equals("MERGED", ignoreCase = true)
+                    if (queueAlreadyMerged) {
+                        val reviewIssue = queueItem.qaIssueId?.let(issuesById::get) ?: issuesById.values.firstOrNull {
+                            relatedExecutionIssueId(it) == executionIssue.id && it.kind.equals("review", ignoreCase = true)
+                        }
+                        val approvalIssue = queueItem.approvalIssueId?.let(issuesById::get) ?: issuesById.values.firstOrNull {
+                            relatedExecutionIssueId(it) == executionIssue.id && it.kind.equals("approval", ignoreCase = true)
+                        }
+                        removeWorkflowIssue(reviewIssue?.id)
+                        removeWorkflowIssue(approvalIssue?.id)
+                        val mergedAt = queueItem.mergedAt ?: now
+                        issuesById[executionIssue.id] = executionIssue.copy(
+                            status = IssueStatus.DONE,
+                            pullRequestState = executionIssue.pullRequestState ?: queueItem.pullRequestState ?: "MERGED",
+                            mergeResult = executionIssue.mergeResult ?: "MERGED",
+                            ceoVerdict = executionIssue.ceoVerdict ?: queueItem.ceoVerdict ?: "APPROVE",
+                            ceoFeedback = executionIssue.ceoFeedback ?: queueItem.ceoFeedback ?: "GitHub reports that the linked pull request is merged.",
+                            providerBlockReason = null,
+                            runtimeDisposition = null,
+                            transitionReason = "GitHub state shows the linked PR is already merged; settled the review queue instead of rebuilding QA.",
+                            updatedAt = now
+                        )
+                        reviewQueueById[queueItem.id] = queueItem.copy(
+                            status = ReviewQueueStatus.MERGED,
+                            pullRequestState = queueItem.pullRequestState ?: executionIssue.pullRequestState ?: "MERGED",
+                            qaIssueId = null,
+                            approvalIssueId = null,
+                            ceoVerdict = queueItem.ceoVerdict ?: executionIssue.ceoVerdict ?: "APPROVE",
+                            ceoFeedback = queueItem.ceoFeedback ?: executionIssue.ceoFeedback ?: "GitHub reports that the linked pull request is merged.",
+                            ceoReviewedAt = queueItem.ceoReviewedAt ?: mergedAt,
+                            providerBlockReason = null,
+                            runtimeDisposition = null,
+                            mergedAt = mergedAt,
+                            updatedAt = now
+                        )
+                        changed += 1
+                        traceEvents += buildCompanyAutomationTraceEvent(
+                            issue = executionIssue,
+                            goal = state.goals.firstOrNull { it.id == executionIssue.goalId },
+                            oldStatus = executionIssue.status,
+                            newStatus = IssueStatus.DONE,
+                            source = "repairWorkflowLineages",
+                            reason = "Settled a stale review queue item because GitHub already reports the linked PR as merged.",
+                            latestTask = latestExecutionTask,
+                            latestRun = latestExecutionRun
+                        )
+                        return@forEach
+                    }
                     val pendingExecutionLineageUpdate =
                         latestExecutionTask != null &&
                             latestExecutionTask.status == DesktopTaskStatus.COMPLETED &&
@@ -16621,6 +16770,7 @@ class DesktopAppService(
             .orEmpty()
         val cleaned = firstLine
             .replace(Regex("""^([\-*•]\s+|\d+[.)]\s+)"""), "")
+            .stripLeadingGoalIntakeSlashCommand()
             .replace(Regex("""^(goal|objective|request|ask|목표|요청|할일)\s*:\s*""", RegexOption.IGNORE_CASE), "")
             .replace(Regex("""\s+"""), " ")
             .trim()
@@ -16631,6 +16781,12 @@ class DesktopAppService(
             .trim()
             .ifBlank { fallback }
     }
+
+    private fun String.stripLeadingGoalIntakeSlashCommand(): String =
+        replace(
+            Regex("""(?i)^/(goal|objective|request|ask|목표|요청|할일)(?=$|[:：\-\s])\s*[:：\-]?\s*"""),
+            ""
+        ).trim()
 
     private fun buildChatIntakePlannedIssues(draft: CeoChatIntakeDraft): List<CeoPlannedIssue> {
         if (Regex("[가-힣]").containsMatchIn(draft.title)) {
@@ -17557,9 +17713,10 @@ class DesktopAppService(
         val createdIssuePairs = plan.issues.mapIndexed { index, plannedIssue ->
             val issueId = UUID.randomUUID().toString()
             issueIdsByRef[plannedIssue.refId.trim()] = issueId
+            val normalizedTitle = normalizeGeneratedIssueTitle(plannedIssue.title)
             val assignee = companyProfiles.firstOrNull { it.roleName.equals(plannedIssue.assigneeRole.trim(), ignoreCase = true) }
                 ?: suggestProfileForCustomIssue(
-                    title = plannedIssue.title,
+                    title = normalizedTitle,
                     description = plannedIssue.description,
                     kind = plannedIssue.kind,
                     profiles = companyProfiles
@@ -17567,7 +17724,7 @@ class DesktopAppService(
             val normalizedKind = plannedIssue.kind.trim().ifBlank { "execution" }.lowercase()
             val executionIntent = inferExecutionIntent(
                 kind = normalizedKind,
-                title = plannedIssue.title.trim(),
+                title = normalizedTitle,
                 description = plannedIssue.description.trim(),
                 plannedCodeProducing = plannedIssue.codeProducing
             )
@@ -17581,7 +17738,7 @@ class DesktopAppService(
             }
             val requiresPullRequest = plannedIssue.requiresPullRequest
                 ?: inferIssueRequiresPullRequest(
-                    title = plannedIssue.title,
+                    title = normalizedTitle,
                     description = listOf(
                         goal.description,
                         plannedIssue.description,
@@ -17594,8 +17751,8 @@ class DesktopAppService(
                 projectContextId = goal.projectContextId,
                 goalId = goal.id,
                 workspaceId = workspace.id,
-                title = plannedIssue.title.trim(),
-                description = plannedIssue.description.trim().ifBlank { plannedIssue.title.trim() },
+                title = normalizedTitle,
+                description = plannedIssue.description.trim().ifBlank { normalizedTitle },
                 status = IssueStatus.PLANNED,
                 priority = plannedIssue.priority.coerceIn(1, 4),
                 kind = normalizedKind,
@@ -17686,6 +17843,14 @@ class DesktopAppService(
         issue.sourceSignal.startsWith(CEO_APPROVAL_SOURCE_PREFIX) -> issue.sourceSignal.removePrefix(CEO_APPROVAL_SOURCE_PREFIX)
         else -> null
     }?.takeIf { it.isNotBlank() }
+
+    private fun normalizeGeneratedIssueTitle(title: String): String {
+        val collapsed = title.trim().replace(Regex("\\s+"), " ")
+        return collapsed
+            .replace(Regex("\\bEngoal\\b", RegexOption.IGNORE_CASE), "Goal")
+            .replace(Regex("\\bEn goal\\b", RegexOption.IGNORE_CASE), "Goal")
+            .ifBlank { "New Issue" }
+    }
 
     private fun isWorkflowIssue(issue: CompanyIssue): Boolean =
         issue.kind.equals("review", ignoreCase = true) || issue.kind.equals("approval", ignoreCase = true)
@@ -20703,8 +20868,14 @@ class DesktopAppService(
                     pullRequestRequired &&
                     hasPublishMetadata &&
                     primaryRun?.publish?.mergeability.equals("DIRTY", ignoreCase = true)
+            val publishAlreadyMerged =
+                finalStatus == DesktopTaskStatus.COMPLETED &&
+                    pullRequestRequired &&
+                    hasPublishMetadata &&
+                    primaryRun?.publish?.pullRequestState.equals("MERGED", ignoreCase = true)
             val publishApprovalRequired = isGitHubPrCreateApprovalRequired(task, primaryRun)
             val nextIssueStatus = when {
+                publishAlreadyMerged -> IssueStatus.DONE
                 publishMergeConflict -> IssueStatus.PLANNED
                 publishApprovalRequired -> IssueStatus.WAITING_FOR_APPROVAL
                 finalStatus == DesktopTaskStatus.COMPLETED && pullRequestRequired && hasPublishMetadata -> IssueStatus.IN_REVIEW
@@ -20829,11 +21000,22 @@ class DesktopAppService(
                 runtimeDisposition = if (completionGateReason != null) "collaboration-gate-blocked" else currentIssue.runtimeDisposition,
                 qaVerdict = if (hasPublishMetadata || completedWithoutPublish) null else currentIssue.qaVerdict,
                 qaFeedback = if (hasPublishMetadata || completedWithoutPublish) null else currentIssue.qaFeedback,
-                ceoVerdict = if (hasPublishMetadata || completedWithoutPublish) null else currentIssue.ceoVerdict,
-                ceoFeedback = if (hasPublishMetadata || completedWithoutPublish) null else currentIssue.ceoFeedback,
+                ceoVerdict = when {
+                    publishAlreadyMerged -> currentIssue.ceoVerdict ?: "APPROVE"
+                    hasPublishMetadata || completedWithoutPublish -> null
+                    else -> currentIssue.ceoVerdict
+                },
+                ceoFeedback = when {
+                    publishAlreadyMerged -> currentIssue.ceoFeedback ?: "GitHub reports that the linked pull request is merged."
+                    hasPublishMetadata || completedWithoutPublish -> null
+                    else -> currentIssue.ceoFeedback
+                },
+                mergeResult = if (publishAlreadyMerged) "MERGED" else currentIssue.mergeResult,
                 transitionReason = when {
                     completionGateReason != null ->
                         completionGateReason
+                    publishAlreadyMerged ->
+                        "Execution completed and GitHub reports PR ${primaryRun?.publish?.pullRequestUrl ?: primaryRun?.publish?.pullRequestNumber} is already merged."
                     publishMergeConflict ->
                         "Execution completed on branch ${primaryRun?.branchName}, but PR ${primaryRun?.publish?.pullRequestUrl ?: primaryRun?.publish?.pullRequestNumber} does not merge cleanly with the latest base branch. Re-running on a refreshed base."
                     publishApprovalRequired ->
@@ -20855,6 +21037,7 @@ class DesktopAppService(
             if (updatedIssue.status != currentIssue.status) {
                 val reason = when {
                     completionGateReason != null -> completionGateReason
+                    publishAlreadyMerged -> "Task completed and GitHub reports the published pull request is already merged."
                     publishMergeConflict -> "Task completed, but GitHub reported that the published PR no longer merges cleanly with the base branch."
                     publishApprovalRequired -> "Task reached PR creation and is waiting for explicit approval before publishing."
                     finalStatus == DesktopTaskStatus.COMPLETED && pullRequestRequired && hasPublishMetadata -> "Task completed and published a pull request."
@@ -20876,6 +21059,7 @@ class DesktopAppService(
                 )
             }
             val queueStatus = when {
+                publishAlreadyMerged -> ReviewQueueStatus.MERGED
                 publishMergeConflict -> ReviewQueueStatus.CHANGES_REQUESTED
                 primaryRun?.publish?.error != null -> ReviewQueueStatus.FAILED_CHECKS
                 hasPublishMetadata -> ReviewQueueStatus.AWAITING_QA
@@ -20965,8 +21149,10 @@ class DesktopAppService(
                     ceoFeedback = null,
                     ceoReviewedAt = null,
                     approvalIssueId = if (clearWorkflowBindings) null else existing?.approvalIssueId,
-                    approvalPauseId = durableRuntimeApprovalPauseId(primaryRun?.id),
-                    providerBlockReason = providerBlockReasonForIssue(gatedIssueStatus, primaryRun),
+                    approvalPauseId = if (publishAlreadyMerged) null else durableRuntimeApprovalPauseId(primaryRun?.id),
+                    providerBlockReason = if (publishAlreadyMerged) null else providerBlockReasonForIssue(gatedIssueStatus, primaryRun),
+                    mergeCommitSha = existing?.mergeCommitSha,
+                    mergedAt = if (publishAlreadyMerged) now else existing?.mergedAt,
                     createdAt = if (publishedReviewIdentityChanged) now else existing?.createdAt ?: now,
                     updatedAt = now,
                     workflowLineage = workflowLineage

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -20828,6 +20828,35 @@ class DesktopAppService(
                 )
                 return@withLock
             }
+            val newerBlockingTask = state.tasks
+                .filter {
+                    it.issueId == currentIssue.id &&
+                        it.id != task.id &&
+                        it.status in setOf(DesktopTaskStatus.FAILED, DesktopTaskStatus.PARTIAL) &&
+                        it.updatedAt >= currentIssue.updatedAt &&
+                        it.createdAt >= task.createdAt
+                }
+                .maxByOrNull { it.updatedAt }
+            val newerBlockingRun = newerBlockingTask?.let { latestRunForTask(state, it.id) }
+            val staleCompletionAfterIssueBlocked =
+                finalStatus == DesktopTaskStatus.COMPLETED &&
+                    currentIssue.status == IssueStatus.BLOCKED &&
+                    task.createdAt <= currentIssue.updatedAt &&
+                    newerBlockingTask != null &&
+                    !isRecoverableInfrastructureFailure(newerBlockingTask, newerBlockingRun)
+            if (staleCompletionAfterIssueBlocked) {
+                informationalTraceEvents += buildCompanyAutomationTraceEvent(
+                    issue = currentIssue,
+                    goal = state.goals.firstOrNull { it.id == currentIssue.goalId },
+                    oldStatus = currentIssue.status,
+                    newStatus = currentIssue.status,
+                    source = "syncExecutionIssueFromTask",
+                    reason = "Skipped stale task completion because the issue was blocked after that task started.",
+                    latestTask = task,
+                    latestRun = primaryRun
+                )
+                return@withLock
+            }
             val hasPublishMetadata = primaryRun?.publish?.pullRequestUrl != null || primaryRun?.publish?.pullRequestNumber != null
             val mergedReviewQueueItem = state.reviewQueue.firstOrNull {
                 it.issueId == currentIssue.id && it.status == ReviewQueueStatus.MERGED

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -112,6 +112,12 @@ import java.util.WeakHashMap
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.exists
 
+private val TERMINAL_TASK_STATUSES = setOf(
+    DesktopTaskStatus.COMPLETED,
+    DesktopTaskStatus.PARTIAL,
+    DesktopTaskStatus.FAILED
+)
+
 @kotlinx.serialization.Serializable
 private data class CompanyAutomationTraceEvent(
     val timestamp: Long,
@@ -19961,12 +19967,17 @@ class DesktopAppService(
         val latestRuns = snapshot.runs.filter { it.taskId == taskId }
         val primaryRun = latestRuns.firstOrNull { it.publish?.pullRequestUrl != null } ?: latestRuns.firstOrNull()
         val issue = snapshot.issues.firstOrNull { it.id == issueId } ?: return
+        val effectiveFinalStatus = if (task.status in TERMINAL_TASK_STATUSES && task.status != finalStatus) {
+            task.status
+        } else {
+            finalStatus
+        }
         runCatching { ingestLegacyStdoutCommunicationFallback(issue, primaryRun) }
         when (issue.kind.lowercase()) {
-            "planning" -> syncPlanningIssueFromTask(task, issue, primaryRun, finalStatus)
-            "review" -> syncReviewIssueFromTask(task, issue, primaryRun, finalStatus)
-            "approval" -> syncApprovalIssueFromTask(task, issue, primaryRun, finalStatus)
-            else -> syncExecutionIssueFromTask(task, issue, primaryRun, finalStatus)
+            "planning" -> syncPlanningIssueFromTask(task, issue, primaryRun, effectiveFinalStatus)
+            "review" -> syncReviewIssueFromTask(task, issue, primaryRun, effectiveFinalStatus)
+            "approval" -> syncApprovalIssueFromTask(task, issue, primaryRun, effectiveFinalStatus)
+            else -> syncExecutionIssueFromTask(task, issue, primaryRun, effectiveFinalStatus)
         }
         stimulateAutonomousCompanyProgress(issue.companyId)
     }

--- a/src/main/kotlin/com/cotor/app/DesktopEndpointPolicy.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopEndpointPolicy.kt
@@ -1,6 +1,7 @@
 package com.cotor.app
 
 import org.slf4j.LoggerFactory
+import java.net.URI
 
 /**
  * Centralizes loopback-vs-remote validation for app-server URLs.
@@ -13,21 +14,22 @@ import org.slf4j.LoggerFactory
 object DesktopEndpointPolicy {
     private val logger = LoggerFactory.getLogger(DesktopEndpointPolicy::class.java)
 
-    private val LOOPBACK_PREFIXES = listOf(
-        "http://127.0.0.1",
-        "http://localhost",
-        "http://[::1]",
-        "https://127.0.0.1",
-        "https://localhost",
-        "https://[::1]",
-    )
+    private val LOOPBACK_HOSTS = setOf("127.0.0.1", "localhost", "::1", "[::1]")
+    private val ALLOWED_SCHEMES = setOf("http", "https")
 
-    fun isLoopback(url: String): Boolean =
-        LOOPBACK_PREFIXES.any { url.startsWith(it) }
+    fun isLoopback(url: String): Boolean {
+        val uri = runCatching { URI(url.trim()) }.getOrNull() ?: return false
+        val scheme = uri.scheme?.lowercase() ?: return false
+        val host = uri.host?.lowercase() ?: return false
+        return scheme in ALLOWED_SCHEMES && host in LOOPBACK_HOSTS && uri.rawUserInfo == null
+    }
 
-    fun remoteAllowed(): Boolean {
-        val flag = System.getenv("COTOR_ALLOW_REMOTE_APP_SERVER") == "1"
-        val token = !System.getenv("COTOR_APP_TOKEN").isNullOrBlank()
+    fun remoteAllowed(
+        envAllowRemote: String? = System.getenv("COTOR_ALLOW_REMOTE_APP_SERVER"),
+        envToken: String? = System.getenv("COTOR_APP_TOKEN")
+    ): Boolean {
+        val flag = envAllowRemote == "1"
+        val token = !envToken.isNullOrBlank()
         return flag && token
     }
 
@@ -37,11 +39,13 @@ object DesktopEndpointPolicy {
      * remote and the remote-allow flag+token are not both set.
      */
     fun resolveA2aEndpoint(
-        envUrl: String? = System.getenv("COTOR_APP_SERVER_URL")
+        envUrl: String? = System.getenv("COTOR_APP_SERVER_URL"),
+        envAllowRemote: String? = System.getenv("COTOR_ALLOW_REMOTE_APP_SERVER"),
+        envToken: String? = System.getenv("COTOR_APP_TOKEN")
     ): String {
         val base = envUrl?.takeIf { it.isNotBlank() }?.trim()?.removeSuffix("/")
             ?: return DEFAULT_LOOPBACK_A2A
-        return if (isLoopback(base) || remoteAllowed()) {
+        return if (isLoopback(base) || remoteAllowed(envAllowRemote, envToken)) {
             "$base/api/a2a"
         } else {
             logger.warn(

--- a/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
@@ -84,7 +84,10 @@ class DesktopStateStore(
     override suspend fun load(): DesktopAppState = withContext(Dispatchers.IO) {
         val stateFile = stateFile()
         if (!stateFile.exists()) {
-            return@withContext DesktopAppState()
+            return@withContext withStateFileLock {
+                cleanupStateTempFiles(stateFile.parent)
+                DesktopAppState()
+            }
         }
         val backupFile = backupStateFile()
         currentFingerprint(stateFile)?.let { fingerprint ->
@@ -97,6 +100,7 @@ class DesktopStateStore(
         }
 
         withStateFileLock {
+            cleanupStateTempFiles(stateFile.parent)
             currentFingerprint(stateFile)?.let { fingerprint ->
                 cachedState
                     ?.takeIf {
@@ -107,7 +111,7 @@ class DesktopStateStore(
             }
             val raw = runCatching { stateFile.readText() }.getOrElse { return@withStateFileLock DesktopAppState() }
             decodeState(raw)?.also { decoded ->
-                val compacted = compactStateForPersistence(normalizeLegacyCompanyRuntimeState(decoded))
+                val compacted = normalizeStateForPersistence(decoded)
                 if (raw != json.encodeToString(DesktopAppState.serializer(), compacted)) {
                     saveLocked(compacted)
                 } else {
@@ -118,7 +122,7 @@ class DesktopStateStore(
             if (backupFile.exists()) {
                 val backupRaw = runCatching { backupFile.readText() }.getOrNull()
                 decodeState(backupRaw.orEmpty())?.also { recovered ->
-                    val compacted = compactStateForPersistence(normalizeLegacyCompanyRuntimeState(recovered))
+                    val compacted = normalizeStateForPersistence(recovered)
                     saveLocked(compacted)
                     return@withStateFileLock compacted
                 }
@@ -152,8 +156,9 @@ class DesktopStateStore(
         // app can start from a completely clean machine state.
         file.parent?.createDirectories()
         managedReposRoot().createDirectories()
-        val compactedState = compactStateForPersistence(normalizeLegacyCompanyRuntimeState(state))
+        val compactedState = normalizeStateForPersistence(state)
         val payload = json.encodeToString(DesktopAppState.serializer(), compactedState)
+        cleanupStateTempFiles(file.parent)
         val tempFile = Files.createTempFile(file.parent, "${file.fileName}.", ".tmp")
         tempFile.writeText(payload)
         enforceOwnerOnlyPermissions(tempFile)
@@ -165,6 +170,15 @@ class DesktopStateStore(
         moveWithAtomicFallback(backupTempFile, backupFile)
         enforceOwnerOnlyPermissions(backupFile)
         updateCache(file, compactedState)
+    }
+
+    private fun cleanupStateTempFiles(directory: Path?) {
+        if (directory == null) {
+            return
+        }
+        stateTempFilesToClean(directory).forEach { tempFile ->
+            runCatching { Files.deleteIfExists(tempFile) }
+        }
     }
 
     private fun decodeStateOrNull(raw: String): DesktopAppState? {
@@ -410,6 +424,143 @@ class DesktopStateStore(
         }
     }
 
+    private fun normalizeStateForPersistence(state: DesktopAppState): DesktopAppState =
+        compactStateForPersistence(pruneDanglingCompanyReferences(normalizeLegacyCompanyRuntimeState(state)))
+
+    private fun pruneDanglingCompanyReferences(state: DesktopAppState): DesktopAppState {
+        val companyIds = state.companies.mapTo(linkedSetOf()) { it.id }
+        val projectContextIds = state.projectContexts
+            .filter { it.companyId in companyIds }
+            .mapTo(linkedSetOf()) { it.id }
+        val goals = state.goals
+            .filter { goal -> goal.companyId in companyIds }
+            .map { goal ->
+                if (goal.projectContextId != null && goal.projectContextId !in projectContextIds) {
+                    goal.copy(projectContextId = null)
+                } else {
+                    goal
+                }
+            }
+        val goalIds = goals.mapTo(linkedSetOf()) { it.id }
+        val issues = state.issues
+            .filter { issue ->
+                issue.companyId in companyIds &&
+                    issue.goalId in goalIds
+            }
+            .map { issue ->
+                if (issue.projectContextId != null && issue.projectContextId !in projectContextIds) {
+                    issue.copy(projectContextId = null)
+                } else {
+                    issue
+                }
+            }
+        val issueIds = issues.mapTo(linkedSetOf()) { it.id }
+        val issuesById = issues.associateBy { it.id }
+        val normalizedReviewQueue = state.reviewQueue.map { item ->
+            val issue = issuesById[item.issueId]
+            if (issue != null && item.companyId.isBlank()) {
+                item.copy(
+                    companyId = issue.companyId,
+                    projectContextId = item.projectContextId ?: issue.projectContextId
+                )
+            } else {
+                item
+            }
+        }
+        val reviewQueueIds = normalizedReviewQueue
+            .filter { it.companyId in companyIds && it.issueId in issueIds }
+            .mapTo(linkedSetOf()) { it.id }
+        val runIds = state.runs.mapTo(linkedSetOf()) { it.id }
+        val taskIds = state.tasks.mapTo(linkedSetOf()) { it.id }
+        val agentIds = state.companyAgentDefinitions
+            .filter { it.companyId in companyIds }
+            .mapTo(linkedSetOf()) { it.id }
+
+        fun validGoalRef(goalId: String?): Boolean = goalId == null || goalId in goalIds
+        fun validIssueRef(issueId: String?): Boolean = issueId == null || issueId in issueIds
+        fun validProjectRef(projectContextId: String?): Boolean =
+            projectContextId == null || projectContextId in projectContextIds
+
+        val runtime = state.runtime.takeIf { it.companyId == null || it.companyId in companyIds }
+            ?: CompanyRuntimeSnapshot()
+
+        return state.copy(
+            projectContexts = state.projectContexts.filter { it.companyId in companyIds },
+            companyAgentDefinitions = state.companyAgentDefinitions.filter { it.companyId in companyIds },
+            agentCapabilityProfiles = state.agentCapabilityProfiles.filter { it.companyId in companyIds },
+            goals = goals,
+            issues = issues,
+            issueDependencies = state.issueDependencies.filter {
+                it.issueId in issueIds && it.dependsOnIssueId in issueIds
+            },
+            orgProfiles = state.orgProfiles.filter { it.companyId in companyIds },
+            workflowTopologies = state.workflowTopologies.filter { it.companyId in companyIds },
+            goalDecisions = state.goalDecisions.mapNotNull { decision ->
+                if (
+                    decision.companyId !in companyIds ||
+                    !validGoalRef(decision.goalId) ||
+                    !validIssueRef(decision.issueId)
+                ) {
+                    null
+                } else {
+                    decision.copy(createdIssues = decision.createdIssues.filter { it in issueIds })
+                }
+            },
+            reviewQueue = normalizedReviewQueue.filter {
+                it.companyId in companyIds && it.issueId in issueIds
+            },
+            companyActivity = state.companyActivity.filter {
+                it.companyId in companyIds &&
+                    validProjectRef(it.projectContextId) &&
+                    validGoalRef(it.goalId) &&
+                    validIssueRef(it.issueId)
+            },
+            signals = state.signals.filter {
+                (it.companyId == null || it.companyId in companyIds) &&
+                    validProjectRef(it.projectContextId) &&
+                    validGoalRef(it.goalId) &&
+                    validIssueRef(it.issueId)
+            },
+            runtime = runtime,
+            companyRuntimes = state.companyRuntimes.filter { it.companyId in companyIds },
+            workflowPipelines = state.workflowPipelines.filter { it.companyId in companyIds },
+            agentContextEntries = state.agentContextEntries.filter {
+                it.companyId in companyIds &&
+                    validGoalRef(it.goalId) &&
+                    validIssueRef(it.issueId)
+            },
+            agentMessages = state.agentMessages.filter {
+                it.companyId in companyIds &&
+                    validGoalRef(it.goalId) &&
+                    validIssueRef(it.issueId)
+            },
+            marketingDelegationPolicies = state.marketingDelegationPolicies.filter {
+                it.companyId in companyIds && it.agentId in agentIds
+            },
+            marketingRuns = state.marketingRuns.filter {
+                it.companyId in companyIds && it.agentId in agentIds
+            },
+            skillRuns = state.skillRuns.filter {
+                it.companyId in companyIds && it.agentId in agentIds
+            },
+            companyRuntimeWorkItems = state.companyRuntimeWorkItems.filter {
+                it.companyId in companyIds &&
+                    validGoalRef(it.goalId) &&
+                    it.issueId in issueIds &&
+                    (it.activeTaskId == null || it.activeTaskId in taskIds)
+            },
+            problemSignals = state.problemSignals.filter {
+                it.companyId in companyIds &&
+                    validProjectRef(it.projectContextId) &&
+                    validGoalRef(it.goalId) &&
+                    validIssueRef(it.issueId) &&
+                    validGoalRef(it.triageGoalId) &&
+                    (it.reviewQueueItemId == null || it.reviewQueueItemId in reviewQueueIds) &&
+                    (it.runId == null || it.runId in runIds)
+            }
+        )
+    }
+
     private fun compactStateForPersistence(state: DesktopAppState): DesktopAppState =
         state.run {
             val unresolvedIssueIds = issues
@@ -522,6 +673,32 @@ class DesktopStateStore(
     private fun compactRequiredText(value: String, maxChars: Int): String =
         compactText(value, maxChars) ?: value
 }
+
+internal fun stateTempFilesToClean(
+    directory: Path,
+    nowMillis: Long = System.currentTimeMillis(),
+    minAgeMillis: Long = 60_000L
+): List<Path> {
+    if (!directory.exists()) {
+        return emptyList()
+    }
+    val stream = Files.list(directory)
+    return try {
+        stream
+            .filter { Files.isRegularFile(it) }
+            .filter { STATE_TEMP_FILE_REGEX.matches(it.fileName.toString()) }
+            .filter { tempFile ->
+                val modifiedAt = runCatching { Files.getLastModifiedTime(tempFile).toMillis() }.getOrDefault(nowMillis)
+                nowMillis - modifiedAt >= minAgeMillis
+            }
+            .toList()
+            .sortedBy { it.fileName.toString() }
+    } finally {
+        stream.close()
+    }
+}
+
+private val STATE_TEMP_FILE_REGEX = Regex("""state\.json(?:\.bak)?\.[^.]+\.tmp""")
 
 /**
  * Desktop data lives under the conventional macOS Application Support location

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
@@ -62,29 +62,34 @@ class LocalPlaywrightBrowserSkillRunner(
         val inputPath = Files.createTempFile(inputDir, "browser-skill-command-", ".json")
         inputPath.writeText(json.encodeToString(BrowserSkillCommand.serializer(), command))
         withTimeout(command.maxRuntimeSeconds.coerceAtLeast(15) * 1_000L) {
-            val process = ProcessBuilder("node", scriptPath.toString(), inputPath.toString())
-                .directory(runtimeDir.toFile())
-                .redirectErrorStream(true)
-                .also { builder ->
-                    builder.environment()["NODE_PATH"] = runtimeDir.resolve("node_modules").toString()
+            var process: Process? = null
+            try {
+                process = ProcessBuilder("node", scriptPath.toString(), inputPath.toString())
+                    .directory(runtimeDir.toFile())
+                    .redirectErrorStream(true)
+                    .also { builder ->
+                        builder.environment()["NODE_PATH"] = runtimeDir.resolve("node_modules").toString()
+                    }
+                    .start()
+                val timeoutSeconds = command.maxRuntimeSeconds.coerceAtLeast(15).toLong()
+                val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+                val output = process.inputStream.bufferedReader().readText().trim()
+                if (!finished) {
+                    destroyProcessTree(process)
+                    error("Browser skill execution timed out after ${timeoutSeconds}s.")
                 }
-                .start()
-            val timeoutSeconds = command.maxRuntimeSeconds.coerceAtLeast(15).toLong()
-            val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
-            val output = process.inputStream.bufferedReader().readText().trim()
-            if (!finished) {
-                process.destroyForcibly()
-                error("Browser skill execution timed out after ${timeoutSeconds}s.")
-            }
-            if (process.exitValue() != 0) {
-                error(output.ifBlank { "Browser skill execution failed with exit ${process.exitValue()}." })
-            }
-            runCatching {
-                json.decodeFromString(BrowserSkillResult.serializer(), output.lines().last())
-            }.getOrElse { error ->
-                throw IllegalStateException(
-                    "Browser skill execution did not return a valid result: ${error.message}. Output: $output"
-                )
+                if (process.exitValue() != 0) {
+                    error(output.ifBlank { "Browser skill execution failed with exit ${process.exitValue()}." })
+                }
+                runCatching {
+                    json.decodeFromString(BrowserSkillResult.serializer(), output.lines().last())
+                }.getOrElse { error ->
+                    throw IllegalStateException(
+                        "Browser skill execution did not return a valid result: ${error.message}. Output: $output"
+                    )
+                }
+            } finally {
+                process?.takeIf { it.isAlive }?.let(::destroyProcessTree)
             }
         }
     }
@@ -107,14 +112,18 @@ class LocalPlaywrightBrowserSkillRunner(
             .redirectErrorStream(true)
             .start()
         val installTimeoutSeconds = timeoutSeconds.coerceAtLeast(120).toLong()
-        val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
-        val output = process.inputStream.bufferedReader().readText().trim()
-        if (!finished) {
-            process.destroyForcibly()
-            error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
-        }
-        if (process.exitValue() != 0) {
-            error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
+        try {
+            val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
+            val output = process.inputStream.bufferedReader().readText().trim()
+            if (!finished) {
+                destroyProcessTree(process)
+                error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
+            }
+            if (process.exitValue() != 0) {
+                error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
+            }
+        } finally {
+            process.takeIf { it.isAlive }?.let(::destroyProcessTree)
         }
     }
 
@@ -222,5 +231,9 @@ private fun browserSkillCommandAvailable(command: String): Boolean =
         val process = ProcessBuilder(command, "--version")
             .redirectErrorStream(true)
             .start()
-        process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
+        try {
+            process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
+        } finally {
+            process.takeIf { it.isAlive }?.let(::destroyProcessTree)
+        }
     }.getOrDefault(false)

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
@@ -37,32 +37,38 @@ class LocalPlaywrightMarketingBrowserRunner(
         withTimeout(command.maxRuntimeSeconds.coerceAtLeast(15) * 1_000L) {
             val inputPath = Files.createTempFile(inputDir, "marketing-command-", ".json")
             inputPath.writeText(json.encodeToString(MarketingBrowserCommand.serializer(), command))
-            val process = ProcessBuilder(
-                "node",
-                scriptPath.toString(),
-                inputPath.toString()
-            )
-                .directory(runtimeDir.toFile())
-                .redirectErrorStream(true)
-                .also { builder ->
-                    builder.environment()["NODE_PATH"] = runtimeDir.resolve("node_modules").toString()
-                }
-                .start()
-            val finished = process.waitFor(command.maxRuntimeSeconds.coerceAtLeast(15).toLong(), TimeUnit.SECONDS)
-            val output = process.inputStream.bufferedReader().readText().trim()
-            if (!finished) {
-                process.destroyForcibly()
-                error("Marketing browser execution timed out after ${command.maxRuntimeSeconds.coerceAtLeast(15)}s.")
-            }
-            if (process.exitValue() != 0) {
-                error(output.ifBlank { "Marketing browser execution failed with exit ${process.exitValue()}." })
-            }
-            runCatching {
-                json.decodeFromString(MarketingBrowserResult.serializer(), output.lines().last())
-            }.getOrElse { error ->
-                throw IllegalStateException(
-                    "Marketing browser execution did not return a valid result: ${error.message}. Output: $output"
+            var process: Process? = null
+            try {
+                process = ProcessBuilder(
+                    "node",
+                    scriptPath.toString(),
+                    inputPath.toString()
                 )
+                    .directory(runtimeDir.toFile())
+                    .redirectErrorStream(true)
+                    .also { builder ->
+                        builder.environment()["NODE_PATH"] = runtimeDir.resolve("node_modules").toString()
+                    }
+                    .start()
+                val timeoutSeconds = command.maxRuntimeSeconds.coerceAtLeast(15).toLong()
+                val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+                val output = process.inputStream.bufferedReader().readText().trim()
+                if (!finished) {
+                    destroyProcessTree(process)
+                    error("Marketing browser execution timed out after ${timeoutSeconds}s.")
+                }
+                if (process.exitValue() != 0) {
+                    error(output.ifBlank { "Marketing browser execution failed with exit ${process.exitValue()}." })
+                }
+                runCatching {
+                    json.decodeFromString(MarketingBrowserResult.serializer(), output.lines().last())
+                }.getOrElse { error ->
+                    throw IllegalStateException(
+                        "Marketing browser execution did not return a valid result: ${error.message}. Output: $output"
+                    )
+                }
+            } finally {
+                process?.takeIf { it.isAlive }?.let(::destroyProcessTree)
             }
         }
     }
@@ -85,14 +91,18 @@ class LocalPlaywrightMarketingBrowserRunner(
             .redirectErrorStream(true)
             .start()
         val installTimeoutSeconds = timeoutSeconds.coerceAtLeast(120).toLong()
-        val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
-        val output = process.inputStream.bufferedReader().readText().trim()
-        if (!finished) {
-            process.destroyForcibly()
-            error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
-        }
-        if (process.exitValue() != 0) {
-            error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
+        try {
+            val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
+            val output = process.inputStream.bufferedReader().readText().trim()
+            if (!finished) {
+                destroyProcessTree(process)
+                error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
+            }
+            if (process.exitValue() != 0) {
+                error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
+            }
+        } finally {
+            process.takeIf { it.isAlive }?.let(::destroyProcessTree)
         }
     }
 
@@ -189,5 +199,9 @@ private fun marketingCommandAvailable(command: String): Boolean =
         val process = ProcessBuilder(command, "--version")
             .redirectErrorStream(true)
             .start()
-        process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
+        try {
+            process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
+        } finally {
+            process.takeIf { it.isAlive }?.let(::destroyProcessTree)
+        }
     }.getOrDefault(false)

--- a/src/main/kotlin/com/cotor/app/ProcessTree.kt
+++ b/src/main/kotlin/com/cotor/app/ProcessTree.kt
@@ -1,0 +1,26 @@
+package com.cotor.app
+
+import java.util.concurrent.TimeUnit
+
+internal fun destroyProcessTree(process: Process, graceMillis: Long = 500) {
+    val descendants = process.toHandle().descendants().toList().asReversed()
+    descendants.forEach { handle ->
+        runCatching { handle.destroy() }
+    }
+    runCatching { process.destroy() }
+    val exited = runCatching { process.waitFor(graceMillis, TimeUnit.MILLISECONDS) }.getOrDefault(false)
+    if (!exited) {
+        descendants.forEach { handle ->
+            runCatching {
+                if (handle.isAlive) {
+                    handle.destroyForcibly()
+                }
+            }
+        }
+        runCatching {
+            if (process.isAlive) {
+                process.destroyForcibly()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -324,6 +324,7 @@ private fun destroyProcessTree(process: Process, logger: Logger) {
         .toArray()
         .filterIsInstance<ProcessHandle>()
         .asReversed()
+    terminateUnixChildren(process.pid(), force = false, logger = logger)
     descendants.forEach { handle ->
         if (handle.isAlive) {
             runCatching { handle.destroy() }
@@ -338,6 +339,7 @@ private fun destroyProcessTree(process: Process, logger: Logger) {
     if (process.isAlive) {
         runCatching { process.waitFor(PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
     }
+    terminateUnixChildren(process.pid(), force = true, logger = logger)
     descendants.forEach { handle ->
         if (handle.isAlive) {
             runCatching { handle.destroyForcibly() }
@@ -350,6 +352,20 @@ private fun destroyProcessTree(process: Process, logger: Logger) {
     }
     waitForProcessHandles(descendants, PROCESS_TREE_JOIN_TIMEOUT_MS)
     runCatching { process.waitFor(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+}
+
+private fun terminateUnixChildren(parentPid: Long, force: Boolean, logger: Logger) {
+    val signal = if (force) "-KILL" else "-TERM"
+    val pkill = ProcessBuilder("pkill", signal, "-P", parentPid.toString())
+    runCatching {
+        val process = pkill.start()
+        process.waitFor(PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        if (process.isAlive) {
+            process.destroyForcibly()
+        }
+    }.onFailure {
+        logger.debug("Failed to request child process termination with pkill for parent pid=$parentPid", it)
+    }
 }
 
 private fun cleanupSurvivingDescendants(process: Process, logger: Logger) {

--- a/src/test/kotlin/com/cotor/app/AppServerInstanceGuardTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerInstanceGuardTest.kt
@@ -77,6 +77,30 @@ class AppServerInstanceGuardTest : FunSpec({
         Files.exists(record.metadataPath) shouldBe true
         guard.release()
     }
+
+    test("desktop app-server status requires both live process and reachable endpoint") {
+        val appHome = Files.createTempDirectory("desktop-app-server-status-home")
+        val guard = DesktopAppServerInstanceGuard(appHomeProvider = { appHome })
+        guard.acquire(host = "127.0.0.1", port = 61234)
+
+        val processOnlyStatus = readDesktopAppServerInstanceStatus(
+            appHome = appHome,
+            processAliveChecker = { true },
+            endpointReachableChecker = { _, _ -> false }
+        )
+        processOnlyStatus.active shouldBe false
+        processOnlyStatus.metadata shouldBe null
+
+        val reachableStatus = readDesktopAppServerInstanceStatus(
+            appHome = appHome,
+            processAliveChecker = { true },
+            endpointReachableChecker = { host, port -> host == "127.0.0.1" && port == 61234 }
+        )
+        reachableStatus.active shouldBe true
+        reachableStatus.metadata?.port shouldBe 61234
+
+        guard.release()
+    }
 })
 
 private class IOExceptionFileChannel(private val lockPath: Path) : FileChannel() {

--- a/src/test/kotlin/com/cotor/app/AppServerTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerTest.kt
@@ -15,10 +15,12 @@ import io.kotest.matchers.string.shouldNotContain
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.options
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
 import io.mockk.clearMocks
@@ -78,6 +80,27 @@ class AppServerTest : FunSpec({
             val response = client.get("/api/app/dashboard")
             response.status shouldBe HttpStatusCode.Unauthorized
             response.bodyAsText() shouldContain "Unauthorized"
+        }
+    }
+
+    test("file origin terminal preflight is allowed for bearer-protected TUI routes") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.options("/api/app/tui/sessions/session-1") {
+                header(HttpHeaders.Origin, "null")
+                header(HttpHeaders.AccessControlRequestMethod, "GET")
+                header(HttpHeaders.AccessControlRequestHeaders, "Authorization")
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+            response.headers[HttpHeaders.AccessControlAllowOrigin] shouldBe "null"
         }
     }
 
@@ -302,6 +325,30 @@ class AppServerTest : FunSpec({
 
             response.status shouldBe HttpStatusCode.OK
             response.bodyAsText() shouldContain "\"repositories\":[]"
+        }
+    }
+
+    test("clone repository route returns bad request for invalid remote URL") {
+        coEvery { desktopService.cloneRepository("file:///tmp/local-repo") } throws
+            IllegalArgumentException("Use an existing GitHub repository URL without credentials, for example https://github.com/owner/repo.git")
+
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val response = client.post("/api/app/repositories/clone") {
+                header("Authorization", "Bearer secret-token")
+                header("Content-Type", "application/json")
+                setBody("""{"url":"file:///tmp/local-repo"}""")
+            }
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldContain "GitHub repository URL"
         }
     }
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceGitHubSyncTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceGitHubSyncTest.kt
@@ -41,7 +41,8 @@ class DesktopAppServiceGitHubSyncTest : FunSpec({
                 provenanceService = ProvenanceService(provenanceStore),
                 knowledgeService = KnowledgeService(knowledgeStore)
             ),
-            knowledgeService = KnowledgeService(knowledgeStore)
+            knowledgeService = KnowledgeService(knowledgeStore),
+            autoStartAutomationRefresh = false
         )
 
         val company = Company(
@@ -83,7 +84,40 @@ class DesktopAppServiceGitHubSyncTest : FunSpec({
         )
         stateStore.save(
             DesktopAppState(
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-1",
+                        name = "repo",
+                        localPath = appHome.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "main",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = "workspace-1",
+                        repositoryId = "repo-1",
+                        name = "repo",
+                        baseBranch = "main",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
                 companies = listOf(company),
+                goals = listOf(
+                    CompanyGoal(
+                        id = "goal-1",
+                        companyId = company.id,
+                        title = "GitHub sync",
+                        description = "Sync PR metadata.",
+                        status = GoalStatus.ACTIVE,
+                        autonomyEnabled = false,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
                 issues = listOf(issue),
                 reviewQueue = listOf(queueItem),
                 companyRuntimes = listOf(
@@ -156,7 +190,8 @@ class DesktopAppServiceGitHubSyncTest : FunSpec({
                 provenanceService = ProvenanceService(provenanceStore),
                 knowledgeService = KnowledgeService(knowledgeStore)
             ),
-            knowledgeService = KnowledgeService(knowledgeStore)
+            knowledgeService = KnowledgeService(knowledgeStore),
+            autoStartAutomationRefresh = false
         )
 
         val company = Company(
@@ -237,7 +272,50 @@ class DesktopAppServiceGitHubSyncTest : FunSpec({
         )
         stateStore.save(
             DesktopAppState(
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-2",
+                        name = "repo",
+                        localPath = appHome.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "main",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
+                workspaces = listOf(
+                    Workspace(
+                        id = "workspace-1",
+                        repositoryId = "repo-2",
+                        name = "repo",
+                        baseBranch = "main",
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
                 companies = listOf(company),
+                goals = listOf(
+                    CompanyGoal(
+                        id = "goal-1",
+                        companyId = company.id,
+                        title = "GitHub terminal sync",
+                        description = "Sync terminal PR states.",
+                        status = GoalStatus.ACTIVE,
+                        autonomyEnabled = false,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    ),
+                    CompanyGoal(
+                        id = "goal-2",
+                        companyId = company.id,
+                        title = "GitHub terminal closed sync",
+                        description = "Sync closed PR states.",
+                        status = GoalStatus.ACTIVE,
+                        autonomyEnabled = false,
+                        createdAt = 1L,
+                        updatedAt = 1L
+                    )
+                ),
                 issues = listOf(mergedIssue, approvalIssue, closedIssue),
                 reviewQueue = listOf(mergedQueue, closedQueue),
                 companyRuntimes = listOf(
@@ -265,7 +343,7 @@ class DesktopAppServiceGitHubSyncTest : FunSpec({
 
         service.syncGitHubProvider(company.id)
         val settled = stateStore.load()
-        settled.reviewQueue.any { it.id == "review-merged" } shouldBe false
+        settled.reviewQueue.first { it.id == "review-merged" }.status shouldBe ReviewQueueStatus.MERGED
         settled.issues.first { it.id == "issue-merged" }.status shouldBe IssueStatus.DONE
         settled.issues.first { it.id == "approval-merged" }.status shouldBe IssueStatus.DONE
         settled.reviewQueue.first { it.id == "review-closed" }.status shouldBe ReviewQueueStatus.CHANGES_REQUESTED

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceMarketingTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceMarketingTest.kt
@@ -164,6 +164,85 @@ class DesktopAppServiceMarketingTest : FunSpec({
         runner.commands.shouldHaveSize(1)
     }
 
+    test("marketing browser screenshot-only no-op is recorded as failed instead of completed") {
+        val appHome = Files.createTempDirectory("desktop-marketing-noop-home")
+        val runner = NoOpMarketingBrowserRunner()
+        val service = marketingService(appHome, runner)
+        val company = service.createCompany(name = "Marketing Noop Co", rootPath = appHome.toString())
+        val agent = service.listCompanyAgentDefinitions(company.id).first { it.title == "Marketing Operator" }
+        service.upsertMarketingDelegationPolicy(
+            UpsertMarketingDelegationPolicyRequest(
+                companyId = company.id,
+                agentId = agent.id,
+                allowedDomains = listOf("cms.example.com"),
+                channelAccounts = listOf(
+                    MarketingChannelAccount(channel = "web", accountRef = "cms", allowedDomains = listOf("cms.example.com"))
+                ),
+                dailyPostLimit = 2
+            )
+        )
+
+        val run = service.createMarketingRun(
+            MarketingRunRequest(
+                companyId = company.id,
+                agentId = agent.id,
+                objective = "Publish an owned web update",
+                channels = listOf("web")
+            )
+        )
+        val skillRun = service.runSkill(
+            name = "content-publisher",
+            companyId = company.id,
+            agentId = agent.id,
+            input = "Publish a delegated product update",
+            parameters = mapOf("channels" to "web")
+        )
+
+        run.status shouldBe MarketingRunStatus.FAILED
+        run.actions.single().status shouldBe MarketingActionStatus.FAILED
+        run.error shouldContain "did not expose an editable field"
+        skillRun.status shouldBe "FAILED"
+        skillRun.error shouldContain "did not expose an editable field"
+    }
+
+    test("analytics reporter without marketing runs is not marked completed") {
+        val appHome = Files.createTempDirectory("desktop-marketing-empty-analytics-home")
+        val service = marketingService(appHome, RecordingMarketingBrowserRunner())
+        val company = service.createCompany(name = "Marketing Empty Analytics Co", rootPath = appHome.toString())
+        val agent = service.listCompanyAgentDefinitions(company.id).first { it.title == "Marketing Operator" }
+        service.upsertMarketingDelegationPolicy(
+            UpsertMarketingDelegationPolicyRequest(
+                companyId = company.id,
+                agentId = agent.id,
+                allowedDomains = listOf("cms.example.com"),
+                channelAccounts = listOf(
+                    MarketingChannelAccount(channel = "web", accountRef = "cms", allowedDomains = listOf("cms.example.com"))
+                ),
+                dailyPostLimit = 2
+            )
+        )
+        val auto = AgentCapabilitySetting(enabled = true, mode = CapabilityMode.AUTO)
+        service.updateAgentCapabilities(
+            companyId = company.id,
+            agentId = agent.id,
+            settings = mapOf(
+                CapabilityKey.SKILL_RUN to auto,
+                CapabilityKey.MARKETING_ANALYTICS_READ to auto
+            )
+        )
+
+        val result = service.runSkill(
+            name = "analytics-reporter",
+            companyId = company.id,
+            agentId = agent.id,
+            input = "Summarize recent marketing runs"
+        )
+
+        result.status shouldBe "FAILED_SETUP"
+        result.error shouldContain "No MarketingRun evidence"
+        result.actions.single() shouldBe "summarized 0 marketing run(s)"
+    }
+
     test("browserSessionRef raw file path is rejected at policy save time") {
         val appHome = Files.createTempDirectory("desktop-marketing-session-ref-home")
         val service = marketingService(appHome, RecordingMarketingBrowserRunner())
@@ -359,4 +438,14 @@ private class RecordingMarketingBrowserRunner : MarketingBrowserRunner {
             inputSummary = command.inputSummary
         )
     }
+}
+
+private class NoOpMarketingBrowserRunner : MarketingBrowserRunner {
+    override suspend fun execute(command: MarketingBrowserCommand): MarketingBrowserResult =
+        MarketingBrowserResult(
+            targetUrl = command.targetUrl,
+            postedUrl = command.targetUrl,
+            screenshotPath = command.screenshotPath,
+            inputSummary = "${command.channel}: no editable field; no publish button"
+        )
 }

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceOwnershipTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceOwnershipTest.kt
@@ -31,7 +31,12 @@ class DesktopAppServiceOwnershipTest : FunSpec({
             createdAt = 1L,
             updatedAt = 1L
         )
-        stateStore.save(DesktopAppState(workflowPipelines = listOf(pipeline)))
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company("company-a")),
+                workflowPipelines = listOf(pipeline)
+            )
+        )
         val service = ownershipService(stateStore)
 
         shouldThrow<IllegalArgumentException> {
@@ -56,7 +61,12 @@ class DesktopAppServiceOwnershipTest : FunSpec({
             createdAt = 1L,
             updatedAt = 1L
         )
-        stateStore.save(DesktopAppState(workflowPipelines = listOf(pipeline)))
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company("company-a")),
+                workflowPipelines = listOf(pipeline)
+            )
+        )
         val service = ownershipService(stateStore)
 
         shouldThrow<IllegalArgumentException> {
@@ -78,7 +88,12 @@ class DesktopAppServiceOwnershipTest : FunSpec({
             content = "Keep this scoped to company A.",
             createdAt = 1L
         )
-        stateStore.save(DesktopAppState(agentContextEntries = listOf(entry)))
+        stateStore.save(
+            DesktopAppState(
+                companies = listOf(company("company-a")),
+                agentContextEntries = listOf(entry)
+            )
+        )
         val service = ownershipService(stateStore)
 
         shouldThrow<IllegalArgumentException> {
@@ -94,5 +109,17 @@ private fun ownershipService(stateStore: DesktopStateStore): DesktopAppService =
         stateStore = stateStore,
         gitWorkspaceService = mockk(relaxed = true),
         configRepository = mockk<ConfigRepository>(relaxed = true),
-        agentExecutor = mockk<AgentExecutor>(relaxed = true)
+        agentExecutor = mockk<AgentExecutor>(relaxed = true),
+        autoStartAutomationRefresh = false
+    )
+
+private fun company(id: String): Company =
+    Company(
+        id = id,
+        name = id,
+        rootPath = ".",
+        repositoryId = "repo-$id",
+        defaultBaseBranch = "main",
+        createdAt = 1L,
+        updatedAt = 1L
     )

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeCleanupTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeCleanupTest.kt
@@ -143,7 +143,7 @@ private fun worktree(repo: Path, taskId: String, agent: String, modifiedAt: Long
     val path = repo.resolve(".cotor").resolve("worktrees").resolve(taskId).resolve(agent).toAbsolutePath().normalize()
     Files.createDirectories(path)
     Files.setLastModifiedTime(path, FileTime.fromMillis(modifiedAt))
-    return path
+    return path.toRealPath()
 }
 
 private fun baseState(companyId: String, repo: Path): DesktopAppState =
@@ -166,6 +166,18 @@ private fun baseState(companyId: String, repo: Path): DesktopAppState =
                 repositoryId = "repo-$companyId",
                 name = "Main",
                 baseBranch = "main",
+                createdAt = 1,
+                updatedAt = 1
+            )
+        ),
+        goals = listOf(
+            CompanyGoal(
+                id = "goal",
+                companyId = companyId,
+                title = "Goal",
+                description = "Runtime retention goal",
+                status = GoalStatus.ACTIVE,
+                autonomyEnabled = false,
                 createdAt = 1,
                 updatedAt = 1
             )

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
@@ -633,11 +633,11 @@ private suspend fun seedRuntimeDispositionWorkspace(
     companyId: String = "company-1"
 ) {
     stateStore.save(
-            DesktopAppState(
-                companies = listOf(runtimeDispositionCompany(companyId, repoRoot)),
-                repositories = listOf(
-                    ManagedRepository(
-                        id = "repo-1",
+        DesktopAppState(
+            companies = listOf(runtimeDispositionCompany(companyId, repoRoot)),
+            repositories = listOf(
+                ManagedRepository(
+                    id = "repo-1",
                     name = "repo",
                     localPath = repoRoot.toString(),
                     sourceKind = RepositorySourceKind.LOCAL,

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
@@ -32,9 +32,9 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         val appHome = Files.createTempDirectory("desktop-runtime-disposition-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-disposition-repo").resolve("repo"))
         val stateStore = DesktopStateStore { appHome }
-        seedRuntimeDispositionWorkspace(stateStore, repoRoot)
         val githubStore = GitHubControlPlaneStore { appHome }
         val companyId = "company-1"
+        seedRuntimeDispositionWorkspace(stateStore, repoRoot, companyId)
         val issueId = "issue-waiting-ci"
         GitHubControlPlaneService(store = githubStore).recordSnapshot(
             PullRequestSnapshot(
@@ -65,7 +65,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
                 policyEngine = PolicyEngine(PolicyStore { appHome }),
                 gitHubControlPlaneService = GitHubControlPlaneService(store = githubStore)
             ),
-            gitHubControlPlaneService = GitHubControlPlaneService(store = githubStore)
+            gitHubControlPlaneService = GitHubControlPlaneService(store = githubStore),
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -154,7 +155,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -246,7 +248,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -310,7 +313,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -356,7 +360,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -449,7 +454,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -498,8 +504,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         val appHome = Files.createTempDirectory("desktop-runtime-dependency-wait-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-dependency-wait-repo").resolve("repo"))
         val stateStore = DesktopStateStore { appHome }
-        seedRuntimeDispositionWorkspace(stateStore, repoRoot)
         val companyId = "company-dependency-wait"
+        seedRuntimeDispositionWorkspace(stateStore, repoRoot, companyId)
         val upstreamId = "issue-upstream"
         val downstreamId = "issue-downstream"
 
@@ -507,7 +513,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true),
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -550,8 +557,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         val appHome = Files.createTempDirectory("desktop-runtime-dependency-ready-home")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-dependency-ready-repo").resolve("repo"))
         val stateStore = DesktopStateStore { appHome }
-        seedRuntimeDispositionWorkspace(stateStore, repoRoot)
         val companyId = "company-dependency-ready"
+        seedRuntimeDispositionWorkspace(stateStore, repoRoot, companyId)
         val upstreamId = "issue-upstream-done"
         val downstreamId = "issue-downstream-ready"
 
@@ -579,7 +586,8 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = agentExecutor
+            agentExecutor = agentExecutor,
+            autoStartAutomationRefresh = false
         )
 
         val state = stateStore.load()
@@ -625,10 +633,11 @@ private suspend fun seedRuntimeDispositionWorkspace(
     companyId: String = "company-1"
 ) {
     stateStore.save(
-        DesktopAppState(
-            repositories = listOf(
-                ManagedRepository(
-                    id = "repo-1",
+            DesktopAppState(
+                companies = listOf(runtimeDispositionCompany(companyId, repoRoot)),
+                repositories = listOf(
+                    ManagedRepository(
+                        id = "repo-1",
                     name = "repo",
                     localPath = repoRoot.toString(),
                     sourceKind = RepositorySourceKind.LOCAL,

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -8463,6 +8463,31 @@ class DesktopAppServiceTest : FunSpec({
             .map { it.id }
             .toSet()
         val retryAt = System.currentTimeMillis()
+        val staleCompletedTask = AgentTask(
+            id = "stale-completed-remediation-task",
+            workspaceId = remediationIssue.workspaceId,
+            issueId = remediationIssue.id,
+            title = remediationIssue.title,
+            prompt = remediationIssue.description,
+            agents = listOf("codex"),
+            status = DesktopTaskStatus.COMPLETED,
+            createdAt = retryAt - 1_000,
+            updatedAt = retryAt + 1
+        )
+        val staleCompletedRun = AgentRun(
+            id = "stale-completed-remediation-run",
+            taskId = staleCompletedTask.id,
+            workspaceId = remediationIssue.workspaceId,
+            repositoryId = nonRecoverSnapshot.repositories.first().id,
+            agentName = "codex",
+            branchName = "codex/cotor/nonrecoverable-remediation/stale",
+            worktreePath = repoRoot.resolve(".cotor/worktrees/nonrecoverable-remediation/stale").toString(),
+            status = AgentRunStatus.COMPLETED,
+            output = "late stale completion after the remediation issue was blocked",
+            error = null,
+            createdAt = retryAt - 1_000,
+            updatedAt = retryAt + 1
+        )
         stateStore.save(
             nonRecoverSnapshot.copy(
                 issues = nonRecoverSnapshot.issues.map {
@@ -8478,14 +8503,14 @@ class DesktopAppServiceTest : FunSpec({
                         it.issueId in siblingFollowUpIssueIds -> it.copy(status = DesktopTaskStatus.COMPLETED, updatedAt = retryAt)
                         else -> it
                     }
-                },
+                } + staleCompletedTask,
                 runs = nonRecoverSnapshot.runs.map {
                     if (it.taskId in siblingFollowUpTaskIds) {
                         it.copy(status = AgentRunStatus.COMPLETED, updatedAt = retryAt)
                     } else {
                         it
                     }
-                } + failedRun
+                } + failedRun + staleCompletedRun
             )
         )
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -14206,7 +14206,8 @@ class DesktopAppServiceTest : FunSpec({
             rootPath = repoRoot.toString(),
             repositoryId = REPOSITORY_ID,
             defaultBaseBranch = "master",
-            createdAt = 1L, updatedAt = 1L
+            createdAt = 1L,
+            updatedAt = 1L
         )
         val goal = CompanyGoal(
             id = "goal-qa-interrupted",
@@ -14273,18 +14274,23 @@ class DesktopAppServiceTest : FunSpec({
                 companies = listOf(company),
                 repositories = listOf(
                     ManagedRepository(
-                        id = REPOSITORY_ID, name = "repo",
+                        id = REPOSITORY_ID,
+                        name = "repo",
                         localPath = repoRoot.toString(),
                         sourceKind = RepositorySourceKind.LOCAL,
                         defaultBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 workspaces = listOf(
                     Workspace(
-                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
-                        name = "repo · master", baseBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        id = WORKSPACE_ID,
+                        repositoryId = REPOSITORY_ID,
+                        name = "repo · master",
+                        baseBranch = "master",
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 projectContexts = listOf(
@@ -14328,7 +14334,8 @@ class DesktopAppServiceTest : FunSpec({
             rootPath = repoRoot.toString(),
             repositoryId = REPOSITORY_ID,
             defaultBaseBranch = "master",
-            createdAt = 1L, updatedAt = 1L
+            createdAt = 1L,
+            updatedAt = 1L
         )
         val goal = CompanyGoal(
             id = "goal-qa-requeue-int",
@@ -14395,18 +14402,23 @@ class DesktopAppServiceTest : FunSpec({
                 companies = listOf(company),
                 repositories = listOf(
                     ManagedRepository(
-                        id = REPOSITORY_ID, name = "repo",
+                        id = REPOSITORY_ID,
+                        name = "repo",
                         localPath = repoRoot.toString(),
                         sourceKind = RepositorySourceKind.LOCAL,
                         defaultBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 workspaces = listOf(
                     Workspace(
-                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
-                        name = "repo · master", baseBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        id = WORKSPACE_ID,
+                        repositoryId = REPOSITORY_ID,
+                        name = "repo · master",
+                        baseBranch = "master",
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 projectContexts = listOf(
@@ -14459,7 +14471,8 @@ class DesktopAppServiceTest : FunSpec({
             rootPath = repoRoot.toString(),
             repositoryId = REPOSITORY_ID,
             defaultBaseBranch = "master",
-            createdAt = 1L, updatedAt = 1L
+            createdAt = 1L,
+            updatedAt = 1L
         )
         val goal = CompanyGoal(
             id = "goal-qa-src-done",
@@ -14504,18 +14517,23 @@ class DesktopAppServiceTest : FunSpec({
                 companies = listOf(company),
                 repositories = listOf(
                     ManagedRepository(
-                        id = REPOSITORY_ID, name = "repo",
+                        id = REPOSITORY_ID,
+                        name = "repo",
                         localPath = repoRoot.toString(),
                         sourceKind = RepositorySourceKind.LOCAL,
                         defaultBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 workspaces = listOf(
                     Workspace(
-                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
-                        name = "repo · master", baseBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        id = WORKSPACE_ID,
+                        repositoryId = REPOSITORY_ID,
+                        name = "repo · master",
+                        baseBranch = "master",
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 projectContexts = listOf(
@@ -14558,7 +14576,8 @@ class DesktopAppServiceTest : FunSpec({
             rootPath = repoRoot.toString(),
             repositoryId = REPOSITORY_ID,
             defaultBaseBranch = "master",
-            createdAt = 1L, updatedAt = 1L
+            createdAt = 1L,
+            updatedAt = 1L
         )
         val goal = CompanyGoal(
             id = "goal-qa-rq-await",
@@ -14605,25 +14624,31 @@ class DesktopAppServiceTest : FunSpec({
             runId = "run-exec-done",
             status = ReviewQueueStatus.AWAITING_QA,
             qaIssueId = qaIssue.id,
-            createdAt = 5L, updatedAt = 5L
+            createdAt = 5L,
+            updatedAt = 5L
         )
         stateStore.save(
             DesktopAppState(
                 companies = listOf(company),
                 repositories = listOf(
                     ManagedRepository(
-                        id = REPOSITORY_ID, name = "repo",
+                        id = REPOSITORY_ID,
+                        name = "repo",
                         localPath = repoRoot.toString(),
                         sourceKind = RepositorySourceKind.LOCAL,
                         defaultBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 workspaces = listOf(
                     Workspace(
-                        id = WORKSPACE_ID, repositoryId = REPOSITORY_ID,
-                        name = "repo · master", baseBranch = "master",
-                        createdAt = 1L, updatedAt = 1L
+                        id = WORKSPACE_ID,
+                        repositoryId = REPOSITORY_ID,
+                        name = "repo · master",
+                        baseBranch = "master",
+                        createdAt = 1L,
+                        updatedAt = 1L
                     )
                 ),
                 projectContexts = listOf(

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -527,6 +527,73 @@ class DesktopAppServiceTest : FunSpec({
             .forEach { reason -> reason shouldContain "CEO planning run assigned" }
     }
 
+    test("chat intake treats slash goal command as goal title not literal prefix") {
+        val appHome = Files.createTempDirectory("chat-intake-slash-goal-home")
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "Slash Goal QA",
+            rootPath = appHome.toString()
+        )
+
+        val response = service.createChatIntake(
+            companyId = company.id,
+            message = "/goal Stabilize marketing skill startup"
+        )
+
+        response.goal.companyId shouldBe company.id
+        response.goal.title shouldBe "Stabilize marketing skill startup"
+        response.goal.description shouldContain "Original user request:"
+        response.goal.description shouldContain "/goal Stabilize marketing skill startup"
+    }
+
+    test("direct goal create and update strip leading slash command markers") {
+        val appHome = Files.createTempDirectory("direct-goal-slash-command-home")
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "Direct Goal QA",
+            rootPath = appHome.toString()
+        )
+
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "- /goal Stabilize company runtime",
+            description = "/목표 회사 런타임 안정화",
+            autonomyEnabled = false
+        )
+
+        goal.title shouldBe "Stabilize company runtime"
+        goal.description shouldBe "회사 런타임 안정화"
+        goal.title shouldNotContain "/goal"
+        goal.description shouldNotContain "/목표"
+
+        val updated = service.updateGoal(
+            goalId = goal.id,
+            title = "/goal Keep startup healthy",
+            description = "/objective Verify app-server health",
+            autonomyEnabled = false,
+            startRuntimeIfNeeded = false
+        )
+
+        updated.title shouldBe "Keep startup healthy"
+        updated.description shouldBe "Verify app-server health"
+        updated.title shouldNotContain "/goal"
+        updated.description shouldNotContain "/objective"
+    }
+
     test("operator command summarizes selected company status") {
         val appHome = Files.createTempDirectory("operator-status-home")
         val stateStore = DesktopStateStore { appHome }
@@ -9554,6 +9621,19 @@ class DesktopAppServiceTest : FunSpec({
                         createdAt = now,
                         updatedAt = now
                     )
+                ),
+                companyRuntimeWorkItems = listOf(
+                    CompanyRuntimeWorkItem(
+                        id = "work-item-shutdown",
+                        companyId = "company-shutdown",
+                        goalId = "goal-shutdown",
+                        issueId = "issue-shutdown",
+                        status = CompanyRuntimeWorkItemStatus.RUNNING,
+                        activeTaskId = "task-shutdown",
+                        durableRunId = "run-shutdown",
+                        createdAt = now,
+                        updatedAt = now
+                    )
                 )
             )
         )
@@ -9565,6 +9645,10 @@ class DesktopAppServiceTest : FunSpec({
         repaired.issues.first { it.id == "issue-shutdown" }.transitionReason shouldContain "Runtime stopped while execution was in progress"
         repaired.tasks.first { it.id == "task-shutdown" }.status shouldBe DesktopTaskStatus.FAILED
         repaired.runs.first { it.id == "run-shutdown" }.error shouldContain "Execution was interrupted because the app-server stopped"
+        val repairedWorkItem = repaired.companyRuntimeWorkItems.first { it.id == "work-item-shutdown" }
+        repairedWorkItem.status shouldBe CompanyRuntimeWorkItemStatus.READY
+        repairedWorkItem.activeTaskId shouldBe null
+        repairedWorkItem.durableRunId shouldBe null
         repaired.companyActivity.any { activity ->
             activity.issueId == "issue-shutdown" &&
                 activity.title == "Interrupted by app-server shutdown"
@@ -10083,6 +10167,42 @@ class DesktopAppServiceTest : FunSpec({
                         message = "Needs attention",
                         createdAt = now
                     )
+                ),
+                goalDecisions = listOf(
+                    GoalOrchestrationDecision(
+                        id = "decision-delete",
+                        companyId = company.id,
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        title = "Delete decision",
+                        summary = "Stale goal decision should be removed with the company.",
+                        createdIssues = listOf(issue.id),
+                        createdAt = now
+                    )
+                ),
+                agentMessages = listOf(
+                    AgentMessage(
+                        id = "message-delete",
+                        companyId = company.id,
+                        fromAgentName = "CEO",
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        kind = "ceo-plan",
+                        subject = "Delete message",
+                        body = "Remove with company.",
+                        createdAt = now
+                    )
+                ),
+                companyRuntimeWorkItems = listOf(
+                    CompanyRuntimeWorkItem(
+                        id = "work-item-delete",
+                        companyId = company.id,
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        status = CompanyRuntimeWorkItemStatus.READY,
+                        createdAt = now,
+                        updatedAt = now
+                    )
                 )
             )
         )
@@ -10097,6 +10217,9 @@ class DesktopAppServiceTest : FunSpec({
         state.issues.filter { it.companyId == company.id }.shouldBeEmpty()
         state.reviewQueue.filter { it.companyId == company.id }.shouldBeEmpty()
         state.signals.filter { it.companyId == company.id }.shouldBeEmpty()
+        state.goalDecisions.filter { it.companyId == company.id }.shouldBeEmpty()
+        state.agentMessages.filter { it.companyId == company.id }.shouldBeEmpty()
+        state.companyRuntimeWorkItems.filter { it.companyId == company.id }.shouldBeEmpty()
         state.companyRuntimes.filter { it.companyId == company.id }.shouldBeEmpty()
         state.runtime.companyId shouldBe null
         contextRoot.exists() shouldBe false
@@ -10184,6 +10307,42 @@ class DesktopAppServiceTest : FunSpec({
                         message = "Delete me",
                         createdAt = now
                     )
+                ),
+                goalDecisions = listOf(
+                    GoalOrchestrationDecision(
+                        id = "goal-delete-decision",
+                        companyId = company.id,
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        title = "Goal delete decision",
+                        summary = "Stale goal decision should be removed with the goal.",
+                        createdIssues = listOf(issue.id),
+                        createdAt = now
+                    )
+                ),
+                agentMessages = listOf(
+                    AgentMessage(
+                        id = "goal-delete-message",
+                        companyId = company.id,
+                        fromAgentName = "CEO",
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        kind = "ceo-plan",
+                        subject = "Goal delete message",
+                        body = "Remove with goal.",
+                        createdAt = now
+                    )
+                ),
+                companyRuntimeWorkItems = listOf(
+                    CompanyRuntimeWorkItem(
+                        id = "goal-delete-work-item",
+                        companyId = company.id,
+                        goalId = goal.id,
+                        issueId = issue.id,
+                        status = CompanyRuntimeWorkItemStatus.READY,
+                        createdAt = now,
+                        updatedAt = now
+                    )
                 )
             )
         )
@@ -10197,6 +10356,9 @@ class DesktopAppServiceTest : FunSpec({
         state.runs.firstOrNull { it.taskId == "goal-delete-task" } shouldBe null
         state.reviewQueue.firstOrNull { it.issueId == issue.id } shouldBe null
         state.signals.firstOrNull { it.goalId == goal.id } shouldBe null
+        state.goalDecisions.firstOrNull { it.goalId == goal.id } shouldBe null
+        state.agentMessages.firstOrNull { it.goalId == goal.id } shouldBe null
+        state.companyRuntimeWorkItems.firstOrNull { it.goalId == goal.id } shouldBe null
         goalFile.exists() shouldBe false
         issueFile.exists() shouldBe false
     }
@@ -11401,6 +11563,109 @@ class DesktopAppServiceTest : FunSpec({
             refreshedQueue.approvalIssueId.shouldBeNull()
             refreshedQueue.ceoVerdict.shouldBeNull()
         }
+    }
+
+    test("workflow lineage repair settles review queue items that already carry merged GitHub state") {
+        val appHome = Files.createTempDirectory("desktop-app-service-merged-queue-settle")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-app-service-merged-queue-settle-repo").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+        coEvery { gitWorkspaceService.ensureInitializedRepositoryRoot(any(), any()) } returns repoRoot
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true)
+        )
+
+        val company = service.createCompany(
+            name = "Merged Queue Settle Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Settle merged PR state",
+            description = "A merged PR must not be rebuilt as awaiting QA.",
+            autonomyEnabled = false
+        )
+        val issue = service.createIssue(
+            companyId = company.id,
+            goalId = goal.id,
+            title = "Ship merged PR",
+            description = "The GitHub PR already merged.",
+            kind = "execution"
+        )
+        val baseState = stateStore.load()
+        val now = System.currentTimeMillis()
+        val qaIssue = CompanyIssue(
+            id = "issue-qa-merged-settle",
+            companyId = company.id,
+            projectContextId = issue.projectContextId,
+            goalId = goal.id,
+            workspaceId = issue.workspaceId,
+            title = "QA review Ship merged PR",
+            description = "Stale QA issue for a PR that already merged.",
+            status = IssueStatus.PLANNED,
+            priority = 2,
+            kind = "review",
+            dependsOn = listOf(issue.id),
+            sourceSignal = "qa-review:${issue.id}",
+            createdAt = now - 1_000,
+            updatedAt = now - 1_000
+        )
+        val queueItem = ReviewQueueItem(
+            id = "rq-merged-settle",
+            companyId = company.id,
+            projectContextId = issue.projectContextId,
+            issueId = issue.id,
+            runId = "run-merged-settle",
+            pullRequestNumber = 20,
+            pullRequestUrl = "https://github.com/bssm-oss/cotor-testv2/pull/20",
+            pullRequestState = "MERGED",
+            status = ReviewQueueStatus.AWAITING_QA,
+            qaIssueId = qaIssue.id,
+            providerBlockReason = "PR no longer merges cleanly",
+            mergeCommitSha = "a5bc2ad",
+            mergedAt = now - 500,
+            createdAt = now - 2_000,
+            updatedAt = now - 500
+        )
+        stateStore.save(
+            baseState.copy(
+                issues = baseState.issues.map { existing ->
+                    if (existing.id == issue.id) {
+                        existing.copy(
+                            status = IssueStatus.IN_REVIEW,
+                            pullRequestNumber = 20,
+                            pullRequestUrl = "https://github.com/bssm-oss/cotor-testv2/pull/20",
+                            pullRequestState = "MERGED",
+                            providerBlockReason = "PR no longer merges cleanly",
+                            transitionReason = "PR no longer merges cleanly",
+                            updatedAt = now
+                        )
+                    } else {
+                        existing
+                    }
+                } + qaIssue,
+                reviewQueue = baseState.reviewQueue + queueItem
+            )
+        )
+
+        service.companyDashboard(company.id)
+
+        val settled = stateStore.load()
+        val settledIssue = settled.issues.first { it.id == issue.id }
+        val settledQueue = settled.reviewQueue.first { it.id == queueItem.id }
+        settledIssue.status shouldBe IssueStatus.DONE
+        settledIssue.mergeResult shouldBe "MERGED"
+        settledIssue.providerBlockReason shouldBe null
+        settledIssue.transitionReason?.contains("does not merge cleanly", ignoreCase = true) shouldBe false
+        settledIssue.ceoVerdict shouldBe "APPROVE"
+        settledQueue.status shouldBe ReviewQueueStatus.MERGED
+        settledQueue.providerBlockReason shouldBe null
+        settledQueue.qaIssueId shouldBe null
+        settled.issues.any { it.id == qaIssue.id } shouldBe false
     }
 
     test("company dashboard heals a stale QA lineage while the runtime is stopped") {

--- a/src/test/kotlin/com/cotor/app/DesktopEndpointPolicyTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopEndpointPolicyTest.kt
@@ -50,10 +50,22 @@ class DesktopEndpointPolicyTest : FunSpec({
         DesktopEndpointPolicy.isLoopback("https://api.cotor.io") shouldBe false
         DesktopEndpointPolicy.isLoopback("http://10.0.0.1:8787") shouldBe false
         DesktopEndpointPolicy.isLoopback("http://192.168.1.100:8787") shouldBe false
+        DesktopEndpointPolicy.isLoopback("http://localhost.evil.test:8787") shouldBe false
+        DesktopEndpointPolicy.isLoopback("http://127.0.0.1.evil.test:8787") shouldBe false
+        DesktopEndpointPolicy.isLoopback("ftp://localhost:8787") shouldBe false
     }
 
     test("trailing slash is stripped before appending api/a2a") {
         val endpoint = DesktopEndpointPolicy.resolveA2aEndpoint("http://127.0.0.1:8787/")
         endpoint shouldBe "http://127.0.0.1:8787/api/a2a"
+    }
+
+    test("remote URL is allowed only with explicit flag and token") {
+        val endpoint = DesktopEndpointPolicy.resolveA2aEndpoint(
+            envUrl = "https://remote.example.com:8787",
+            envAllowRemote = "1",
+            envToken = "token"
+        )
+        endpoint shouldBe "https://remote.example.com:8787/api/a2a"
     }
 })

--- a/src/test/kotlin/com/cotor/app/DesktopEndpointPolicyTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopEndpointPolicyTest.kt
@@ -2,7 +2,6 @@ package com.cotor.app
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldStartWith
 
 class DesktopEndpointPolicyTest : FunSpec({
 

--- a/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
@@ -14,6 +14,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
+import java.nio.file.attribute.FileTime
 import kotlin.io.path.readText
 
 class DesktopStateStoreTest : FunSpec({
@@ -46,6 +47,135 @@ class DesktopStateStoreTest : FunSpec({
 
         recovered.companies.map { it.name } shouldBe listOf("Recovered Company")
         Files.readString(appHome.resolve("state.json")).trimEnd().endsWith("}}") shouldBe false
+    }
+
+    test("save removes stale state temp files") {
+        val appHome = Files.createTempDirectory("desktop-state-store-temp-cleanup-home")
+        val store = DesktopStateStore { appHome }
+        Files.writeString(appHome.resolve("state.json.111.tmp"), "{}")
+        Files.writeString(appHome.resolve("state.json.bak.222.tmp"), "{}")
+        Files.writeString(appHome.resolve("state.json.bak"), "{}")
+        val staleTime = FileTime.fromMillis(System.currentTimeMillis() - 120_000L)
+        Files.setLastModifiedTime(appHome.resolve("state.json.111.tmp"), staleTime)
+        Files.setLastModifiedTime(appHome.resolve("state.json.bak.222.tmp"), staleTime)
+
+        store.save(DesktopAppState())
+
+        stateTempFilesToClean(appHome) shouldBe emptyList()
+        appHome.resolve("state.json").toFile().exists() shouldBe true
+        appHome.resolve("state.json.bak").toFile().exists() shouldBe true
+    }
+
+    test("fresh state temp files are not cleaned while another save may still be moving them") {
+        val appHome = Files.createTempDirectory("desktop-state-store-fresh-temp-home")
+        val freshTemp = appHome.resolve("state.json.bak.fresh.tmp")
+        Files.writeString(freshTemp, "{}")
+
+        stateTempFilesToClean(
+            directory = appHome,
+            nowMillis = Files.getLastModifiedTime(freshTemp).toMillis() + 1_000L
+        ) shouldBe emptyList()
+    }
+
+    test("load prunes dangling company goal and runtime records") {
+        val appHome = Files.createTempDirectory("desktop-state-store-dangling-company-home")
+        val store = DesktopStateStore { appHome }
+        val now = 1L
+        val validCompany = Company(
+            id = "company-1",
+            name = "Valid Company",
+            rootPath = "/tmp/valid-company",
+            repositoryId = "repo-1",
+            defaultBaseBranch = "master",
+            createdAt = now,
+            updatedAt = now
+        )
+        val validGoal = CompanyGoal(
+            id = "goal-1",
+            companyId = validCompany.id,
+            title = "Keep valid work",
+            description = "Keep valid goal records.",
+            status = GoalStatus.ACTIVE,
+            createdAt = now,
+            updatedAt = now
+        )
+        val validIssue = CompanyIssue(
+            id = "issue-1",
+            companyId = validCompany.id,
+            goalId = validGoal.id,
+            workspaceId = "workspace-1",
+            title = "Keep valid issue",
+            description = "Keep valid issue records.",
+            status = IssueStatus.PLANNED,
+            createdAt = now,
+            updatedAt = now
+        )
+        val danglingDecision = GoalOrchestrationDecision(
+            id = "decision-stale",
+            companyId = "deleted-company",
+            goalId = "deleted-goal",
+            issueId = "deleted-issue",
+            title = "Delete stale decision",
+            summary = "This belongs to a deleted company.",
+            createdAt = now
+        )
+        val validDecision = GoalOrchestrationDecision(
+            id = "decision-valid",
+            companyId = validCompany.id,
+            goalId = validGoal.id,
+            issueId = validIssue.id,
+            title = "Keep valid decision",
+            summary = "This belongs to the live company.",
+            createdIssues = listOf(validIssue.id, "deleted-issue"),
+            createdAt = now
+        )
+        val danglingWorkItem = CompanyRuntimeWorkItem(
+            id = "work-stale",
+            companyId = "deleted-company",
+            goalId = "deleted-goal",
+            issueId = "deleted-issue",
+            status = CompanyRuntimeWorkItemStatus.READY,
+            createdAt = now,
+            updatedAt = now
+        )
+        val validWorkItem = CompanyRuntimeWorkItem(
+            id = "work-valid",
+            companyId = validCompany.id,
+            goalId = validGoal.id,
+            issueId = validIssue.id,
+            status = CompanyRuntimeWorkItemStatus.READY,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        store.save(
+            DesktopAppState(
+                companies = listOf(validCompany),
+                goals = listOf(
+                    validGoal,
+                    validGoal.copy(id = "deleted-goal", companyId = "deleted-company")
+                ),
+                issues = listOf(
+                    validIssue,
+                    validIssue.copy(id = "deleted-issue", companyId = "deleted-company", goalId = "deleted-goal")
+                ),
+                goalDecisions = listOf(validDecision, danglingDecision),
+                companyRuntimeWorkItems = listOf(validWorkItem, danglingWorkItem),
+                companyRuntimes = listOf(
+                    CompanyRuntimeSnapshot(companyId = validCompany.id, status = CompanyRuntimeStatus.RUNNING),
+                    CompanyRuntimeSnapshot(companyId = "deleted-company", status = CompanyRuntimeStatus.RUNNING)
+                )
+            )
+        )
+
+        val recovered = store.load()
+
+        recovered.goals.map { it.id } shouldBe listOf(validGoal.id)
+        recovered.issues.map { it.id } shouldBe listOf(validIssue.id)
+        recovered.goalDecisions.map { it.id } shouldBe listOf(validDecision.id)
+        recovered.goalDecisions.single().createdIssues shouldBe listOf(validIssue.id)
+        recovered.companyRuntimeWorkItems.map { it.id } shouldBe listOf(validWorkItem.id)
+        recovered.companyRuntimes.map { it.companyId } shouldBe listOf(validCompany.id)
     }
 
     test("load restores the last good backup when the primary state file is corrupted") {
@@ -123,6 +253,16 @@ class DesktopStateStoreTest : FunSpec({
                     defaultBaseBranch = "master",
                     createdAt = 1L,
                     updatedAt = 1L
+                )
+            ),
+            projectContexts = listOf(
+                CompanyProjectContext(
+                    id = "project-1",
+                    companyId = "company-1",
+                    name = "Lenient Company",
+                    slug = "lenient-company",
+                    contextDocPath = appHome.resolve("project.md").toString(),
+                    lastUpdatedAt = 1L
                 )
             ),
             goals = listOf(
@@ -307,6 +447,39 @@ class DesktopStateStoreTest : FunSpec({
         val store = DesktopStateStore { appHome }
         val longPrompt = "prompt-".repeat(800)
         val state = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Unresolved Prompt Company",
+                    rootPath = "/tmp/unresolved-prompt-company",
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            projectContexts = listOf(
+                CompanyProjectContext(
+                    id = "project-1",
+                    companyId = "company-1",
+                    name = "Unresolved Prompt Company",
+                    slug = "unresolved-prompt-company",
+                    contextDocPath = appHome.resolve("project.md").toString(),
+                    lastUpdatedAt = 1L
+                )
+            ),
+            goals = listOf(
+                CompanyGoal(
+                    id = "goal-1",
+                    companyId = "company-1",
+                    projectContextId = "project-1",
+                    title = "Keep prompt",
+                    description = "Keep unresolved prompt context.",
+                    status = GoalStatus.ACTIVE,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
             issues = listOf(
                 CompanyIssue(
                     id = "issue-1",
@@ -348,6 +521,39 @@ class DesktopStateStoreTest : FunSpec({
         val store = DesktopStateStore { appHome }
         val longOutput = "```json\n{\"goalSummary\":\"" + "plan-".repeat(900) + "\",\"issues\":[{\"refId\":\"exec-1\",\"title\":\"Work\",\"description\":\"Do work\",\"assigneeRole\":\"Builder\"}]}\n```"
         val state = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Unresolved Output Company",
+                    rootPath = "/tmp/unresolved-output-company",
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            projectContexts = listOf(
+                CompanyProjectContext(
+                    id = "project-1",
+                    companyId = "company-1",
+                    name = "Unresolved Output Company",
+                    slug = "unresolved-output-company",
+                    contextDocPath = appHome.resolve("project.md").toString(),
+                    lastUpdatedAt = 1L
+                )
+            ),
+            goals = listOf(
+                CompanyGoal(
+                    id = "goal-1",
+                    companyId = "company-1",
+                    projectContextId = "project-1",
+                    title = "Keep output",
+                    description = "Keep unresolved run output.",
+                    status = GoalStatus.ACTIVE,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
             issues = listOf(
                 CompanyIssue(
                     id = "issue-1",

--- a/src/test/kotlin/com/cotor/app/DesktopTuiSessionServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopTuiSessionServiceTest.kt
@@ -65,9 +65,13 @@ class DesktopTuiSessionServiceTest : FunSpec({
             DesktopAppState(
                 repositories = listOf(
                     ManagedRepository(
-                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
-                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
-                        createdAt = 1, updatedAt = 1
+                        id = "repo-1",
+                        name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1,
+                        updatedAt = 1
                     )
                 ),
                 workspaces = listOf(
@@ -99,9 +103,13 @@ class DesktopTuiSessionServiceTest : FunSpec({
             DesktopAppState(
                 repositories = listOf(
                     ManagedRepository(
-                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
-                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
-                        createdAt = 1, updatedAt = 1
+                        id = "repo-1",
+                        name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1,
+                        updatedAt = 1
                     )
                 ),
                 workspaces = listOf(
@@ -134,9 +142,13 @@ class DesktopTuiSessionServiceTest : FunSpec({
             DesktopAppState(
                 repositories = listOf(
                     ManagedRepository(
-                        id = "repo-1", name = "repo", localPath = repoRoot.toString(),
-                        sourceKind = RepositorySourceKind.LOCAL, defaultBranch = "master",
-                        createdAt = 1, updatedAt = 1
+                        id = "repo-1",
+                        name = "repo",
+                        localPath = repoRoot.toString(),
+                        sourceKind = RepositorySourceKind.LOCAL,
+                        defaultBranch = "master",
+                        createdAt = 1,
+                        updatedAt = 1
                     )
                 ),
                 workspaces = listOf(


### PR DESCRIPTION
## Summary

This PR fixes the Cotor desktop/runtime issues found during the installed-app and local app-server validation pass:

- supervises packaged app-server Java children so launcher termination also stops the backend process
- removes stale copied desktop runtime jars on normal and abnormal backend shutdown paths
- repairs app-server/company runtime state when persisted state says RUNNING but the pid/port is no longer reachable
- normalizes interrupted delegated tasks, dangling active task ids, merged PR review state, and contradictory transition reasons
- prevents stale task completion callbacks from marking newer blocked remediation work as done
- kills timed-out process trees more reliably, including Unix background children that Java descendants can miss
- aligns local Playwright skill setup timeout with its inner install timeout and ensures subprocess cleanup
- hardens security-sensitive local desktop boundaries: terminal rendering, app-server URL policy, marketing browser session references, clone URL handling, and endpoint reachability checks
- makes Team skill cards truthful when a skill is disabled or approval-gated, instead of presenting an action as runnable
- keeps deterministic operator-chat actions such as `/goal` and ASK_ME HR staffing local-first instead of leaking to backend operator chat before command parsing
- refreshes the graphify report after the runtime/security/test changes

## Commit breakdown

- `fix(desktop): supervise bundled backend lifecycle`
  - adds `ProcessTree` and launcher child tracking
  - cleans copied runtime jars from `EmbeddedBackendLauncher`
  - adds launcher lifecycle regression coverage
- `fix(security): harden desktop app-server boundaries`
  - restricts Swift app-server override policy to loopback by default
  - avoids terminal `innerHTML` rendering for untrusted strings
  - validates desktop endpoint reachability and file-origin terminal requests
  - tightens app-server route error handling
- `fix(company): repair runtime and review state recovery`
  - reconciles stale backend runtime pid/port state with live reachability
  - resets interrupted work items and dangling active tasks into recoverable state
  - reconciles merged GitHub PRs with review queue state
  - makes marketing no-op / analytics-empty outcomes visible instead of falsely successful
- `fix(skills): align playwright setup timeouts`
  - prevents first-run Playwright install from being killed by the outer runner timeout
  - guarantees launched runner processes are cleaned up
- `fix(desktop): surface truthful runtime and skill state`
  - updates Swift models/store/views so backend-offline and non-runnable skills are displayed accurately
  - adds Swift model/store coverage for the new runtime and skill-state behavior
- `chore(graph): refresh graphify report`
  - updates the repository graph report after code changes
- `test(desktop): stabilize operator chat and URL protocol tests`
  - formats Kotlin tests to satisfy CI `formatCheck`
  - scopes Swift URLProtocol test handlers by host to avoid parallel mock collisions
  - preserves local-first operator command parsing before backend operator chat fallback
- `fix(company): ignore stale task completion replays`
  - uses the persisted terminal task status as the source of truth during issue sync
  - prevents late successful callbacks from overriding newer non-recoverable blocked remediation state
  - refreshes graphify after the CI runtime-shard fix
- `fix(runtime): preserve blocked remediation state`
  - narrows stale completion replay blocking so manual reruns of blocked work still complete
  - adds an explicit stale-completion regression case to the runtime test
  - asks Unix `pkill -P` to terminate timed-out background children before force-killing the process tree
  - refreshes graphify after the final CI follow-up

## Validation

Automated validation run locally on this branch:

- `git diff --check`
- `./gradlew --no-daemon formatCheck`
- `./gradlew test`
- `./gradlew --no-daemon test --stacktrace --tests 'com.cotor.app.DesktopAppServiceTest' -x jacocoTestReport -x jacocoTestCoverageVerification`
- `./gradlew --no-daemon test --rerun-tasks --stacktrace --tests 'com.cotor.app.DesktopAppServiceTest' -x jacocoTestReport -x jacocoTestCoverageVerification`
- `./gradlew --no-daemon test --rerun-tasks --stacktrace --tests 'com.cotor.data.process.ProcessManagerTest' -x jacocoTestReport -x jacocoTestCoverageVerification`
- `swift build` from `macos/`
- `swift test` from `macos/` (122 tests passed)
- `bash shell/test-desktop-launcher-runtime.sh`
- `graphify update .`

Manual validation already performed before opening this PR:

- rebuilt and installed `/Applications/Cotor Desktop.app` with `./shell/install-desktop-app.sh`
- opened the installed app and clicked through company creation, Team, Issues, and company detail surfaces
- confirmed Team skill cards show disabled/non-runnable state instead of suggesting unavailable execution
- started and stopped an installed-app company backend runtime through the local API
- quit the installed app and verified the packaged app-server Java process did not remain alive
- ran a source app-server smoke test on a temporary home and port, including `/health`, company create, dashboard fetch, goal create, runtime read, and shutdown

## CI follow-up

The first CI run on `17961575` failed only `verify-app-company-runtime` because `DesktopAppServiceTest` observed a blocked remediation issue becoming `DONE`. Follow-up commits fixed task-to-issue sync so persisted terminal task state wins, and so stale task completions are ignored only when a newer non-recoverable failed task owns the blocked issue state.

The next CI run also exposed `ProcessManagerTest` on Linux leaving a timed-out shell background descendant alive. The process manager now combines Java descendant cleanup with Unix parent-child cleanup via `pkill -P` before force kill.

## Notes

Untracked local screenshots and generated graph path artifacts were intentionally left out of this PR.
