### PR TITLE
[codex] Fix installed desktop resource bundle loading

### DIFF
--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -614,7 +614,7 @@ private struct CotorBrandLogo: View {
     }
 
     private static let logoImage: NSImage? = {
-        guard let url = Bundle.module.url(
+        guard let url = DesktopResources.url(
             forResource: "CotorHeaderMark",
             withExtension: "png",
             subdirectory: "Brand"

--- a/macos/Sources/CotorDesktopApp/DesktopResources.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopResources.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+enum DesktopResources {
+    private static let swiftPMBundleName = "CotorDesktop_CotorDesktopApp.bundle"
+
+    static func url(
+        forResource name: String,
+        withExtension fileExtension: String?,
+        subdirectory: String? = nil
+    ) -> URL? {
+        url(
+            forResource: name,
+            withExtension: fileExtension,
+            subdirectory: subdirectory,
+            mainBundleURL: Bundle.main.bundleURL,
+            mainResourceURL: Bundle.main.resourceURL,
+            executablePath: CommandLine.arguments.first,
+            sourceFilePath: #filePath
+        )
+    }
+
+    static func url(
+        forResource name: String,
+        withExtension fileExtension: String?,
+        subdirectory: String? = nil,
+        mainBundleURL: URL,
+        mainResourceURL: URL?,
+        executablePath: String?,
+        sourceFilePath: String,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let fileName = fileExtension.map { "\(name).\($0)" } ?? name
+        for root in resourceRootCandidates(
+            mainBundleURL: mainBundleURL,
+            mainResourceURL: mainResourceURL,
+            executablePath: executablePath,
+            sourceFilePath: sourceFilePath
+        ) {
+            let candidate = append(subdirectory: subdirectory, fileName: fileName, to: root)
+            var isDirectory = ObjCBool(false)
+            if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory), !isDirectory.boolValue {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    static func resourceRootCandidates(
+        mainBundleURL: URL,
+        mainResourceURL: URL?,
+        executablePath: String?,
+        sourceFilePath: String
+    ) -> [URL] {
+        var candidates: [URL] = []
+
+        if let mainResourceURL {
+            candidates.append(mainResourceURL.appendingPathComponent(swiftPMBundleName, isDirectory: true))
+        }
+
+        candidates.append(
+            mainBundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Resources", isDirectory: true)
+                .appendingPathComponent(swiftPMBundleName, isDirectory: true)
+        )
+        candidates.append(mainBundleURL.appendingPathComponent(swiftPMBundleName, isDirectory: true))
+
+        if let executablePath, !executablePath.isEmpty {
+            let executableURL = URL(fileURLWithPath: executablePath)
+            let executableDirectory = executableURL.deletingLastPathComponent()
+            candidates.append(executableDirectory.appendingPathComponent(swiftPMBundleName, isDirectory: true))
+            candidates.append(
+                executableDirectory
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("Resources", isDirectory: true)
+                    .appendingPathComponent(swiftPMBundleName, isDirectory: true)
+            )
+        }
+
+        let sourceResources = URL(fileURLWithPath: sourceFilePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources", isDirectory: true)
+        candidates.append(sourceResources)
+
+        return uniqueStandardizedURLs(candidates)
+    }
+
+    private static func append(subdirectory: String?, fileName: String, to root: URL) -> URL {
+        guard let subdirectory, !subdirectory.isEmpty else {
+            return root.appendingPathComponent(fileName, isDirectory: false)
+        }
+        return root
+            .appendingPathComponent(subdirectory, isDirectory: true)
+            .appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    private static func uniqueStandardizedURLs(_ urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        var unique: [URL] = []
+
+        for url in urls {
+            let standardized = url.standardizedFileURL
+            if seen.insert(standardized.path).inserted {
+                unique.append(standardized)
+            }
+        }
+
+        return unique
+    }
+}

--- a/macos/Sources/CotorDesktopApp/WebView.swift
+++ b/macos/Sources/CotorDesktopApp/WebView.swift
@@ -48,7 +48,7 @@ struct TerminalWebView: NSViewRepresentable {
         webView.navigationDelegate = context.coordinator
         context.coordinator.webView = webView
 
-        guard let htmlURL = Bundle.module.url(forResource: "terminal", withExtension: "html", subdirectory: "Terminal") else {
+        guard let htmlURL = DesktopResources.url(forResource: "terminal", withExtension: "html", subdirectory: "Terminal") else {
             webView.loadHTMLString(
                 """
                 <html><body style="background:#0b0f14;color:#f5f7fb;font-family:Menlo,monospace;padding:24px;">Missing terminal bundle resources.</body></html>

--- a/macos/Tests/CotorDesktopAppTests/DesktopResourcesTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopResourcesTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import CotorDesktopApp
+
+struct DesktopResourcesTests {
+    @Test
+    func installedAppResourceBundleIsResolvedFromContentsResources() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cotor-resources-installed-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let appBundle = tmpDir.appendingPathComponent("Cotor Desktop.app", isDirectory: true)
+        let resourceBundle = appBundle
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("CotorDesktop_CotorDesktopApp.bundle", isDirectory: true)
+        let brandDir = resourceBundle.appendingPathComponent("Brand", isDirectory: true)
+        try FileManager.default.createDirectory(at: brandDir, withIntermediateDirectories: true)
+        let logo = brandDir.appendingPathComponent("CotorHeaderMark.png", isDirectory: false)
+        try Data("logo".utf8).write(to: logo)
+
+        let resolved = DesktopResources.url(
+            forResource: "CotorHeaderMark",
+            withExtension: "png",
+            subdirectory: "Brand",
+            mainBundleURL: appBundle,
+            mainResourceURL: appBundle.appendingPathComponent("Contents/Resources", isDirectory: true),
+            executablePath: appBundle.appendingPathComponent("Contents/MacOS/CotorDesktopBinary").path,
+            sourceFilePath: tmpDir.appendingPathComponent("DesktopResources.swift").path
+        )
+
+        #expect(resolved == logo.standardizedFileURL)
+    }
+
+    @Test
+    func swiftPMAdjacentResourceBundleIsResolvedForSourceBuilds() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cotor-resources-swiftpm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let buildDir = tmpDir.appendingPathComponent("release", isDirectory: true)
+        let resourceBundle = buildDir.appendingPathComponent("CotorDesktop_CotorDesktopApp.bundle", isDirectory: true)
+        let terminalDir = resourceBundle.appendingPathComponent("Terminal", isDirectory: true)
+        try FileManager.default.createDirectory(at: terminalDir, withIntermediateDirectories: true)
+        let terminalHTML = terminalDir.appendingPathComponent("terminal.html", isDirectory: false)
+        try Data("<html></html>".utf8).write(to: terminalHTML)
+
+        let resolved = DesktopResources.url(
+            forResource: "terminal",
+            withExtension: "html",
+            subdirectory: "Terminal",
+            mainBundleURL: tmpDir.appendingPathComponent("CotorDesktopPackageTests.xctest", isDirectory: true),
+            mainResourceURL: nil,
+            executablePath: buildDir.appendingPathComponent("CotorDesktopApp").path,
+            sourceFilePath: tmpDir.appendingPathComponent("DesktopResources.swift").path
+        )
+
+        #expect(resolved == terminalHTML.standardizedFileURL)
+    }
+}

--- a/shell/build-desktop-app-bundle.sh
+++ b/shell/build-desktop-app-bundle.sh
@@ -85,6 +85,8 @@ fi
 APP_BINARY="${APP_BINARY:-$(find_built_app_binary)}"
 BACKEND_JAR="$(find "$PROJECT_ROOT/build/libs" -name 'cotor-*-all.jar' -type f | head -n 1)"
 RESOURCE_BUNDLES="$(find "$PACKAGE_ROOT/.build" -path '*/release/*.bundle' -type d)"
+DESKTOP_RESOURCE_BUNDLE="CotorDesktop_CotorDesktopApp.bundle"
+DESKTOP_RESOURCE_BUNDLE_PATH="$(find "$PACKAGE_ROOT/.build" -path "*/release/$DESKTOP_RESOURCE_BUNDLE" -type d | head -n 1)"
 
 if [[ -z "$APP_BINARY" || ! -f "$APP_BINARY" ]]; then
     echo "❌ Could not locate the built CotorDesktopApp binary."
@@ -93,6 +95,16 @@ fi
 
 if [[ -z "$BACKEND_JAR" || ! -f "$BACKEND_JAR" ]]; then
     echo "❌ Could not locate the bundled backend jar."
+    exit 1
+fi
+
+if [[ -z "$DESKTOP_RESOURCE_BUNDLE_PATH" || ! -d "$DESKTOP_RESOURCE_BUNDLE_PATH" ]]; then
+    echo "❌ Could not locate the built desktop resource bundle: $DESKTOP_RESOURCE_BUNDLE"
+    exit 1
+fi
+
+if [[ ! -f "$DESKTOP_RESOURCE_BUNDLE_PATH/Brand/CotorHeaderMark.png" || ! -f "$DESKTOP_RESOURCE_BUNDLE_PATH/Terminal/terminal.html" ]]; then
+    echo "❌ Desktop resource bundle is missing required Brand or Terminal assets."
     exit 1
 fi
 
@@ -152,6 +164,8 @@ cp "$BACKEND_JAR" "$APP_BACKEND/cotor-backend.jar"
 if [[ -n "$RESOURCE_BUNDLES" ]]; then
     while IFS= read -r bundle_path; do
         [[ -z "$bundle_path" ]] && continue
+        bundle_name="$(basename "$bundle_path")"
+        rm -rf "$APP_RESOURCES/$bundle_name"
         cp -R "$bundle_path" "$APP_RESOURCES/"
     done <<< "$RESOURCE_BUNDLES"
 fi


### PR DESCRIPTION
## Summary
- Add a desktop resource resolver that finds SwiftPM assets from the installed app's `Contents/Resources/CotorDesktop_CotorDesktopApp.bundle` instead of relying directly on `Bundle.module`.
- Route the header logo and terminal WebView HTML through that resolver so the installed app can launch without the SwiftPM resource accessor fatal error.
- Harden desktop app bundle packaging to fail fast when the resource bundle, logo, or terminal HTML is missing.

## Root cause
The packaged macOS app placed SwiftPM resources under `Contents/Resources`, but the generated `Bundle.module` accessor could fatal before UI startup when the installed app was launched. The fix keeps resources in the signed app resources directory and resolves them explicitly at runtime.

## Validation
- `swift test` in `macos/` passed with 126 tests.
- `bash -n shell/build-desktop-app-bundle.sh && git diff --check HEAD~2..HEAD` passed.
- `./gradlew --no-daemon formatCheck test -x jacocoTestCoverageVerification` passed earlier on the fixed worktree before publish.
- `bash shell/test-desktop-launcher-runtime.sh` passed earlier on the fixed worktree.
- Rebuilt and installed `/Applications/Cotor Desktop.app`; `codesign --verify --deep --strict` passed for the built and installed app bundles.
- Direct installed-app UI smoke passed: app launched, `/health` was healthy, Company/Goals/Issues/Reports/Team/Operator Chat/TUI surfaces opened, terminal HTML loaded from the packaged bundle, operator chat responded, and quitting the app left no backend/app-server child process behind.