### PR TITLE
fix(qa): stabilize junit xml test reports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,10 @@ tasks.register("formatCheck") {
 tasks.test {
     useJUnitPlatform()
     maxParallelForks = 1
+    reports.junitXml.apply {
+        includeSystemOutLog.set(false)
+        includeSystemErrLog.set(false)
+    }
     testLogging {
         events("failed", "skipped")
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-05-23)
 
 ## Corpus Check
-- 364 files · ~625,231 words
+- 364 files · ~625,236 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary


### PR DESCRIPTION
## 발견된 버그
- 머지 후 전체 Gradle QA 루프에서 테스트 케이스는 통과했지만 Gradle JUnit XML 생성 단계가 `TestOutputStore`의 `EOFException`으로 실패했습니다.
- `DesktopAppServiceTest` 단독 `cleanTest` 실행은 통과했고, 전체 XML은 stdout/stderr output store 재생 중 일부 파일이 비어 있거나 잘린 상태로 생성되어 `./gradlew ... test`가 실패했습니다.

## 수정 내용
- Gradle `test` 태스크의 JUnit XML 리포트에서 stdout/stderr payload embedding을 비활성화했습니다.
- 테스트 pass/fail 판정, JUnit XML 생성, 콘솔의 failed/skipped 로깅은 유지하고, 큰 통합 테스트 실행 후 binary output store 재생에 의존하지 않게 했습니다.
- graphify 리포트를 갱신했습니다.

## 재테스트 결과
- `./gradlew --no-daemon cleanTest formatCheck test shadowJar --stacktrace`
- `swift test --package-path macos && swift build --package-path macos`
- `./shell/test-desktop-launcher-runtime.sh && git diff --check && xmllint --noout build/test-results/test/TEST-com.cotor.app.DesktopAppServiceTest.xml`

## 문서/리스크
- 사용자 동작 변경은 아니어서 영문/국문 제품 문서는 변경하지 않았습니다.
- XML 리포트에 stdout/stderr 본문은 더 이상 포함되지 않습니다. 실패 요약은 Gradle testLogging으로 계속 출력됩니다.