### PR TITLE
fix(qa): disable flaky html test report generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,7 @@ tasks.test {
         includeSystemOutLog.set(false)
         includeSystemErrLog.set(false)
     }
+    reports.html.required.set(false)
     testLogging {
         events("failed", "skipped")
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-05-23)
 
 ## Corpus Check
-- 364 files · ~625,236 words
+- 364 files · ~625,237 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,4 +1,4 @@
-# Graph Report - cotor  (2026-05-23)
+# Graph Report - cotor  (2026-05-24)
 
 ## Corpus Check
 - 364 files · ~625,237 words

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -2723,7 +2723,7 @@ class DesktopAppServiceTest : FunSpec({
 
         fixture.service.runTask(fixture.task.id)
         val run = fixture.awaitRuns().single()
-        val updatedIssue = withTimeout(30_000) {
+        val updatedIssue = withTimeout(90_000) {
             while (true) {
                 val candidate = fixture.stateStore.load().issues.single { it.id == issue.id }
                 if (candidate.status == IssueStatus.WAITING_FOR_APPROVAL) {
@@ -4731,7 +4731,7 @@ class DesktopAppServiceTest : FunSpec({
         )
 
         service.runTask(qaTask.id)
-        withTimeout(30_000) {
+        withTimeout(90_000) {
             while (stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }.qaVerdict != "PASS") {
                 delay(25)
             }
@@ -4793,7 +4793,7 @@ class DesktopAppServiceTest : FunSpec({
         )
 
         service.runTask(approvalTask.id)
-        withTimeout(30_000) {
+        withTimeout(90_000) {
             while (stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }.status != ReviewQueueStatus.MERGED) {
                 delay(25)
             }


### PR DESCRIPTION
## 발견된 버그
- PR #406 머지 후 `./gradlew --no-daemon test --rerun-tasks --stacktrace` 최종 루프에서 테스트 실행은 완료됐지만 Gradle HTML test report 생성 단계가 `TestOutputStore`의 `EOFException`으로 실패했습니다.
- JUnit XML stdout/stderr embedding은 이미 꺼졌지만, HTML per-class report가 같은 binary output store를 다시 읽고 있었습니다.
- 첫 CI 재실행에서는 `deterministic installed app markdown PRs can pass QA and CEO without provider runs`가 Ubuntu runner에서 30초 review-queue wait를 초과해 실패했습니다.

## 수정 내용
- Gradle `test` 태스크에서 HTML test report 생성을 비활성화했습니다.
- JUnit XML, 테스트 pass/fail 판정, 콘솔 failed/skipped 로깅은 유지합니다.
- deterministic review-flow 테스트의 QA/CEO wait budget을 인접 안정화 테스트와 같은 90초로 늘렸습니다.
- graphify 리포트를 갱신했습니다.

## 재테스트 결과
- `./gradlew --no-daemon test --rerun-tasks --stacktrace`
- `./gradlew --no-daemon formatCheck shadowJar --stacktrace`
- `swift test --package-path macos && swift build --package-path macos`
- `./shell/test-desktop-launcher-runtime.sh && xmllint --noout build/test-results/test/TEST-com.cotor.app.DesktopAppServiceTest.xml`

## 문서/리스크
- 사용자 동작 변경이 아니므로 영문/국문 제품 문서는 변경하지 않았습니다.
- 로컬 HTML 테스트 리포트는 생성되지 않습니다. XML과 콘솔 로그 기반 QA/CI는 유지됩니다.