### PR TITLE
test(qa): isolate operator approval review tests

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-05-24)
 
 ## Corpus Check
-- 364 files · ~625,237 words
+- 364 files · ~625,324 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -34,7 +34,7 @@ import kotlin.io.path.exists
 @OptIn(kotlin.io.path.ExperimentalPathApi::class)
 @Isolate
 class A2aApiTest : FunSpec({
-    val desktopService = mockk<DesktopAppService>(relaxed = true)
+    val desktopService = mockk<DesktopAppService>(relaxed = true, relaxUnitFun = true)
     val tuiSessionService = mockk<DesktopTuiSessionService>(relaxed = true)
     val json = Json { encodeDefaults = true }
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceReviewVerdictControlTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceReviewVerdictControlTest.kt
@@ -33,7 +33,8 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val company = service.createCompany(
@@ -161,7 +162,8 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val company = service.createCompany(
@@ -285,7 +287,8 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val company = service.createCompany(
@@ -423,7 +426,8 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val company = service.createCompany(
@@ -613,7 +617,8 @@ class DesktopAppServiceReviewVerdictControlTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = gitWorkspaceService,
             configRepository = mockk<ConfigRepository>(relaxed = true),
-            agentExecutor = mockk<AgentExecutor>(relaxed = true)
+            agentExecutor = mockk<AgentExecutor>(relaxed = true),
+            autoStartAutomationRefresh = false
         )
 
         val error = runCatching {
@@ -664,7 +669,8 @@ private suspend fun mergeGuardFixture(
         stateStore = stateStore,
         gitWorkspaceService = gitWorkspaceService,
         configRepository = mockk<ConfigRepository>(relaxed = true),
-        agentExecutor = mockk<AgentExecutor>(relaxed = true)
+        agentExecutor = mockk<AgentExecutor>(relaxed = true),
+        autoStartAutomationRefresh = false
     )
     val now = System.currentTimeMillis()
     val company = Company(

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -648,7 +648,8 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = mockk(relaxed = true),
             configRepository = mockk(relaxed = true),
-            agentExecutor = mockk(relaxed = true)
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
         )
         val company = service.createCompany(name = "Operator Free Model", rootPath = appHome.toString())
 
@@ -1147,7 +1148,8 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = mockk(relaxed = true),
             configRepository = mockk(relaxed = true),
-            agentExecutor = mockk(relaxed = true)
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
         )
         val company = service.createCompany(name = "Operator Approval", rootPath = appHome.toString())
         val now = System.currentTimeMillis()
@@ -4732,7 +4734,11 @@ class DesktopAppServiceTest : FunSpec({
 
         service.runTask(qaTask.id)
         withTimeout(90_000) {
-            while (stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }.qaVerdict != "PASS") {
+            while (true) {
+                val item = stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }
+                if (item.qaVerdict == "PASS" && item.status == ReviewQueueStatus.READY_FOR_CEO) {
+                    break
+                }
                 delay(25)
             }
         }
@@ -4742,7 +4748,13 @@ class DesktopAppServiceTest : FunSpec({
         queueAfterQa.status shouldBe ReviewQueueStatus.READY_FOR_CEO
         queueAfterQa.qaVerdict shouldBe "PASS"
 
-        val approvalIssue = refreshed.issues.firstOrNull { it.goalId == goal.id && it.kind == "approval" }
+        val approvalIssue = queueAfterQa.approvalIssueId?.let { approvalIssueId ->
+            refreshed.issues.firstOrNull { it.id == approvalIssueId }
+        } ?: refreshed.issues.firstOrNull {
+            it.goalId == goal.id &&
+                it.kind == "approval" &&
+                it.sourceSignal == "ceo-approval:${executionIssue.id}"
+        }
             ?: CompanyIssue(
                 id = java.util.UUID.randomUUID().toString(),
                 companyId = company.id,
@@ -4784,6 +4796,18 @@ class DesktopAppServiceTest : FunSpec({
                     )
                 )
             }
+        val beforeApprovalTask = stateStore.load()
+        stateStore.save(
+            beforeApprovalTask.copy(
+                reviewQueue = beforeApprovalTask.reviewQueue.map { item ->
+                    if (item.issueId == executionIssue.id) {
+                        item.copy(approvalIssueId = approvalIssue.id, updatedAt = System.currentTimeMillis())
+                    } else {
+                        item
+                    }
+                }
+            )
+        )
         val approvalTask = service.createTask(
             workspaceId = approvalIssue.workspaceId,
             title = approvalIssue.title,


### PR DESCRIPTION
## Discovered bug
- The post-merge QA loop found operator approval/review tests could be perturbed by background automation refreshes while the fixture was asserting deterministic review queue state.
- The deterministic installed-app PR approval fixture also depended on a loosely discovered approval issue, which can race with queue linkage during isolated full-suite execution.

## Fix
- Disable automatic automation refresh in the affected DesktopAppService test fixtures so each test owns its state transitions.
- Use the review queue approvalIssueId when available, fall back to the sourceSignal lookup, and persist the approval issue linkage before creating the approval task.
- Relax MockK unit functions in the A2A API DesktopAppService mock to avoid incidental unit-call failures.
- Refresh graphify metadata after the test changes.

## Retest results
- PASS: ./gradlew --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false test --tests com.cotor.a2a.A2aApiTest --tests com.cotor.app.DesktopAppServiceReviewVerdictControlTest --tests com.cotor.app.DesktopAppServiceTest --stacktrace
- PASS: ./gradlew --no-daemon --no-build-cache --max-workers=1 -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false clean test --stacktrace

## Docs
- No user-facing behavior changed; English/Korean docs were not updated.