### PR TITLE
fix(qa): stabilize desktop bootstrap and opencode execution

### DIFF
--- a/docs/OPENCODE_AGENT.ko.md
+++ b/docs/OPENCODE_AGENT.ko.md
@@ -43,15 +43,15 @@ agents:
 `OpenCodePlugin`은 다음을 실행합니다:
 
 ```bash
-opencode run --model <model> --format json "Execute the instructions in the attached prompt file." --file <0600-prompt-file>
+opencode run --print-logs --log-level ERROR --dangerously-skip-permissions --model <model> --format json "Execute the instructions in the attached prompt file." --file <0600-prompt-file>
 ```
 
-이는 전체 작업 프롬프트를 process argument에 노출하지 않고 OpenCode를 논인터랙티브 모드로 실행합니다. 플러그인은 프롬프트를 임시 `0600` 파일에 쓰고, 파일로 첨부한 뒤 stdout을 캡처하고, 임시 파일을 삭제한 다음 파싱된 출력을 Cotor의 오케스트레이션 레이어에 반환합니다.
+이는 전체 작업 프롬프트를 process argument에 노출하지 않고 OpenCode를 논인터랙티브 모드로 실행합니다. Cotor는 OpenCode 호출 전에 회사 capability 검사와 태스크 worktree 격리를 적용하고, OpenCode CLI가 인터랙티브 권한 프롬프트로 app-server를 막지 않도록 `--dangerously-skip-permissions`를 사용합니다. 플러그인은 프롬프트를 임시 `0600` 파일에 쓰고, 파일로 첨부한 뒤 stdout을 캡처하고, 임시 파일을 삭제한 다음 파싱된 출력을 Cotor의 오케스트레이션 레이어에 반환합니다.
 
 ### 명령 흐름
 
 1. Cotor가 프롬프트 수신 (파이프라인, 인터랙티브 세션, 또는 회사 워크플로우에서)
-2. `OpenCodePlugin.execute()`가 프롬프트를 임시 파일에 쓰고 명령어 빌드: `["opencode", "run", "--model", "<model>", "--format", "json", "Execute the instructions in the attached prompt file.", "--file", "<prompt-file>"]`
+2. `OpenCodePlugin.execute()`가 프롬프트를 임시 파일에 쓰고 명령어 빌드: `["opencode", "run", "--print-logs", "--log-level", "ERROR", "--dangerously-skip-permissions", "--model", "<model>", "--format", "json", "Execute the instructions in the attached prompt file.", "--file", "<prompt-file>"]`
 3. `ProcessManager`가 설정된 env/작업 디렉토리로 자식 프로세스 생성
 4. 프로세스 출력이 캡처되어 `PluginExecutionOutput`으로 반환
 5. 프로세스가 0이 아닌 종료 코드로 종료되면 캡처된 stdout/stderr와 함께 `ProcessExecutionException` 발생
@@ -126,7 +126,7 @@ OpenCode의 `run` 명령어는 프롬프트 완료 후 종료되어야 합니다
 
 | 에이전트 | 명령어 | 자동 승인 | 비고 |
 |---------|--------|----------|------|
-| opencode | `opencode run <prompt>` | yolo 모드 설정 | 오픈소스, 설정 가능 |
+| opencode | `opencode run --dangerously-skip-permissions <prompt>` | Cotor capability 검사 + OpenCode skip-permissions 플래그 | 오픈소스, 설정 가능 |
 | codex | `codex exec --full-auto` | `--full-auto` 플래그 | OpenAI |
 | claude | `claude --dangerously-skip-permissions` | `--dangerously-skip-permissions` | Anthropic |
 | gemini | `gemini --yolo` | `--yolo` 플래그 | Google |

--- a/docs/OPENCODE_AGENT.md
+++ b/docs/OPENCODE_AGENT.md
@@ -43,15 +43,15 @@ agents:
 The `OpenCodePlugin` executes:
 
 ```bash
-opencode run --model <model> --format json "Execute the instructions in the attached prompt file." --file <0600-prompt-file>
+opencode run --print-logs --log-level ERROR --dangerously-skip-permissions --model <model> --format json "Execute the instructions in the attached prompt file." --file <0600-prompt-file>
 ```
 
-This runs OpenCode in non-interactive mode while keeping the full task prompt out of process arguments. The plugin writes the prompt to a temporary `0600` file, attaches it, captures stdout, deletes the temporary file, and returns the parsed output to Cotor's orchestration layer.
+This runs OpenCode in non-interactive mode while keeping the full task prompt out of process arguments. Cotor applies its own company capability checks and isolates work in a task worktree before invoking OpenCode, then uses `--dangerously-skip-permissions` so the OpenCode CLI cannot block the app-server on an interactive permission prompt. The plugin writes the prompt to a temporary `0600` file, attaches it, captures stdout, deletes the temporary file, and returns the parsed output to Cotor's orchestration layer.
 
 ### Command Flow
 
 1. Cotor receives a prompt (from pipeline, interactive session, or company workflow)
-2. `OpenCodePlugin.execute()` writes the prompt to a temporary file and builds the command: `["opencode", "run", "--model", "<model>", "--format", "json", "Execute the instructions in the attached prompt file.", "--file", "<prompt-file>"]`
+2. `OpenCodePlugin.execute()` writes the prompt to a temporary file and builds the command: `["opencode", "run", "--print-logs", "--log-level", "ERROR", "--dangerously-skip-permissions", "--model", "<model>", "--format", "json", "Execute the instructions in the attached prompt file.", "--file", "<prompt-file>"]`
 3. `ProcessManager` spawns the child process with configured env/working directory
 4. Process output is captured and returned as `PluginExecutionOutput`
 5. If the process exits with a non-zero code, a `ProcessExecutionException` is thrown with captured stdout/stderr
@@ -126,7 +126,7 @@ OpenCode's `run` command should exit after completing the prompt. If it hangs:
 
 | Agent | Command | Auto-Approval | Notes |
 |-------|---------|---------------|-------|
-| opencode | `opencode run <prompt>` | Via yolo mode config | Open-source, configurable |
+| opencode | `opencode run --dangerously-skip-permissions <prompt>` | Cotor capability checks plus OpenCode skip-permissions flag | Open-source, configurable |
 | codex | `codex exec --full-auto` | `--full-auto` flag | OpenAI |
 | claude | `claude --dangerously-skip-permissions` | `--dangerously-skip-permissions` | Anthropic |
 | gemini | `gemini --yolo` | `--yolo` flag | Google |

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - cotor  (2026-05-26)
 
 ## Corpus Check
-- 364 files · ~626,310 words
+- 364 files · ~626,521 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4828 nodes · 6753 edges · 309 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 820 edges (avg confidence: 0.8)
+- 4830 nodes · 6759 edges · 305 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 823 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -218,20 +218,20 @@
 - [[_COMMUNITY_Community 205|Community 205]]
 - [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
-- [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
 - [[_COMMUNITY_Community 210|Community 210]]
 - [[_COMMUNITY_Community 211|Community 211]]
+- [[_COMMUNITY_Community 212|Community 212]]
 - [[_COMMUNITY_Community 213|Community 213]]
 - [[_COMMUNITY_Community 214|Community 214]]
 - [[_COMMUNITY_Community 215|Community 215]]
 - [[_COMMUNITY_Community 216|Community 216]]
 - [[_COMMUNITY_Community 217|Community 217]]
 - [[_COMMUNITY_Community 218|Community 218]]
-- [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
 - [[_COMMUNITY_Community 222|Community 222]]
+- [[_COMMUNITY_Community 223|Community 223]]
 - [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
 - [[_COMMUNITY_Community 226|Community 226]]
@@ -312,21 +312,17 @@
 - [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
 - [[_COMMUNITY_Community 303|Community 303]]
-- [[_COMMUNITY_Community 304|Community 304]]
-- [[_COMMUNITY_Community 305|Community 305]]
 - [[_COMMUNITY_Community 306|Community 306]]
-- [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 310|Community 310]]
-- [[_COMMUNITY_Community 312|Community 312]]
-- [[_COMMUNITY_Community 313|Community 313]]
+- [[_COMMUNITY_Community 308|Community 308]]
+- [[_COMMUNITY_Community 309|Community 309]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 258 edges
+1. `DesktopStore` - 260 edges
 2. `DesktopTextKey` - 128 edges
 3. `CodingKeys` - 106 edges
 4. `DesktopAPI` - 99 edges
 5. `GitWorkspaceService` - 78 edges
-6. `DesktopStoreTests` - 68 edges
+6. `DesktopStoreTests` - 69 edges
 7. `language` - 58 edges
 8. `ModelsTests` - 35 edges
 9. `Data` - 34 edges
@@ -339,10 +335,10 @@
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
 - `language` --calls--> `localizedSourceKind()`  [INFERRED]
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
+- `preparedBrandMark()` --calls--> `Data`  [INFERRED]
+  macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
-- `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]
-  macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/Models.swift
 
 ## Communities
 
@@ -351,1705 +347,1687 @@ Cohesion: 0.0
 Nodes (51): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+43 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (156): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+148 more)
+Cohesion: 0.02
+Nodes (25): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+17 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (18): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+10 more)
+Cohesion: 0.01
+Nodes (259): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+251 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.02
-Nodes (181): Codable, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, IssueRecord, MeetingRoomExpression, confused (+173 more)
+Cohesion: 0.01
+Nodes (152): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+144 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (25): ActionStore, RetryingFileChannel, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload (+17 more)
+Cohesion: 0.03
+Nodes (17): ActionStore, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload, nonEmpty() (+9 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.02
-Nodes (132): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+124 more)
+Cohesion: 0.01
+Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.01
-Nodes (127): DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents, appHome, appLocation, appName (+119 more)
-
-### Community 7 - "Community 7"
 Cohesion: 0.02
 Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
-### Community 8 - "Community 8"
+### Community 7 - "Community 7"
 Cohesion: 0.02
 Nodes (125): CodingKey, EmbeddedBackendHealthPayload, CodingKeys, community, confidenceScore, fileType, id, label (+117 more)
 
+### Community 8 - "Community 8"
+Cohesion: 0.03
+Nodes (28): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, Scanner, DesktopAppLifecycleDelegate (+20 more)
+
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Nodes (52): BuiltinAgentCatalog, BuiltinAgentSpec, BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand (+44 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.04
-Nodes (17): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendLauncher, isBackendRuntimeJar() (+9 more)
+Cohesion: 0.02
+Nodes (20): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, DesktopStoreCapturingURLProtocol (+12 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
-Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.06
-Nodes (9): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DesktopStoreCapturingURLProtocol, DesktopStoreTests, Locked, DesktopAPICapturingURLProtocol (+1 more)
-
-### Community 14 - "Community 14"
 Cohesion: 0.03
 Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
 
-### Community 15 - "Community 15"
+### Community 14 - "Community 14"
 Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.04
-Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
+### Community 15 - "Community 15"
+Cohesion: 0.05
+Nodes (51): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+43 more)
 
-### Community 17 - "Community 17"
+### Community 16 - "Community 16"
 Cohesion: 0.04
 Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
-### Community 19 - "Community 19"
-Cohesion: 0.07
+### Community 18 - "Community 18"
+Cohesion: 0.08
 Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
 
-### Community 20 - "Community 20"
-Cohesion: 0.13
-Nodes (4): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, Color
+### Community 19 - "Community 19"
+Cohesion: 0.11
+Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
 
-### Community 21 - "Community 21"
+### Community 20 - "Community 20"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
-### Community 22 - "Community 22"
+### Community 21 - "Community 21"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 23 - "Community 23"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (2): CachedState, DesktopStateStore
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (7): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.07
 Nodes (2): DesktopTuiSessionService, RuntimeSession
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.07
 Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
 
-### Community 29 - "Community 29"
+### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
-### Community 30 - "Community 30"
+### Community 29 - "Community 29"
 Cohesion: 0.08
 Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
-### Community 31 - "Community 31"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
-### Community 32 - "Community 32"
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, StageExecution, StageStats, StatsDetails, StatsManager (+1 more)
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
 
-### Community 39 - "Community 39"
-Cohesion: 0.11
-Nodes (3): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel
-
-### Community 40 - "Community 40"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (2): CoroutineProcessManager, ProcessManager
 
-### Community 41 - "Community 41"
+### Community 39 - "Community 39"
 Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 42 - "Community 42"
+### Community 40 - "Community 40"
 Cohesion: 0.12
 Nodes (1): A2aRouter
 
-### Community 43 - "Community 43"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (1): DurableRuntimeService
 
-### Community 44 - "Community 44"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
 
-### Community 45 - "Community 45"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
-### Community 46 - "Community 46"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
-### Community 47 - "Community 47"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (1): AgentCapabilityGuard
 
-### Community 48 - "Community 48"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
-### Community 49 - "Community 49"
+### Community 47 - "Community 47"
 Cohesion: 0.12
 Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
-### Community 50 - "Community 50"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (1): StarterAgentSpec
 
-### Community 51 - "Community 51"
-Cohesion: 0.13
-Nodes (1): Scanner
-
-### Community 52 - "Community 52"
+### Community 49 - "Community 49"
 Cohesion: 0.13
 Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
 
-### Community 53 - "Community 53"
+### Community 50 - "Community 50"
 Cohesion: 0.13
 Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
-### Community 54 - "Community 54"
+### Community 51 - "Community 51"
 Cohesion: 0.13
 Nodes (1): RecoveryExecutor
 
-### Community 55 - "Community 55"
+### Community 52 - "Community 52"
 Cohesion: 0.13
 Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
-### Community 56 - "Community 56"
+### Community 53 - "Community 53"
 Cohesion: 0.13
 Nodes (1): ConditionEvaluator
 
-### Community 57 - "Community 57"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (1): BoardControllerTest
 
-### Community 58 - "Community 58"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
-### Community 59 - "Community 59"
+### Community 56 - "Community 56"
 Cohesion: 0.14
 Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
-### Community 60 - "Community 60"
+### Community 57 - "Community 57"
 Cohesion: 0.14
 Nodes (2): DefaultSecurityValidator, SecurityValidator
 
-### Community 61 - "Community 61"
+### Community 58 - "Community 58"
 Cohesion: 0.14
 Nodes (1): DurableRuntimeStore
 
-### Community 62 - "Community 62"
+### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
-### Community 63 - "Community 63"
+### Community 60 - "Community 60"
 Cohesion: 0.14
 Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
-### Community 64 - "Community 64"
+### Community 61 - "Community 61"
 Cohesion: 0.14
 Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
-### Community 65 - "Community 65"
+### Community 62 - "Community 62"
 Cohesion: 0.15
 Nodes (12): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, ReplayApprovalRequiredException (+4 more)
 
-### Community 66 - "Community 66"
+### Community 63 - "Community 63"
 Cohesion: 0.15
 Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
-### Community 67 - "Community 67"
+### Community 64 - "Community 64"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
-### Community 68 - "Community 68"
+### Community 65 - "Community 65"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
-### Community 69 - "Community 69"
+### Community 66 - "Community 66"
 Cohesion: 0.17
 Nodes (1): GoalDrivenTaskPlannerTest
 
-### Community 70 - "Community 70"
+### Community 67 - "Community 67"
 Cohesion: 0.17
 Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
-### Community 71 - "Community 71"
+### Community 68 - "Community 68"
 Cohesion: 0.17
 Nodes (11): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionRequest, ActionResult (+3 more)
 
-### Community 72 - "Community 72"
+### Community 69 - "Community 69"
 Cohesion: 0.17
 Nodes (4): PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
-### Community 73 - "Community 73"
+### Community 70 - "Community 70"
 Cohesion: 0.17
 Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
-### Community 74 - "Community 74"
+### Community 71 - "Community 71"
 Cohesion: 0.18
 Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
-### Community 75 - "Community 75"
+### Community 72 - "Community 72"
 Cohesion: 0.18
 Nodes (1): BoardServiceTest
 
-### Community 76 - "Community 76"
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
-### Community 77 - "Community 77"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
-### Community 78 - "Community 78"
+### Community 75 - "Community 75"
 Cohesion: 0.18
 Nodes (1): VerificationBundleService
 
-### Community 79 - "Community 79"
+### Community 76 - "Community 76"
 Cohesion: 0.18
 Nodes (1): ProvenanceService
 
-### Community 80 - "Community 80"
+### Community 77 - "Community 77"
 Cohesion: 0.18
 Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
-### Community 81 - "Community 81"
+### Community 78 - "Community 78"
 Cohesion: 0.18
 Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
-### Community 82 - "Community 82"
+### Community 79 - "Community 79"
 Cohesion: 0.18
 Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
-### Community 83 - "Community 83"
+### Community 80 - "Community 80"
 Cohesion: 0.18
 Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
-### Community 84 - "Community 84"
+### Community 81 - "Community 81"
 Cohesion: 0.18
 Nodes (2): ErrorMessages, UserFriendlyError
 
-### Community 85 - "Community 85"
-Cohesion: 0.18
-Nodes (3): CoroutineEventBus, EventBus, EventSubscription
-
-### Community 86 - "Community 86"
+### Community 82 - "Community 82"
 Cohesion: 0.18
 Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
-### Community 87 - "Community 87"
+### Community 83 - "Community 83"
 Cohesion: 0.18
 Nodes (1): StatsCommand
 
-### Community 88 - "Community 88"
+### Community 84 - "Community 84"
 Cohesion: 0.18
 Nodes (1): DoctorCommand
 
-### Community 89 - "Community 89"
+### Community 85 - "Community 85"
+Cohesion: 0.2
+Nodes (1): A2aArtifactStore
+
+### Community 86 - "Community 86"
 Cohesion: 0.2
 Nodes (1): TemplateEngineTest
 
-### Community 90 - "Community 90"
-Cohesion: 0.2
-Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
-
-### Community 91 - "Community 91"
+### Community 87 - "Community 87"
 Cohesion: 0.2
 Nodes (1): ChatTranscriptWriter
 
-### Community 92 - "Community 92"
+### Community 88 - "Community 88"
 Cohesion: 0.2
 Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
-### Community 93 - "Community 93"
+### Community 89 - "Community 89"
 Cohesion: 0.2
 Nodes (1): VerificationStore
 
-### Community 94 - "Community 94"
+### Community 90 - "Community 90"
 Cohesion: 0.2
 Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
-### Community 95 - "Community 95"
+### Community 91 - "Community 91"
 Cohesion: 0.2
 Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
-### Community 96 - "Community 96"
+### Community 92 - "Community 92"
 Cohesion: 0.2
 Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
 
-### Community 97 - "Community 97"
+### Community 93 - "Community 93"
 Cohesion: 0.2
 Nodes (1): PolicyStore
 
-### Community 98 - "Community 98"
+### Community 94 - "Community 94"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 99 - "Community 99"
+### Community 95 - "Community 95"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 100 - "Community 100"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
-### Community 101 - "Community 101"
+### Community 97 - "Community 97"
 Cohesion: 0.22
 Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
-### Community 102 - "Community 102"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
-### Community 103 - "Community 103"
+### Community 99 - "Community 99"
 Cohesion: 0.22
 Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
-### Community 104 - "Community 104"
+### Community 100 - "Community 100"
 Cohesion: 0.22
 Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
-### Community 105 - "Community 105"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (1): LocalModelDefaults
 
-### Community 106 - "Community 106"
+### Community 102 - "Community 102"
 Cohesion: 0.22
 Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
-### Community 107 - "Community 107"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
-### Community 108 - "Community 108"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
-### Community 109 - "Community 109"
+### Community 105 - "Community 105"
 Cohesion: 0.25
 Nodes (1): BoardController
 
-### Community 110 - "Community 110"
+### Community 106 - "Community 106"
 Cohesion: 0.25
 Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
-### Community 111 - "Community 111"
+### Community 107 - "Community 107"
 Cohesion: 0.25
 Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
-### Community 112 - "Community 112"
+### Community 108 - "Community 108"
 Cohesion: 0.25
 Nodes (1): CompanyIssueReadiness
 
-### Community 113 - "Community 113"
+### Community 109 - "Community 109"
 Cohesion: 0.25
 Nodes (1): ChatSession
 
-### Community 114 - "Community 114"
+### Community 110 - "Community 110"
 Cohesion: 0.25
 Nodes (1): GitHubControlPlaneStore
 
-### Community 115 - "Community 115"
+### Community 111 - "Community 111"
 Cohesion: 0.25
 Nodes (1): OpenCodeDefaults
 
-### Community 116 - "Community 116"
+### Community 112 - "Community 112"
 Cohesion: 0.25
 Nodes (2): JsonParser, YamlParser
 
-### Community 117 - "Community 117"
+### Community 113 - "Community 113"
 Cohesion: 0.25
 Nodes (1): DiagramGenerator
 
-### Community 118 - "Community 118"
+### Community 114 - "Community 114"
 Cohesion: 0.25
 Nodes (2): Linter, LintResult
 
-### Community 119 - "Community 119"
+### Community 115 - "Community 115"
 Cohesion: 0.25
 Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
-### Community 120 - "Community 120"
+### Community 116 - "Community 116"
 Cohesion: 0.29
 Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
-### Community 121 - "Community 121"
+### Community 117 - "Community 117"
 Cohesion: 0.29
 Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
-### Community 122 - "Community 122"
+### Community 118 - "Community 118"
 Cohesion: 0.29
 Nodes (1): LocalModelPluginTest
 
-### Community 123 - "Community 123"
+### Community 119 - "Community 119"
 Cohesion: 0.29
 Nodes (1): DefaultResultAnalyzer
 
-### Community 124 - "Community 124"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (2): A2aDedupeStore, StoredAck
 
-### Community 125 - "Community 125"
+### Community 121 - "Community 121"
 Cohesion: 0.29
 Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
-### Community 126 - "Community 126"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (2): A2aSessionPersistenceStore, Snapshot
 
-### Community 127 - "Community 127"
+### Community 123 - "Community 123"
 Cohesion: 0.29
 Nodes (1): DurableResumeCoordinator
 
-### Community 128 - "Community 128"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
-### Community 129 - "Community 129"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (1): FileReaderPlugin
 
-### Community 130 - "Community 130"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (1): OpenAIPlugin
 
-### Community 131 - "Community 131"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (1): InteractiveCommandCompleter
 
-### Community 132 - "Community 132"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
-### Community 133 - "Community 133"
+### Community 129 - "Community 129"
 Cohesion: 0.33
 Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
-### Community 134 - "Community 134"
+### Community 130 - "Community 130"
 Cohesion: 0.33
 Nodes (1): CompanyRuntimeBindingServiceTest
 
-### Community 135 - "Community 135"
+### Community 131 - "Community 131"
 Cohesion: 0.33
 Nodes (1): ProductionReliabilityBaselineTest
 
-### Community 136 - "Community 136"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
-### Community 137 - "Community 137"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
-### Community 138 - "Community 138"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (1): GitHubControlPlaneService
 
-### Community 139 - "Community 139"
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (1): QaVerificationPlugin
 
-### Community 140 - "Community 140"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (1): CommandPlugin
 
-### Community 141 - "Community 141"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (2): DefaultResultAggregator, ResultAggregator
 
-### Community 142 - "Community 142"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (1): CodexDashboardCommand
 
-### Community 143 - "Community 143"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (2): PluginCommand, PluginInitCommand
 
-### Community 144 - "Community 144"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (1): PolicyEngine
 
-### Community 145 - "Community 145"
+### Community 141 - "Community 141"
 Cohesion: 0.4
 Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
 
-### Community 146 - "Community 146"
+### Community 142 - "Community 142"
 Cohesion: 0.4
 Nodes (1): OpenCodePluginTest
 
-### Community 147 - "Community 147"
+### Community 143 - "Community 143"
 Cohesion: 0.4
 Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
-### Community 148 - "Community 148"
+### Community 144 - "Community 144"
 Cohesion: 0.4
 Nodes (1): CliGoldenSnapshotTest
 
-### Community 149 - "Community 149"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (1): DesktopEndpointPolicy
 
-### Community 150 - "Community 150"
+### Community 146 - "Community 146"
 Cohesion: 0.4
 Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
-### Community 151 - "Community 151"
+### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (1): EvidencePathPolicy
 
-### Community 152 - "Community 152"
+### Community 148 - "Community 148"
 Cohesion: 0.4
 Nodes (1): CompanyRuntimeMachine
 
-### Community 153 - "Community 153"
+### Community 149 - "Community 149"
 Cohesion: 0.4
 Nodes (1): WorkQueue
 
-### Community 154 - "Community 154"
+### Community 150 - "Community 150"
 Cohesion: 0.4
 Nodes (1): NetworkEndpointPolicy
 
-### Community 155 - "Community 155"
+### Community 151 - "Community 151"
 Cohesion: 0.4
 Nodes (1): CheckpointGraphStore
 
-### Community 156 - "Community 156"
+### Community 152 - "Community 152"
 Cohesion: 0.4
 Nodes (1): SideEffectJournalStore
 
-### Community 157 - "Community 157"
+### Community 153 - "Community 153"
 Cohesion: 0.4
 Nodes (1): ProvenanceStore
 
-### Community 158 - "Community 158"
+### Community 154 - "Community 154"
 Cohesion: 0.4
 Nodes (1): CodexDefaults
 
-### Community 159 - "Community 159"
+### Community 155 - "Community 155"
 Cohesion: 0.4
 Nodes (1): CotorHttpClients
 
-### Community 160 - "Community 160"
+### Community 156 - "Community 156"
 Cohesion: 0.4
 Nodes (2): StuckDetector, StuckSignal
 
-### Community 161 - "Community 161"
+### Community 157 - "Community 157"
 Cohesion: 0.4
 Nodes (1): AppServerCommand
 
-### Community 162 - "Community 162"
+### Community 158 - "Community 158"
 Cohesion: 0.4
 Nodes (2): SyntaxValidationResult, SyntaxValidator
 
-### Community 163 - "Community 163"
-Cohesion: 0.5
-Nodes (1): BoardServiceApplicationTests
-
-### Community 164 - "Community 164"
-Cohesion: 0.67
-Nodes (2): fromEntity(), PostSummaryResponse
-
-### Community 165 - "Community 165"
-Cohesion: 0.5
-Nodes (1): PostRepository
-
-### Community 166 - "Community 166"
-Cohesion: 0.5
-Nodes (1): Post
-
-### Community 167 - "Community 167"
+### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (1): findPrimes()
 
-### Community 168 - "Community 168"
+### Community 160 - "Community 160"
+Cohesion: 0.5
+Nodes (1): BoardServiceApplicationTests
+
+### Community 161 - "Community 161"
 Cohesion: 0.67
 Nodes (2): BoardServiceApplication, main()
 
-### Community 169 - "Community 169"
+### Community 162 - "Community 162"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostDetailResponse
 
-### Community 170 - "Community 170"
+### Community 163 - "Community 163"
+Cohesion: 0.5
+Nodes (1): PostRepository
+
+### Community 164 - "Community 164"
+Cohesion: 0.5
+Nodes (1): Post
+
+### Community 165 - "Community 165"
+Cohesion: 0.67
+Nodes (2): fromEntity(), PostSummaryResponse
+
+### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (1): AgentCapabilityGuardTest
 
-### Community 171 - "Community 171"
+### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceOwnershipTest
 
-### Community 172 - "Community 172"
+### Community 168 - "Community 168"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
-### Community 173 - "Community 173"
+### Community 169 - "Community 169"
 Cohesion: 0.5
 Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
-### Community 174 - "Community 174"
+### Community 170 - "Community 170"
 Cohesion: 0.5
 Nodes (2): CommandPluginTest, RecordingProcessManager
 
-### Community 175 - "Community 175"
+### Community 171 - "Community 171"
 Cohesion: 0.5
 Nodes (2): FileReaderPluginTest, NoopProcessManager
 
-### Community 176 - "Community 176"
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (1): PipelineOrchestratorPropertyTest
 
-### Community 177 - "Community 177"
+### Community 173 - "Community 173"
 Cohesion: 0.5
 Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
-### Community 178 - "Community 178"
+### Community 174 - "Community 174"
 Cohesion: 0.5
 Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
-### Community 179 - "Community 179"
+### Community 175 - "Community 175"
 Cohesion: 0.5
 Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
-### Community 180 - "Community 180"
+### Community 176 - "Community 176"
 Cohesion: 0.5
 Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
 
-### Community 181 - "Community 181"
+### Community 177 - "Community 177"
 Cohesion: 0.5
 Nodes (1): StateRepository
 
-### Community 182 - "Community 182"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (3): ChatMessage, ChatMode, ChatRole
 
-### Community 183 - "Community 183"
+### Community 179 - "Community 179"
 Cohesion: 0.5
 Nodes (1): DurableRuntimeFlags
 
-### Community 184 - "Community 184"
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
-### Community 185 - "Community 185"
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
-### Community 186 - "Community 186"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (2): TimelineCollector, TimelineResult
 
-### Community 187 - "Community 187"
+### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (1): StageConflictDetector
 
-### Community 188 - "Community 188"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (1): SimpleCLI
 
-### Community 189 - "Community 189"
+### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (2): OutputValidator, StageValidationOutcome
 
-### Community 190 - "Community 190"
+### Community 186 - "Community 186"
 Cohesion: 0.67
 Nodes (1): PostCreateRequest
 
-### Community 191 - "Community 191"
+### Community 187 - "Community 187"
 Cohesion: 0.67
 Nodes (1): PostUpdateRequest
 
-### Community 192 - "Community 192"
+### Community 188 - "Community 188"
 Cohesion: 0.67
 Nodes (1): VersionConflictException
 
-### Community 193 - "Community 193"
+### Community 189 - "Community 189"
 Cohesion: 0.67
 Nodes (1): PostNotFoundException
 
-### Community 194 - "Community 194"
+### Community 190 - "Community 190"
 Cohesion: 0.67
 Nodes (1): PermissionDeniedException
 
-### Community 195 - "Community 195"
+### Community 191 - "Community 191"
 Cohesion: 0.67
 Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
-### Community 196 - "Community 196"
+### Community 192 - "Community 192"
 Cohesion: 0.67
 Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
-### Community 197 - "Community 197"
+### Community 193 - "Community 193"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIntegrationHarness
 
-### Community 198 - "Community 198"
+### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
-### Community 199 - "Community 199"
+### Community 195 - "Community 195"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceExecutionMemoryTest
 
-### Community 200 - "Community 200"
+### Community 196 - "Community 196"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
-### Community 201 - "Community 201"
+### Community 197 - "Community 197"
 Cohesion: 0.67
 Nodes (1): CheckpointFixtureProcess
 
-### Community 202 - "Community 202"
+### Community 198 - "Community 198"
 Cohesion: 0.67
 Nodes (1): CheckpointResumeIntegrationTest
 
-### Community 203 - "Community 203"
+### Community 199 - "Community 199"
 Cohesion: 0.67
 Nodes (1): RuntimeConstructorConsistencyTest
 
-### Community 204 - "Community 204"
+### Community 200 - "Community 200"
 Cohesion: 0.67
 Nodes (1): PipelineOrchestratorMapTest
 
-### Community 205 - "Community 205"
+### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (1): TemplateCommandTest
 
-### Community 206 - "Community 206"
+### Community 202 - "Community 202"
 Cohesion: 0.67
 Nodes (1): InitCommandTest
 
-### Community 207 - "Community 207"
+### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (1): ValidateCommandTest
 
-### Community 208 - "Community 208"
+### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (1): DesktopLifecycleCommandTest
 
-### Community 209 - "Community 209"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (1): ResultAnalyzer
 
-### Community 210 - "Community 210"
+### Community 206 - "Community 206"
 Cohesion: 0.67
 Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 211 - "Community 211"
+### Community 207 - "Community 207"
 Cohesion: 0.67
 Nodes (2): VideoPlanRequest, VideoPlanResult
 
-### Community 213 - "Community 213"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (1): DurableRuntimeContext
 
-### Community 214 - "Community 214"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (1): HelloCommand
 
-### Community 215 - "Community 215"
+### Community 211 - "Community 211"
 Cohesion: 0.67
 Nodes (1): WebCommand
 
-### Community 216 - "Community 216"
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (1): LintCommand
 
-### Community 217 - "Community 217"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (1): ExplainCommand
 
-### Community 218 - "Community 218"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (1): CheckpointGCCommand
 
-### Community 219 - "Community 219"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (2): StageTimelineEntry, StageTimelineState
 
-### Community 220 - "Community 220"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (1): PipelineTemplateValidator
 
-### Community 221 - "Community 221"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (1): DefaultOutputValidator
 
-### Community 222 - "Community 222"
+### Community 218 - "Community 218"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 224 - "Community 224"
+### Community 220 - "Community 220"
 Cohesion: 1.0
 Nodes (1): KotestProjectConfig
 
-### Community 225 - "Community 225"
+### Community 221 - "Community 221"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 226 - "Community 226"
+### Community 222 - "Community 222"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 227 - "Community 227"
+### Community 223 - "Community 223"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 228 - "Community 228"
+### Community 224 - "Community 224"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 229 - "Community 229"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 230 - "Community 230"
+### Community 226 - "Community 226"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 231 - "Community 231"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 232 - "Community 232"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 233 - "Community 233"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 234 - "Community 234"
+### Community 230 - "Community 230"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 235 - "Community 235"
+### Community 231 - "Community 231"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 236 - "Community 236"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 237 - "Community 237"
+### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 238 - "Community 238"
+### Community 234 - "Community 234"
 Cohesion: 1.0
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 239 - "Community 239"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 240 - "Community 240"
+### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 241 - "Community 241"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 242 - "Community 242"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 243 - "Community 243"
+### Community 239 - "Community 239"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceMergeConfirmationTest
 
-### Community 244 - "Community 244"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreTest
 
-### Community 245 - "Community 245"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
-### Community 246 - "Community 246"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): AutonomousDiscoveryServiceTest
 
-### Community 247 - "Community 247"
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (1): SkillModelsTest
 
-### Community 248 - "Community 248"
+### Community 244 - "Community 244"
 Cohesion: 1.0
 Nodes (1): CompanyRuntimeMachineTest
 
-### Community 249 - "Community 249"
+### Community 245 - "Community 245"
 Cohesion: 1.0
 Nodes (1): ChatTranscriptWriterTest
 
-### Community 250 - "Community 250"
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (1): ChatSessionTest
 
-### Community 251 - "Community 251"
+### Community 247 - "Community 247"
 Cohesion: 1.0
 Nodes (1): NetworkEndpointPolicyTest
 
-### Community 252 - "Community 252"
+### Community 248 - "Community 248"
 Cohesion: 1.0
 Nodes (1): SecurityValidatorTest
 
-### Community 253 - "Community 253"
+### Community 249 - "Community 249"
 Cohesion: 1.0
 Nodes (1): A2aArtifactStoreTest
 
-### Community 254 - "Community 254"
+### Community 250 - "Community 250"
 Cohesion: 1.0
 Nodes (1): A2aApiTest
 
-### Community 255 - "Community 255"
+### Community 251 - "Community 251"
 Cohesion: 1.0
 Nodes (1): A2aSessionStoreTest
 
-### Community 256 - "Community 256"
+### Community 252 - "Community 252"
 Cohesion: 1.0
 Nodes (1): A2aDedupeStoreTest
 
-### Community 257 - "Community 257"
+### Community 253 - "Community 253"
 Cohesion: 1.0
 Nodes (1): RecoveryExecutorTest
 
-### Community 258 - "Community 258"
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (1): GitHubControlPlaneServiceTest
 
-### Community 259 - "Community 259"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (1): StoreConcurrencyTest
 
-### Community 260 - "Community 260"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (1): DurableRuntimeServiceTest
 
-### Community 261 - "Community 261"
+### Community 257 - "Community 257"
 Cohesion: 1.0
 Nodes (1): DurableResumeCoordinatorTest
 
-### Community 262 - "Community 262"
+### Community 258 - "Community 258"
 Cohesion: 1.0
 Nodes (1): ActionExecutionServiceTest
 
-### Community 263 - "Community 263"
+### Community 259 - "Community 259"
 Cohesion: 1.0
 Nodes (1): LinearClientEndpointPolicyTest
 
-### Community 264 - "Community 264"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (1): VerificationBundleServiceTest
 
-### Community 265 - "Community 265"
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (1): KnowledgeServiceTest
 
-### Community 266 - "Community 266"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (1): LocalModelDefaultsTest
 
-### Community 267 - "Community 267"
+### Community 263 - "Community 263"
 Cohesion: 1.0
 Nodes (1): ObservabilityServiceTest
 
-### Community 268 - "Community 268"
+### Community 264 - "Community 264"
 Cohesion: 1.0
 Nodes (1): FileConfigRepositoryTest
 
-### Community 269 - "Community 269"
+### Community 265 - "Community 265"
 Cohesion: 1.0
 Nodes (1): QaTestGenerationFixtureTest
 
-### Community 270 - "Community 270"
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (1): ConfigRepositoryImportTest
 
-### Community 271 - "Community 271"
+### Community 267 - "Community 267"
 Cohesion: 1.0
 Nodes (1): ExampleConfigSmokeTest
 
-### Community 272 - "Community 272"
+### Community 268 - "Community 268"
 Cohesion: 1.0
 Nodes (1): YamlParserTest
 
-### Community 273 - "Community 273"
+### Community 269 - "Community 269"
 Cohesion: 1.0
 Nodes (1): CodexPluginTest
 
-### Community 274 - "Community 274"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (1): CotorHttpClientsTest
 
-### Community 275 - "Community 275"
+### Community 271 - "Community 271"
 Cohesion: 1.0
 Nodes (1): ProcessManagerTest
 
-### Community 276 - "Community 276"
+### Community 272 - "Community 272"
 Cohesion: 1.0
 Nodes (1): ErrorHelperTest
 
-### Community 277 - "Community 277"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (1): ResultAggregatorTest
 
-### Community 278 - "Community 278"
+### Community 274 - "Community 274"
 Cohesion: 1.0
 Nodes (1): ConditionEvaluatorTest
 
-### Community 279 - "Community 279"
+### Community 275 - "Community 275"
 Cohesion: 1.0
 Nodes (1): AgentExecutorTest
 
-### Community 280 - "Community 280"
+### Community 276 - "Community 276"
 Cohesion: 1.0
 Nodes (1): StuckDetectorTest
 
-### Community 281 - "Community 281"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (1): PipelineGuardServiceTest
 
-### Community 282 - "Community 282"
+### Community 278 - "Community 278"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorDagValidationTest
 
-### Community 283 - "Community 283"
+### Community 279 - "Community 279"
 Cohesion: 1.0
 Nodes (1): StageConflictDetectorTest
 
-### Community 284 - "Community 284"
+### Community 280 - "Community 280"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorTemplatingTest
 
-### Community 285 - "Community 285"
+### Community 281 - "Community 281"
 Cohesion: 1.0
 Nodes (1): CoroutineEventBusTest
 
-### Community 286 - "Community 286"
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (1): WebServerTest
 
-### Community 287 - "Community 287"
+### Community 283 - "Community 283"
 Cohesion: 1.0
 Nodes (1): CompletionCommandTest
 
-### Community 288 - "Community 288"
+### Community 284 - "Community 284"
 Cohesion: 1.0
 Nodes (1): HelpCommandTest
 
-### Community 289 - "Community 289"
+### Community 285 - "Community 285"
 Cohesion: 1.0
 Nodes (1): AppServerCommandTest
 
-### Community 290 - "Community 290"
+### Community 286 - "Community 286"
 Cohesion: 1.0
 Nodes (1): StarterAgentResolverTest
 
-### Community 291 - "Community 291"
+### Community 287 - "Community 287"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandCompleterTest
 
-### Community 292 - "Community 292"
+### Community 288 - "Community 288"
 Cohesion: 1.0
 Nodes (1): AgentCommandTest
 
-### Community 293 - "Community 293"
+### Community 289 - "Community 289"
 Cohesion: 1.0
 Nodes (1): PluginCommandTest
 
-### Community 294 - "Community 294"
+### Community 290 - "Community 290"
 Cohesion: 1.0
 Nodes (1): AuthCommandTest
 
-### Community 295 - "Community 295"
+### Community 291 - "Community 291"
 Cohesion: 1.0
 Nodes (1): HelloCommandTest
 
-### Community 296 - "Community 296"
+### Community 292 - "Community 292"
 Cohesion: 1.0
 Nodes (1): LintCommandTest
 
-### Community 297 - "Community 297"
+### Community 293 - "Community 293"
 Cohesion: 1.0
 Nodes (1): CompanyCommandTest
 
-### Community 298 - "Community 298"
+### Community 294 - "Community 294"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandTest
 
-### Community 299 - "Community 299"
+### Community 295 - "Community 295"
 Cohesion: 1.0
 Nodes (1): StatsCommandTest
 
-### Community 300 - "Community 300"
+### Community 296 - "Community 296"
 Cohesion: 1.0
 Nodes (1): CodexDashboardCommandTest
 
-### Community 301 - "Community 301"
+### Community 297 - "Community 297"
 Cohesion: 1.0
 Nodes (1): StatsManagerTest
 
-### Community 302 - "Community 302"
+### Community 298 - "Community 298"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorTest
 
-### Community 303 - "Community 303"
+### Community 299 - "Community 299"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorExtTest
 
-### Community 304 - "Community 304"
+### Community 300 - "Community 300"
 Cohesion: 1.0
 Nodes (1): LinterTest
 
-### Community 305 - "Community 305"
+### Community 301 - "Community 301"
 Cohesion: 1.0
 Nodes (1): DefaultOutputValidatorTest
 
-### Community 306 - "Community 306"
+### Community 302 - "Community 302"
 Cohesion: 1.0
 Nodes (1): PolicyEngineTest
 
-### Community 307 - "Community 307"
+### Community 303 - "Community 303"
 Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
-### Community 310 - "Community 310"
+### Community 306 - "Community 306"
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 312 - "Community 312"
+### Community 308 - "Community 308"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 313 - "Community 313"
+### Community 309 - "Community 309"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
 - **1002 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+997 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 23`** (34 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
+- **Thin community `Community 22`** (34 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 25`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 28`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 32`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
+- **Thin community `Community 38`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 39`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 40`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 41`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 42`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 47`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 45`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+- **Thin community `Community 48`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
+- **Thin community `Community 51`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 53`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 54`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 57`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 60`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
+- **Thin community `Community 58`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
+- **Thin community `Community 63`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 66`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 72`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 73`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 76`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 75`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 76`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 79`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 81`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 83`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 84`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 85`** (10 nodes): `A2aArtifactStore`, `.append()`, `.count()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `.scopedOpsMetrics()`, `A2aArtifactStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 89`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 86`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 90`** (10 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `.signal()`, `AutonomousDiscoveryService.kt`
+- **Thin community `Community 87`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 91`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 89`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 93`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 93`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 97`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 94`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 98`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
+- **Thin community `Community 95`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 99`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
+- **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 105`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 106`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 108`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 109`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 110`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 111`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 112`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 113`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 114`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 117`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 118`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 119`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 120`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 121`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 122`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 123`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 125`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 126`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 127`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 129`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 130`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 131`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 132`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 133`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 134`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 135`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 136`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 137`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 138`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 139`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 140`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 141`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 142`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 143`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 144`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 145`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 146`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 147`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 148`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 149`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 150`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 151`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 152`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 153`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 154`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 155`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 156`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 157`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 158`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 159`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 160`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 161`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 162`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 163`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 164`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 165`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 166`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 167`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 168`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 169`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 170`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 171`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 172`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 173`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 174`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 176`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 177`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 179`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 182`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 183`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 184`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 185`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 186`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 187`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 188`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 189`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 190`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 191`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 192`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 193`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 194`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 197`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 198`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 199`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 200`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 201`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 202`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 203`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 204`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 205`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 206`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 207`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 209`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 210`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 211`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 212`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 213`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 215`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 216`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 217`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 218`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 220`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 221`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 222`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 223`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 224`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 225`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 226`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 227`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 230`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 231`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 232`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 233`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 234`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 235`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 236`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 237`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 238`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 240`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 241`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 242`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 243`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 244`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 245`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 246`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 247`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 248`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 249`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 250`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 251`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 252`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 253`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 254`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 255`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 256`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 257`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 258`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 259`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 260`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 261`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 262`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 263`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 264`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 265`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 267`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 268`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 269`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 270`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 271`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 272`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 273`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 274`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 275`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 276`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 277`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 278`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 279`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 280`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 281`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 282`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 283`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 284`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 285`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 286`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 287`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 288`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 289`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 290`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 291`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 296`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 297`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 298`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 299`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 300`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 301`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 302`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 303`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 306`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 308`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 309`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 5`, `Community 11`, `Community 13`, `Community 16`, `Community 19`?**
+- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 11`, `Community 15`, `Community 18`, `Community 85`?**
   _High betweenness centrality (0.099) - this node is a cross-community bridge._
-- **Why does `TuiSession` connect `Community 2` to `Community 10`?**
-  _High betweenness centrality (0.030) - this node is a cross-community bridge._
-- **Are the 37 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.fullAutoOperatorChatRequestAddsConfirmationToTimeline()`) actually correct?**
-  _`DesktopStore` has 37 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `DesktopTextKey` connect `Community 5` to `Community 1`?**
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Are the 38 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
+  _`DesktopStore` has 38 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
   _1002 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.02 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor  (2026-05-26)
+# Graph Report - cotor-qa-appbuild-20260526  (2026-05-26)
 
 ## Corpus Check
-- 364 files · ~626,521 words
+- 358 files · ~612,665 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4830 nodes · 6759 edges · 305 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 823 edges (avg confidence: 0.8)
+- 4752 nodes · 6584 edges · 308 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 787 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -218,9 +218,9 @@
 - [[_COMMUNITY_Community 205|Community 205]]
 - [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
+- [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
 - [[_COMMUNITY_Community 210|Community 210]]
-- [[_COMMUNITY_Community 211|Community 211]]
 - [[_COMMUNITY_Community 212|Community 212]]
 - [[_COMMUNITY_Community 213|Community 213]]
 - [[_COMMUNITY_Community 214|Community 214]]
@@ -228,9 +228,9 @@
 - [[_COMMUNITY_Community 216|Community 216]]
 - [[_COMMUNITY_Community 217|Community 217]]
 - [[_COMMUNITY_Community 218|Community 218]]
+- [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
-- [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 223|Community 223]]
 - [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
@@ -312,9 +312,12 @@
 - [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
 - [[_COMMUNITY_Community 303|Community 303]]
+- [[_COMMUNITY_Community 304|Community 304]]
+- [[_COMMUNITY_Community 305|Community 305]]
 - [[_COMMUNITY_Community 306|Community 306]]
-- [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 311|Community 311]]
+- [[_COMMUNITY_Community 312|Community 312]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DesktopStore` - 260 edges
@@ -325,102 +328,102 @@
 6. `DesktopStoreTests` - 69 edges
 7. `language` - 58 edges
 8. `ModelsTests` - 35 edges
-9. `Data` - 34 edges
+9. `Data` - 33 edges
 10. `DesktopStateStore` - 30 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `language` --calls--> `userFacingIssueKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `userFacingDecisionTitle()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `localizedSourceKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `preparedBrandMark()` --calls--> `Data`  [INFERRED]
-  macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
+- `userFacingIssueKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `userFacingDecisionTitle()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `localizedSourceKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+- `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]
+  macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/Models.swift
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.0
-Nodes (51): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+43 more)
+Nodes (52): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+44 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (25): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+17 more)
+Cohesion: 0.01
+Nodes (165): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+157 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (259): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+251 more)
+Cohesion: 0.02
+Nodes (19): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+11 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (152): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+144 more)
+Cohesion: 0.03
+Nodes (122): settings(), Codable, AgentSkillCardRecord, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled (+114 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (17): ActionStore, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload, nonEmpty() (+9 more)
+Cohesion: 0.02
+Nodes (27): ActionStore, RetryingFileChannel, AppLogger, CompanySidebarDisclosureState, APIError, http, ConfigureGitHubOriginPayload, Data (+19 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
-Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
+Nodes (154): CaseIterable, AgentSkillScope, browserQA, buildTest, marketing, qaReview, repositoryMap, video (+146 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.02
-Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
+Cohesion: 0.01
+Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (125): CodingKey, EmbeddedBackendHealthPayload, CodingKeys, community, confidenceScore, fileType, id, label (+117 more)
+Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (28): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, Scanner, DesktopAppLifecycleDelegate (+20 more)
+Cohesion: 0.02
+Nodes (104): CodingKeys, action, activeGoalCount, activeIssueCount, activity, adaptiveTickMs, agentCapabilityProfiles, agentContextEntries (+96 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (52): BuiltinAgentCatalog, BuiltinAgentSpec, BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand (+44 more)
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (20): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, DesktopStoreCapturingURLProtocol (+12 more)
+Cohesion: 0.04
+Nodes (19): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+11 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
-Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.03
 Nodes (8): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, EphemeralOpenCodeConfig, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
 
 ### Community 14 - "Community 14"
-Cohesion: 0.09
-Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
+Cohesion: 0.06
+Nodes (12): Entry, MeetingRoomInteractionEvent, MeetingRoomRenderPlan, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, MeetingRoomSceneReducer, MeetingRoomSceneState, MeetingRoomVisualState (+4 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (51): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+43 more)
+Cohesion: 0.04
+Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.04
-Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
+Cohesion: 0.06
+Nodes (28): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+20 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.04
-Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
+Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.08
-Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
+Cohesion: 0.04
+Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.11
-Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
+Cohesion: 0.19
+Nodes (12): OrgProfileBatchEditPayloadDraft, agent(), decision(), goal(), issue(), MeetingRoomProjectionTests, message(), profile() (+4 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.05
@@ -496,51 +499,51 @@ Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success
 
 ### Community 38 - "Community 38"
 Cohesion: 0.11
-Nodes (2): CoroutineProcessManager, ProcessManager
+Nodes (3): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel
 
 ### Community 39 - "Community 39"
 Cohesion: 0.11
-Nodes (1): TemplateCommand
+Nodes (2): CoroutineProcessManager, ProcessManager
 
 ### Community 40 - "Community 40"
-Cohesion: 0.12
-Nodes (1): A2aRouter
+Cohesion: 0.11
+Nodes (1): TemplateCommand
 
 ### Community 41 - "Community 41"
 Cohesion: 0.12
-Nodes (1): DurableRuntimeService
+Nodes (1): A2aRouter
 
 ### Community 42 - "Community 42"
 Cohesion: 0.12
-Nodes (2): ConfigRepository, ParsedConfig
+Nodes (1): DurableRuntimeService
 
 ### Community 43 - "Community 43"
 Cohesion: 0.12
-Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
+Nodes (2): ConfigRepository, ParsedConfig
 
 ### Community 44 - "Community 44"
 Cohesion: 0.12
-Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
+Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
 ### Community 45 - "Community 45"
 Cohesion: 0.12
-Nodes (1): AgentCapabilityGuard
+Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
 ### Community 46 - "Community 46"
 Cohesion: 0.12
-Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
+Nodes (1): AgentCapabilityGuard
 
 ### Community 47 - "Community 47"
 Cohesion: 0.12
-Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
+Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
-Nodes (1): StarterAgentSpec
+Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
 ### Community 49 - "Community 49"
-Cohesion: 0.13
-Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
+Cohesion: 0.12
+Nodes (1): StarterAgentSpec
 
 ### Community 50 - "Community 50"
 Cohesion: 0.13
@@ -672,898 +675,910 @@ Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 82 - "Community 82"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (3): CoroutineEventBus, EventBus, EventSubscription
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (1): StatsCommand
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (1): DoctorCommand
+Nodes (1): StatsCommand
 
 ### Community 85 - "Community 85"
-Cohesion: 0.2
-Nodes (1): A2aArtifactStore
+Cohesion: 0.18
+Nodes (1): DoctorCommand
 
 ### Community 86 - "Community 86"
 Cohesion: 0.2
-Nodes (1): TemplateEngineTest
+Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
 
 ### Community 87 - "Community 87"
 Cohesion: 0.2
-Nodes (1): ChatTranscriptWriter
+Nodes (1): TemplateEngineTest
 
 ### Community 88 - "Community 88"
 Cohesion: 0.2
-Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
+Nodes (1): ChatTranscriptWriter
 
 ### Community 89 - "Community 89"
 Cohesion: 0.2
-Nodes (1): VerificationStore
+Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
 ### Community 90 - "Community 90"
 Cohesion: 0.2
-Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
+Nodes (1): VerificationStore
 
 ### Community 91 - "Community 91"
 Cohesion: 0.2
-Nodes (3): ErrorHelper, ErrorInfo, ErrorType
+Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
 ### Community 92 - "Community 92"
 Cohesion: 0.2
-Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
+Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
 ### Community 93 - "Community 93"
 Cohesion: 0.2
-Nodes (1): PolicyStore
+Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
 
 ### Community 94 - "Community 94"
+Cohesion: 0.2
+Nodes (1): PolicyStore
+
+### Community 95 - "Community 95"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.22
 Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.22
 Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.22
 Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.22
 Nodes (1): LocalModelDefaults
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.22
 Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.25
 Nodes (1): BoardController
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.25
 Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
-### Community 107 - "Community 107"
-Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
-
 ### Community 108 - "Community 108"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (1): DesktopAppServiceRuntimeCleanupTest
 
 ### Community 109 - "Community 109"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (1): CompanyIssueReadiness
 
 ### Community 111 - "Community 111"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (1): ChatSession
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (1): A2aArtifactStore
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (2): Linter, LintResult
+Nodes (1): OpenCodeDefaults
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
+Nodes (2): JsonParser, YamlParser
 
 ### Community 116 - "Community 116"
-Cohesion: 0.29
-Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
+Cohesion: 0.25
+Nodes (1): DiagramGenerator
 
 ### Community 117 - "Community 117"
-Cohesion: 0.29
-Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
+Cohesion: 0.25
+Nodes (2): Linter, LintResult
 
 ### Community 118 - "Community 118"
-Cohesion: 0.29
-Nodes (1): LocalModelPluginTest
+Cohesion: 0.25
+Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
 ### Community 119 - "Community 119"
 Cohesion: 0.29
-Nodes (1): DefaultResultAnalyzer
+Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
 ### Community 120 - "Community 120"
 Cohesion: 0.29
-Nodes (2): A2aDedupeStore, StoredAck
+Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
 ### Community 121 - "Community 121"
 Cohesion: 0.29
-Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
+Nodes (1): LocalModelPluginTest
 
 ### Community 122 - "Community 122"
 Cohesion: 0.29
-Nodes (2): A2aSessionPersistenceStore, Snapshot
+Nodes (1): DefaultResultAnalyzer
 
 ### Community 123 - "Community 123"
 Cohesion: 0.29
-Nodes (1): DurableResumeCoordinator
+Nodes (2): A2aDedupeStore, StoredAck
 
 ### Community 124 - "Community 124"
 Cohesion: 0.29
-Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
+Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
 ### Community 125 - "Community 125"
 Cohesion: 0.29
-Nodes (1): FileReaderPlugin
+Nodes (2): A2aSessionPersistenceStore, Snapshot
 
 ### Community 126 - "Community 126"
 Cohesion: 0.29
-Nodes (1): OpenAIPlugin
+Nodes (1): DurableResumeCoordinator
 
 ### Community 127 - "Community 127"
 Cohesion: 0.29
-Nodes (1): InteractiveCommandCompleter
+Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
 ### Community 128 - "Community 128"
 Cohesion: 0.29
-Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
+Nodes (1): FileReaderPlugin
 
 ### Community 129 - "Community 129"
-Cohesion: 0.33
-Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
+Cohesion: 0.29
+Nodes (1): OpenAIPlugin
 
 ### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (1): CompanyRuntimeBindingServiceTest
+Cohesion: 0.29
+Nodes (1): InteractiveCommandCompleter
 
 ### Community 131 - "Community 131"
-Cohesion: 0.33
-Nodes (1): ProductionReliabilityBaselineTest
+Cohesion: 0.29
+Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
 ### Community 132 - "Community 132"
 Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
+Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
-Nodes (2): CompanyVerificationDecision, CompanyVerifierService
+Nodes (1): CompanyRuntimeBindingServiceTest
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (1): ProductionReliabilityBaselineTest
 
 ### Community 135 - "Community 135"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 136 - "Community 136"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
 ### Community 137 - "Community 137"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (1): GitHubControlPlaneService
 
 ### Community 138 - "Community 138"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
+Nodes (1): QaVerificationPlugin
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): CommandPlugin
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 141 - "Community 141"
-Cohesion: 0.4
-Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
+Cohesion: 0.33
+Nodes (1): CodexDashboardCommand
 
 ### Community 142 - "Community 142"
-Cohesion: 0.4
-Nodes (1): OpenCodePluginTest
+Cohesion: 0.33
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 143 - "Community 143"
-Cohesion: 0.4
-Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 144 - "Community 144"
 Cohesion: 0.4
-Nodes (1): CliGoldenSnapshotTest
+Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
 
 ### Community 145 - "Community 145"
 Cohesion: 0.4
-Nodes (1): DesktopEndpointPolicy
+Nodes (1): OpenCodePluginTest
 
 ### Community 146 - "Community 146"
 Cohesion: 0.4
-Nodes (1): LocalPlaywrightMarketingBrowserRunner
+Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
 ### Community 147 - "Community 147"
 Cohesion: 0.4
-Nodes (1): EvidencePathPolicy
+Nodes (1): CliGoldenSnapshotTest
 
 ### Community 148 - "Community 148"
 Cohesion: 0.4
-Nodes (1): CompanyRuntimeMachine
+Nodes (1): DesktopEndpointPolicy
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (1): WorkQueue
+Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
-Nodes (1): NetworkEndpointPolicy
+Nodes (1): EvidencePathPolicy
 
 ### Community 151 - "Community 151"
 Cohesion: 0.4
-Nodes (1): CheckpointGraphStore
+Nodes (1): CompanyRuntimeMachine
 
 ### Community 152 - "Community 152"
 Cohesion: 0.4
-Nodes (1): SideEffectJournalStore
+Nodes (1): WorkQueue
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
-Nodes (1): ProvenanceStore
+Nodes (1): NetworkEndpointPolicy
 
 ### Community 154 - "Community 154"
 Cohesion: 0.4
-Nodes (1): CodexDefaults
+Nodes (1): CheckpointGraphStore
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
-Nodes (1): CotorHttpClients
+Nodes (1): SideEffectJournalStore
 
 ### Community 156 - "Community 156"
 Cohesion: 0.4
-Nodes (2): StuckDetector, StuckSignal
+Nodes (1): ProvenanceStore
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (1): AppServerCommand
+Nodes (1): CodexDefaults
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
-Nodes (2): SyntaxValidationResult, SyntaxValidator
+Nodes (1): CotorHttpClients
 
 ### Community 159 - "Community 159"
-Cohesion: 0.5
-Nodes (1): findPrimes()
+Cohesion: 0.4
+Nodes (2): StuckDetector, StuckSignal
 
 ### Community 160 - "Community 160"
+Cohesion: 0.4
+Nodes (1): AppServerCommand
+
+### Community 161 - "Community 161"
+Cohesion: 0.4
+Nodes (2): SyntaxValidationResult, SyntaxValidator
+
+### Community 162 - "Community 162"
 Cohesion: 0.5
 Nodes (1): BoardServiceApplicationTests
 
-### Community 161 - "Community 161"
-Cohesion: 0.67
-Nodes (2): BoardServiceApplication, main()
-
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostDetailResponse
 
-### Community 163 - "Community 163"
-Cohesion: 0.5
-Nodes (1): PostRepository
-
 ### Community 164 - "Community 164"
-Cohesion: 0.5
-Nodes (1): Post
-
-### Community 165 - "Community 165"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostSummaryResponse
 
+### Community 165 - "Community 165"
+Cohesion: 0.5
+Nodes (1): PostRepository
+
 ### Community 166 - "Community 166"
 Cohesion: 0.5
-Nodes (1): AgentCapabilityGuardTest
+Nodes (1): Post
 
 ### Community 167 - "Community 167"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceOwnershipTest
+Nodes (1): findPrimes()
 
 ### Community 168 - "Community 168"
-Cohesion: 0.5
-Nodes (1): DesktopAppServiceAgentModelNormalizationTest
+Cohesion: 0.67
+Nodes (2): BoardServiceApplication, main()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.5
-Nodes (2): CapturingProcessManager, QaVerificationPluginTest
+Nodes (1): AgentCapabilityGuardTest
 
 ### Community 170 - "Community 170"
 Cohesion: 0.5
-Nodes (2): CommandPluginTest, RecordingProcessManager
+Nodes (1): DesktopAppServiceOwnershipTest
 
 ### Community 171 - "Community 171"
 Cohesion: 0.5
-Nodes (2): FileReaderPluginTest, NoopProcessManager
+Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
 ### Community 172 - "Community 172"
 Cohesion: 0.5
-Nodes (1): PipelineOrchestratorPropertyTest
+Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
 ### Community 173 - "Community 173"
 Cohesion: 0.5
-Nodes (2): ProviderCatalogEntry, ProviderScanResult
+Nodes (2): CommandPluginTest, RecordingProcessManager
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
-Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
+Nodes (2): FileReaderPluginTest, NoopProcessManager
 
 ### Community 175 - "Community 175"
 Cohesion: 0.5
-Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
+Nodes (1): PipelineOrchestratorPropertyTest
 
 ### Community 176 - "Community 176"
 Cohesion: 0.5
-Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
+Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
 ### Community 177 - "Community 177"
 Cohesion: 0.5
-Nodes (1): StateRepository
+Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
 ### Community 178 - "Community 178"
 Cohesion: 0.5
-Nodes (3): ChatMessage, ChatMode, ChatRole
+Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
-Nodes (1): DurableRuntimeFlags
+Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
-Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
+Nodes (1): StateRepository
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
+Nodes (3): ChatMessage, ChatMode, ChatRole
 
 ### Community 182 - "Community 182"
 Cohesion: 0.5
-Nodes (2): TimelineCollector, TimelineResult
+Nodes (1): DurableRuntimeFlags
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
-Nodes (1): StageConflictDetector
+Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (1): SimpleCLI
+Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
-Nodes (2): OutputValidator, StageValidationOutcome
+Nodes (2): TimelineCollector, TimelineResult
 
 ### Community 186 - "Community 186"
-Cohesion: 0.67
-Nodes (1): PostCreateRequest
+Cohesion: 0.5
+Nodes (1): StageConflictDetector
 
 ### Community 187 - "Community 187"
-Cohesion: 0.67
-Nodes (1): PostUpdateRequest
+Cohesion: 0.5
+Nodes (1): SimpleCLI
 
 ### Community 188 - "Community 188"
-Cohesion: 0.67
-Nodes (1): VersionConflictException
+Cohesion: 0.5
+Nodes (2): OutputValidator, StageValidationOutcome
 
 ### Community 189 - "Community 189"
 Cohesion: 0.67
-Nodes (1): PostNotFoundException
+Nodes (1): PostCreateRequest
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): PermissionDeniedException
+Nodes (1): PostUpdateRequest
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
+Nodes (1): VersionConflictException
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
+Nodes (1): PostNotFoundException
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIntegrationHarness
+Nodes (1): PermissionDeniedException
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
+Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceExecutionMemoryTest
+Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
+Nodes (1): DesktopAppServiceIntegrationHarness
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (1): CheckpointFixtureProcess
+Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): CheckpointResumeIntegrationTest
+Nodes (1): DesktopAppServiceExecutionMemoryTest
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): RuntimeConstructorConsistencyTest
+Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): PipelineOrchestratorMapTest
+Nodes (1): CheckpointFixtureProcess
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): TemplateCommandTest
+Nodes (1): CheckpointResumeIntegrationTest
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): InitCommandTest
+Nodes (1): RuntimeConstructorConsistencyTest
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (1): ValidateCommandTest
+Nodes (1): PipelineOrchestratorMapTest
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): DesktopLifecycleCommandTest
+Nodes (1): TemplateCommandTest
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): ResultAnalyzer
+Nodes (1): InitCommandTest
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
+Nodes (1): ValidateCommandTest
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (2): VideoPlanRequest, VideoPlanResult
+Nodes (1): DesktopLifecycleCommandTest
+
+### Community 208 - "Community 208"
+Cohesion: 0.67
+Nodes (1): ResultAnalyzer
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (1): DurableRuntimeContext
+Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (1): HelloCommand
-
-### Community 211 - "Community 211"
-Cohesion: 0.67
-Nodes (1): WebCommand
+Nodes (2): VideoPlanRequest, VideoPlanResult
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (1): LintCommand
+Nodes (1): DurableRuntimeContext
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
-Nodes (1): ExplainCommand
+Nodes (1): HelloCommand
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
-Nodes (1): CheckpointGCCommand
+Nodes (1): WebCommand
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (2): StageTimelineEntry, StageTimelineState
+Nodes (1): LintCommand
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (1): PipelineTemplateValidator
+Nodes (1): ExplainCommand
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): DefaultOutputValidator
+Nodes (1): CheckpointGCCommand
 
 ### Community 218 - "Community 218"
-Cohesion: 1.0
-Nodes (1): TemplateValidatorTest
+Cohesion: 0.67
+Nodes (2): StageTimelineEntry, StageTimelineState
+
+### Community 219 - "Community 219"
+Cohesion: 0.67
+Nodes (1): PipelineTemplateValidator
 
 ### Community 220 - "Community 220"
-Cohesion: 1.0
-Nodes (1): KotestProjectConfig
+Cohesion: 0.67
+Nodes (1): DefaultOutputValidator
 
 ### Community 221 - "Community 221"
 Cohesion: 1.0
-Nodes (1): KoinResolutionSmokeTest
-
-### Community 222 - "Community 222"
-Cohesion: 1.0
-Nodes (1): CheckpointManagerTest
+Nodes (1): TemplateValidatorTest
 
 ### Community 223 - "Community 223"
 Cohesion: 1.0
-Nodes (1): DefaultResultAnalyzerTest
+Nodes (1): KotestProjectConfig
 
 ### Community 224 - "Community 224"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceGitHubSyncTest
+Nodes (1): KoinResolutionSmokeTest
 
 ### Community 225 - "Community 225"
 Cohesion: 1.0
-Nodes (1): AppServerPlatformRoutesTest
+Nodes (1): CheckpointManagerTest
 
 ### Community 226 - "Community 226"
 Cohesion: 1.0
-Nodes (1): EvidencePathPolicyTest
+Nodes (1): DefaultResultAnalyzerTest
 
 ### Community 227 - "Community 227"
 Cohesion: 1.0
-Nodes (1): AppServerDurableRuntimeTest
+Nodes (1): DesktopAppServiceGitHubSyncTest
 
 ### Community 228 - "Community 228"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceParallelDispatchTest
+Nodes (1): AppServerPlatformRoutesTest
 
 ### Community 229 - "Community 229"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
+Nodes (1): EvidencePathPolicyTest
 
 ### Community 230 - "Community 230"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceDashboardRuntimeTest
+Nodes (1): AppServerDurableRuntimeTest
 
 ### Community 231 - "Community 231"
 Cohesion: 1.0
-Nodes (1): CompanyVerifierServiceTest
+Nodes (1): DesktopAppServiceParallelDispatchTest
 
 ### Community 232 - "Community 232"
 Cohesion: 1.0
-Nodes (1): AppServerVerificationRouteTest
+Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
 ### Community 233 - "Community 233"
 Cohesion: 1.0
-Nodes (1): AppServerTest
+Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
 ### Community 234 - "Community 234"
 Cohesion: 1.0
-Nodes (1): DesktopTuiSessionServiceTest
+Nodes (1): CompanyVerifierServiceTest
 
 ### Community 235 - "Community 235"
 Cohesion: 1.0
-Nodes (1): DesktopStateStoreLockTest
+Nodes (1): AppServerVerificationRouteTest
 
 ### Community 236 - "Community 236"
 Cohesion: 1.0
-Nodes (1): DesktopEndpointPolicyTest
+Nodes (1): AppServerTest
 
 ### Community 237 - "Community 237"
 Cohesion: 1.0
-Nodes (1): ExecutionBackendsTest
+Nodes (1): DesktopTuiSessionServiceTest
 
 ### Community 238 - "Community 238"
 Cohesion: 1.0
-Nodes (1): CodexAppServerManagerTest
+Nodes (1): DesktopStateStoreLockTest
 
 ### Community 239 - "Community 239"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceMergeConfirmationTest
+Nodes (1): DesktopEndpointPolicyTest
 
 ### Community 240 - "Community 240"
 Cohesion: 1.0
-Nodes (1): DesktopStateStoreTest
+Nodes (1): ExecutionBackendsTest
 
 ### Community 241 - "Community 241"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceDashboardPrCleanupTest
+Nodes (1): CodexAppServerManagerTest
 
 ### Community 242 - "Community 242"
 Cohesion: 1.0
-Nodes (1): AutonomousDiscoveryServiceTest
+Nodes (1): DesktopAppServiceMergeConfirmationTest
 
 ### Community 243 - "Community 243"
 Cohesion: 1.0
-Nodes (1): SkillModelsTest
+Nodes (1): DesktopStateStoreTest
 
 ### Community 244 - "Community 244"
 Cohesion: 1.0
-Nodes (1): CompanyRuntimeMachineTest
+Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
 ### Community 245 - "Community 245"
 Cohesion: 1.0
-Nodes (1): ChatTranscriptWriterTest
+Nodes (1): AutonomousDiscoveryServiceTest
 
 ### Community 246 - "Community 246"
 Cohesion: 1.0
-Nodes (1): ChatSessionTest
+Nodes (1): SkillModelsTest
 
 ### Community 247 - "Community 247"
 Cohesion: 1.0
-Nodes (1): NetworkEndpointPolicyTest
+Nodes (1): CompanyRuntimeMachineTest
 
 ### Community 248 - "Community 248"
 Cohesion: 1.0
-Nodes (1): SecurityValidatorTest
+Nodes (1): ChatTranscriptWriterTest
 
 ### Community 249 - "Community 249"
 Cohesion: 1.0
-Nodes (1): A2aArtifactStoreTest
+Nodes (1): ChatSessionTest
 
 ### Community 250 - "Community 250"
 Cohesion: 1.0
-Nodes (1): A2aApiTest
+Nodes (1): NetworkEndpointPolicyTest
 
 ### Community 251 - "Community 251"
 Cohesion: 1.0
-Nodes (1): A2aSessionStoreTest
+Nodes (1): SecurityValidatorTest
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (1): A2aDedupeStoreTest
+Nodes (1): A2aArtifactStoreTest
 
 ### Community 253 - "Community 253"
 Cohesion: 1.0
-Nodes (1): RecoveryExecutorTest
+Nodes (1): A2aApiTest
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (1): GitHubControlPlaneServiceTest
+Nodes (1): A2aSessionStoreTest
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (1): StoreConcurrencyTest
+Nodes (1): A2aDedupeStoreTest
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (1): DurableRuntimeServiceTest
+Nodes (1): RecoveryExecutorTest
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): DurableResumeCoordinatorTest
+Nodes (1): GitHubControlPlaneServiceTest
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): ActionExecutionServiceTest
+Nodes (1): StoreConcurrencyTest
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): LinearClientEndpointPolicyTest
+Nodes (1): DurableRuntimeServiceTest
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): VerificationBundleServiceTest
+Nodes (1): DurableResumeCoordinatorTest
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): KnowledgeServiceTest
+Nodes (1): ActionExecutionServiceTest
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (1): LocalModelDefaultsTest
+Nodes (1): LinearClientEndpointPolicyTest
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): ObservabilityServiceTest
+Nodes (1): VerificationBundleServiceTest
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): FileConfigRepositoryTest
+Nodes (1): KnowledgeServiceTest
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): QaTestGenerationFixtureTest
+Nodes (1): LocalModelDefaultsTest
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): ConfigRepositoryImportTest
+Nodes (1): ObservabilityServiceTest
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): ExampleConfigSmokeTest
+Nodes (1): FileConfigRepositoryTest
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): YamlParserTest
+Nodes (1): QaTestGenerationFixtureTest
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): CodexPluginTest
+Nodes (1): ConfigRepositoryImportTest
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): CotorHttpClientsTest
+Nodes (1): ExampleConfigSmokeTest
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): ProcessManagerTest
+Nodes (1): YamlParserTest
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): ErrorHelperTest
+Nodes (1): CodexPluginTest
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): ResultAggregatorTest
+Nodes (1): CotorHttpClientsTest
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): ConditionEvaluatorTest
+Nodes (1): ProcessManagerTest
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): AgentExecutorTest
+Nodes (1): ErrorHelperTest
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): StuckDetectorTest
+Nodes (1): ResultAggregatorTest
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): PipelineGuardServiceTest
+Nodes (1): ConditionEvaluatorTest
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorDagValidationTest
+Nodes (1): AgentExecutorTest
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): StageConflictDetectorTest
+Nodes (1): StuckDetectorTest
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorTemplatingTest
+Nodes (1): PipelineGuardServiceTest
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): CoroutineEventBusTest
+Nodes (1): PipelineOrchestratorDagValidationTest
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): WebServerTest
+Nodes (1): StageConflictDetectorTest
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): CompletionCommandTest
+Nodes (1): PipelineOrchestratorTemplatingTest
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): HelpCommandTest
+Nodes (1): CoroutineEventBusTest
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): AppServerCommandTest
+Nodes (1): WebServerTest
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): StarterAgentResolverTest
+Nodes (1): CompletionCommandTest
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandCompleterTest
+Nodes (1): HelpCommandTest
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): AgentCommandTest
+Nodes (1): AppServerCommandTest
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): PluginCommandTest
+Nodes (1): StarterAgentResolverTest
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): AuthCommandTest
+Nodes (1): InteractiveCommandCompleterTest
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): HelloCommandTest
+Nodes (1): AgentCommandTest
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): LintCommandTest
+Nodes (1): PluginCommandTest
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): CompanyCommandTest
+Nodes (1): AuthCommandTest
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandTest
+Nodes (1): HelloCommandTest
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): StatsCommandTest
+Nodes (1): LintCommandTest
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): CodexDashboardCommandTest
+Nodes (1): CompanyCommandTest
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): StatsManagerTest
+Nodes (1): InteractiveCommandTest
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorTest
+Nodes (1): StatsCommandTest
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorExtTest
+Nodes (1): CodexDashboardCommandTest
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): LinterTest
+Nodes (1): StatsManagerTest
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): DefaultOutputValidatorTest
+Nodes (1): PipelineValidatorTest
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): PolicyEngineTest
+Nodes (1): PipelineValidatorExtTest
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): RiskApprovalInterceptorTest
+Nodes (1): LinterTest
+
+### Community 304 - "Community 304"
+Cohesion: 1.0
+Nodes (1): DefaultOutputValidatorTest
+
+### Community 305 - "Community 305"
+Cohesion: 1.0
+Nodes (1): PolicyEngineTest
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
+Nodes (1): RiskApprovalInterceptorTest
+
+### Community 309 - "Community 309"
+Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 308 - "Community 308"
+### Community 311 - "Community 311"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 309 - "Community 309"
+### Community 312 - "Community 312"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **1002 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+997 more)
+- **985 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+980 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 22`** (34 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1573,19 +1588,19 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
+- **Thin community `Community 39`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 40`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 41`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 42`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 46`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+- **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 51`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1611,423 +1626,427 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 81`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 84`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 85`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (10 nodes): `A2aArtifactStore`, `.append()`, `.count()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `.scopedOpsMetrics()`, `A2aArtifactStore.kt`
+- **Thin community `Community 86`** (10 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `.signal()`, `AutonomousDiscoveryService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 87`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 88`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 89`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 90`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 93`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 94`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 94`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
+- **Thin community `Community 95`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 95`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
+- **Thin community `Community 96`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 102`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 106`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 107`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 108`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 108`** (8 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 110`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 111`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 112`** (8 nodes): `A2aArtifactStore`, `.append()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `A2aArtifactStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 113`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 114`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 115`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 116`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 117`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 120`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 121`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 122`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 123`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 124`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 125`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 126`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 128`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 129`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 130`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 132`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 133`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 134`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 135`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 136`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 137`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 138`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 139`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 140`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 141`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 142`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 143`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 144`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 145`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 146`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 147`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 148`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 149`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 150`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 151`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 152`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 153`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 154`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 155`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 156`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 157`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 158`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 159`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 160`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 161`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 162`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 165`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 166`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 167`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 168`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 169`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 170`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 171`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 172`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 173`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 174`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 175`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 176`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 177`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 179`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 180`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 182`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 185`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 186`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 187`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 188`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 189`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 190`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 191`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 192`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 193`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 194`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 195`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 196`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 197`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 200`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 201`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 202`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 203`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 204`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 206`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 207`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 208`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 209`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 210`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 212`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 213`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 215`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 216`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 217`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 218`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 219`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 220`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 221`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 223`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 224`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 225`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 226`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 227`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 228`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 229`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 230`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 231`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 234`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 235`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 236`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 237`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 238`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 240`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 241`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 242`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 243`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 244`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 245`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 246`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 247`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 248`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 249`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 250`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 251`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 252`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 253`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 254`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 255`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 256`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 257`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 258`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 259`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 260`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 261`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 262`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 263`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 264`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 265`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 267`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 268`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 269`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 270`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 271`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 272`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 273`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 274`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 275`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 276`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 277`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 278`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 279`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 280`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 281`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 282`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 283`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 284`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 285`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 286`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 287`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 288`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 289`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 290`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 291`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 296`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 297`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 298`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 299`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 300`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 301`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 302`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 303`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 304`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 305`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+- **Thin community `Community 306`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 309`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 311`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 312`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 11`, `Community 15`, `Community 18`, `Community 85`?**
-  _High betweenness centrality (0.099) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 5` to `Community 1`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 5`, `Community 15`?**
+  _High betweenness centrality (0.092) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 2` to `Community 1`, `Community 3`, `Community 5`, `Community 6`, `Community 14`, `Community 16`?**
+  _High betweenness centrality (0.035) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 6` to `Community 2`?**
+  _High betweenness centrality (0.034) - this node is a cross-community bridge._
 - **Are the 38 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
   _`DesktopStore` has 38 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
-  _1002 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
+  _985 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor-qa-appbuild-20260526  (2026-05-26)
 
 ## Corpus Check
-- 358 files · ~612,665 words
+- 358 files · ~612,630 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -332,12 +332,12 @@
 10. `DesktopStateStore` - 30 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `userFacingIssueKind()` --calls--> `language`  [INFERRED]
-  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
-- `userFacingDecisionTitle()` --calls--> `language`  [INFERRED]
-  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
-- `localizedSourceKind()` --calls--> `language`  [INFERRED]
-  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `language` --calls--> `userFacingIssueKind()`  [INFERRED]
+  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
+- `language` --calls--> `userFacingDecisionTitle()`  [INFERRED]
+  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
+- `language` --calls--> `localizedSourceKind()`  [INFERRED]
+  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
 - `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -1094,18 +1094,27 @@ final class DesktopStore: ObservableObject {
         await EmbeddedBackendLauncher.shared.ensureRunning()
         // Installed app bundles launch the backend lazily, so the first request can
         // arrive before `cotor app-server` has finished binding its localhost port.
-        for attempt in 0 ..< 4 {
+        let maxAttempts = 4
+        for attempt in 0 ..< maxAttempts {
             await refreshDashboard()
-            if !isOffline {
+            if !shouldRetryBootstrapAfterRefresh(attempt: attempt, maxAttempts: maxAttempts) {
                 return
             }
-            if attempt < 3 {
-                statusState = .waitingForServer
-                objectWillChange.send()
-                await EmbeddedBackendLauncher.shared.ensureRunning()
-                try? await Task.sleep(for: .seconds(1))
-            }
+            statusState = .waitingForServer
+            objectWillChange.send()
+            await EmbeddedBackendLauncher.shared.ensureRunning()
+            try? await Task.sleep(for: .seconds(1))
         }
+    }
+
+    func shouldRetryBootstrapAfterRefresh(attempt: Int, maxAttempts: Int) -> Bool {
+        guard attempt < maxAttempts - 1 else { return false }
+        if isOffline { return true }
+        return dashboard.companies.isEmpty &&
+            dashboard.repositories.isEmpty &&
+            dashboard.goals.isEmpty &&
+            dashboard.issues.isEmpty &&
+            dashboard.tasks.isEmpty
     }
 
     func handleAppBecameActive() async {

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -104,6 +104,48 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func bootstrapRetriesEmptySuccessfulDashboardBeforeSettling() {
+        let store = DesktopStore()
+
+        store.isOffline = false
+        store.dashboard = DashboardPayload.empty
+
+        #expect(store.shouldRetryBootstrapAfterRefresh(attempt: 0, maxAttempts: 4))
+        #expect(!store.shouldRetryBootstrapAfterRefresh(attempt: 3, maxAttempts: 4))
+
+        store.dashboard = DashboardPayload(
+            repositories: [],
+            workspaces: [],
+            tasks: [],
+            settings: DashboardPayload.empty.settings,
+            companies: [company(id: "company", repositoryId: "repo", name: "Company")],
+            companyAgentDefinitions: [],
+            agentCapabilityProfiles: [],
+            projectContexts: [],
+            goals: [],
+            issues: [],
+            reviewQueue: [],
+            orgProfiles: [],
+            workflowTopologies: [],
+            goalDecisions: [],
+            runningAgentSessions: [],
+            backendStatuses: [],
+            opsMetrics: DashboardPayload.empty.opsMetrics,
+            activity: [],
+            companyRuntimes: [],
+            agentContextEntries: [],
+            agentMessages: [],
+            agentPerformance: []
+        )
+
+        #expect(!store.shouldRetryBootstrapAfterRefresh(attempt: 0, maxAttempts: 4))
+
+        store.isOffline = true
+
+        #expect(store.shouldRetryBootstrapAfterRefresh(attempt: 0, maxAttempts: 4))
+    }
+
+    @Test
     func fullAutoOperatorChatRequestAddsConfirmationToTimeline() async {
         let store = DesktopStore()
 

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -346,7 +346,7 @@ class DesktopAppService(
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val companyRuntimeJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val companyRuntimeWakeSignals = ConcurrentHashMap<String, MutableSharedFlow<Unit>>()
-    private val automationRefreshJobs: MutableMap<String, Job> = linkedMapOf()
+    private val automationRefreshJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val activeTaskJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val intentionallyInterruptedTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val recentCompanyAutomationTraceKeys = ConcurrentHashMap<String, Long>()

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -16721,6 +16721,10 @@ class DesktopAppService(
         }
     }
 
+    internal suspend fun runTaskInlineForTesting(taskId: String) {
+        executeTaskInline(taskId)
+    }
+
     private suspend fun recordRunFailure(
         task: AgentTask,
         workspace: Workspace,

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -863,6 +863,9 @@ class OpenCodePlugin : AgentPlugin {
             add("--print-logs")
             add("--log-level")
             add("ERROR")
+            if (!planningOnly) {
+                add("--dangerously-skip-permissions")
+            }
             if (planningOnly) {
                 context.workingDirectory?.let {
                     add("--dir")

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -4732,16 +4732,7 @@ class DesktopAppServiceTest : FunSpec({
             issueId = qaIssue.id
         )
 
-        service.runTask(qaTask.id)
-        withTimeout(90_000) {
-            while (true) {
-                val item = stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }
-                if (item.qaVerdict == "PASS" && item.status == ReviewQueueStatus.READY_FOR_CEO) {
-                    break
-                }
-                delay(25)
-            }
-        }
+        service.runTaskInlineForTesting(qaTask.id)
 
         var refreshed = stateStore.load()
         val queueAfterQa = refreshed.reviewQueue.single { it.issueId == executionIssue.id }
@@ -4816,12 +4807,7 @@ class DesktopAppServiceTest : FunSpec({
             issueId = approvalIssue.id
         )
 
-        service.runTask(approvalTask.id)
-        withTimeout(90_000) {
-            while (stateStore.load().reviewQueue.single { it.issueId == executionIssue.id }.status != ReviewQueueStatus.MERGED) {
-                delay(25)
-            }
-        }
+        service.runTaskInlineForTesting(approvalTask.id)
 
         refreshed = stateStore.load()
         refreshed.reviewQueue.single { it.issueId == executionIssue.id }.status shouldBe ReviewQueueStatus.MERGED

--- a/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
@@ -1058,19 +1058,20 @@ class OpenCodePluginTest : FunSpec({
 private const val OPENCODE_PROMPT_INSTRUCTION = "Execute the instructions in the attached prompt file."
 
 private fun assertOpenCodeRunCommand(command: List<String>, model: String, expectedPrompt: String) {
-    command.size shouldBe 11
+    command.size shouldBe 12
     command[0] shouldBe "opencode"
     command[1] shouldBe "run"
     command[2] shouldBe "--print-logs"
     command[3] shouldBe "--log-level"
     command[4] shouldBe "ERROR"
-    command[5] shouldBe "--model"
-    command[6] shouldBe model
-    command[7] shouldBe "--format"
-    command[8] shouldBe "json"
-    command[9] shouldBe OPENCODE_PROMPT_INSTRUCTION
-    command[10].startsWith("--file=") shouldBe true
-    Files.readString(Path.of(command[10].removePrefix("--file="))) shouldBe expectedPrompt
+    command[5] shouldBe "--dangerously-skip-permissions"
+    command[6] shouldBe "--model"
+    command[7] shouldBe model
+    command[8] shouldBe "--format"
+    command[9] shouldBe "json"
+    command[10] shouldBe OPENCODE_PROMPT_INSTRUCTION
+    command[11].startsWith("--file=") shouldBe true
+    Files.readString(Path.of(command[11].removePrefix("--file="))) shouldBe expectedPrompt
 }
 
 private fun localRoutingServer(handler: (HttpExchange) -> Unit): HttpServer {


### PR DESCRIPTION
## 발견된 버그
- Installed macOS app could briefly settle on a successful but empty dashboard during embedded backend startup, showing no companies until manual Refresh.
- OpenCode execution could wait on interactive permission prompts even though Cotor already applies company-scoped capability checks and runs work in isolated task worktrees.

## 수정 내용
- Added bootstrap retry logic for empty successful dashboard snapshots before the desktop shell settles.
- Added Swift coverage for empty-dashboard retry behavior.
- Added `--dangerously-skip-permissions` to non-planning OpenCode runs after Cotor capability checks.
- Updated OpenCode command assertions and English/Korean OpenCode docs.
- Refreshed `graphify-out/GRAPH_REPORT.md`.

## 재테스트 결과
- `swift test --package-path macos`
- `swift build --package-path macos`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 test --tests com.cotor.data.plugin.OpenCodePluginTest -x jacocoTestReport -x jacocoTestCoverageVerification --rerun-tasks --stacktrace`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 test -x jacocoTestReport -x jacocoTestCoverageVerification --rerun-tasks --stacktrace`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 formatCheck --stacktrace`
- `graphify update .`

## 남은 확인
- CI 완료 후 installed app을 다시 교체하고 첫 실행에서 회사 목록이 Refresh 없이 뜨는지 수동 확인합니다.