### PR TITLE
fix(qa): seed repository mapper skill permissions

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor-ultraqa-20260526.qJfPNp  (2026-05-26)
 
 ## Corpus Check
-- 358 files · ~612,626 words
+- 358 files · ~612,895 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -20287,16 +20287,26 @@ class DesktopAppService(
         profile: AgentCapabilityProfile,
         now: Long
     ): AgentCapabilityProfile {
-        if (!isChiefAgentDefinition(definition)) {
-            return profile
-        }
         var changed = false
         val nextSettings = profile.settings.toMutableMap()
-        chiefAgentApprovalSettings().forEach { (key, setting) ->
-            val current = nextSettings[key]
-            if (current == null || !current.enabled || current.mode == CapabilityMode.DISABLED) {
-                nextSettings[key] = setting
-                changed = true
+
+        if (isChiefAgentDefinition(definition)) {
+            chiefAgentApprovalSettings().forEach { (key, setting) ->
+                val current = nextSettings[key]
+                if (current == null || !current.enabled || current.mode == CapabilityMode.DISABLED) {
+                    nextSettings[key] = setting
+                    changed = true
+                }
+            }
+        }
+        if (isRepositoryMappingAgentDefinition(definition)) {
+            val defaults = defaultAgentCapabilitySettings()
+            repositoryMappingSkillSettings(company.rootPath).forEach { (key, setting) ->
+                val current = nextSettings[key]
+                if (current == null || current == defaults[key]) {
+                    nextSettings[key] = setting
+                    changed = true
+                }
             }
         }
         if (!changed) {
@@ -20315,9 +20325,44 @@ class DesktopAppService(
         val base = repositoryScopedCompanyAgentCapabilitySettings(company.rootPath)
         return when {
             isChiefAgentDefinition(definition) -> base + chiefAgentApprovalSettings()
+            isRepositoryMappingAgentDefinition(definition) -> base + repositoryMappingSkillSettings(company.rootPath)
             isMarketingOperatorDefinition(definition) -> base + marketingOperatorSkillSettings()
             else -> base
         }
+    }
+
+    private fun isRepositoryMappingAgentDefinition(definition: CompanyAgentDefinition): Boolean =
+        definition.title.equals("Engineering Lead", ignoreCase = true)
+
+    private fun repositoryMappingSkillSettings(rootPath: String): Map<CapabilityKey, AgentCapabilitySetting> {
+        val repositoryRoot = Path.of(rootPath).toAbsolutePath().normalize().toString()
+        val notes = "Repository mapping is delegated only inside this company's root for the operator repo-map shortcut."
+        return mapOf(
+            CapabilityKey.SKILL_RUN to AgentCapabilitySetting(
+                enabled = true,
+                mode = CapabilityMode.AUTO,
+                skillAllowlist = listOf("graphify"),
+                requiresEvidence = true,
+                requiresReview = false,
+                notes = notes
+            ),
+            CapabilityKey.KNOWLEDGE_GRAPH_READ to AgentCapabilitySetting(
+                enabled = true,
+                mode = CapabilityMode.READ_ONLY,
+                pathAllowlist = listOf(repositoryRoot),
+                requiresEvidence = true,
+                requiresReview = false,
+                notes = notes
+            ),
+            CapabilityKey.KNOWLEDGE_GRAPH_WRITE to AgentCapabilitySetting(
+                enabled = true,
+                mode = CapabilityMode.AUTO,
+                pathAllowlist = listOf(repositoryRoot),
+                requiresEvidence = true,
+                requiresReview = false,
+                notes = notes
+            )
+        )
     }
 
     private fun isMarketingOperatorDefinition(definition: CompanyAgentDefinition): Boolean =

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -24,6 +24,40 @@ class SkillRuntimeTest : FunSpec({
         graphify.requiredCapabilities.contains(CapabilityKey.KNOWLEDGE_GRAPH_WRITE) shouldBe true
     }
 
+    test("new companies seed a repository mapper agent for the operator repo map shortcut") {
+        val appHome = Files.createTempDirectory("skill-graphify-seed-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val service = skillRuntimeService(appHome)
+        val company = service.createCompany(name = "Graph Seed Co", rootPath = repoRoot.toString())
+        val companyRoot = java.nio.file.Path.of(company.rootPath).toAbsolutePath().normalize()
+        companyRoot.resolve("graphify-out").createDirectories()
+        companyRoot.resolve("graphify-out").resolve("GRAPH_REPORT.md").writeText("# Graph\n\n- service: DesktopAppService")
+        val dashboard = service.dashboard()
+        val engineeringLead = dashboard.companyAgentDefinitions.first {
+            it.companyId == company.id && it.title == "Engineering Lead"
+        }
+        val profile = dashboard.agentCapabilityProfiles.first {
+            it.companyId == company.id && it.agentId == engineeringLead.id
+        }
+        val skillRun = profile.settings.getValue(CapabilityKey.SKILL_RUN)
+        val graphWrite = profile.settings.getValue(CapabilityKey.KNOWLEDGE_GRAPH_WRITE)
+
+        skillRun.mode shouldBe CapabilityMode.AUTO
+        skillRun.skillAllowlist.contains("graphify") shouldBe true
+        graphWrite.mode shouldBe CapabilityMode.AUTO
+        graphWrite.pathAllowlist.contains(companyRoot.toString()) shouldBe true
+
+        val result = service.runSkill(
+            name = "graphify",
+            companyId = company.id,
+            agentId = engineeringLead.id,
+            parameters = mapOf("refresh" to "false")
+        )
+
+        result.status shouldBe "COMPLETED"
+        result.output shouldContain "DesktopAppService"
+    }
+
     test("runSkill dispatches graphify to graph report evidence instead of READY") {
         val appHome = Files.createTempDirectory("skill-graphify-home")
         val service = skillRuntimeService(appHome)


### PR DESCRIPTION
## 발견된 버그
- 설치된 데스크톱 앱에서 새 회사를 만든 뒤 운영 채팅의 `리포 맵` 빠른 명령을 직접 누르면 `선택한 회사에서 바로 실행 가능한 리포지토리 맵 스킬이 없습니다.`라고 실패했습니다.
- 원인은 기본 회사 에이전트 시딩이 `graphify` 스킬 실행 권한과 `KNOWLEDGE_GRAPH_WRITE` 권한을 어떤 에이전트에도 명시적으로 주지 않아, UI의 스킬 카드가 Repository Mapper를 runnable skill로 볼 수 없던 것입니다.

## 수정 내용
- 새 회사의 Engineering Lead에 `graphify` 스킬 실행 권한을 명시적으로 시딩했습니다.
- `KNOWLEDGE_GRAPH_READ`/`KNOWLEDGE_GRAPH_WRITE`를 회사 루트 path allowlist로 제한해 리포지토리 맵 갱신 범위를 안전하게 묶었습니다.
- 기존 기본값 상태의 레거시 capability profile도 준비 단계에서 같은 정책으로 보정되도록 했습니다.
- 새 회사에서 Repository Mapper가 즉시 실행되는 회귀 테스트를 추가했습니다.

## 재테스트 결과
- `./gradlew --no-daemon test --tests 'com.cotor.app.SkillRuntimeTest' -x jacocoTestReport -x jacocoTestCoverageVerification --stacktrace` PASS
- `swift test --package-path macos` PASS
- `graphify update .` PASS
- `./gradlew test --no-daemon` PASS
- `./gradlew formatCheck --no-daemon -Dkotlin.incremental=false` PASS
