### PR TITLE
fix(qa): prefer predelegated skill agents

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-05-26)
 
 ## Corpus Check
-- 364 files · ~627,296 words
+- 364 files · ~627,478 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -6879,19 +6879,33 @@ class DesktopAppService(
     private suspend fun resolveOperatorSkillAgent(companyId: String, skillName: String): String? {
         val state = stateStore.load()
         val enabledDefinitions = state.companyAgentDefinitions.filter { it.companyId == companyId && it.enabled }
-        val byAllowlist = enabledDefinitions.firstOrNull { definition ->
+        data class SkillAgentCandidate(
+            val definition: CompanyAgentDefinition,
+            val setting: AgentCapabilitySetting,
+            val exactAllowlistMatch: Boolean
+        )
+
+        val candidates = enabledDefinitions.mapNotNull { definition ->
             val setting = state.agentCapabilityProfiles
                 .firstOrNull { it.companyId == companyId && it.agentId == definition.id }
                 ?.settings
                 ?.get(CapabilityKey.SKILL_RUN)
-            setting?.enabled == true &&
+                ?: return@mapNotNull null
+            val exactAllowlistMatch = setting.skillAllowlist.any { it.equals(skillName, ignoreCase = true) }
+            val allowedByCapability = setting.enabled &&
                 setting.mode != CapabilityMode.DISABLED &&
-                (setting.skillAllowlist.isEmpty() || setting.skillAllowlist.any { it.equals(skillName, ignoreCase = true) })
+                (setting.skillAllowlist.isEmpty() || exactAllowlistMatch)
+            if (allowedByCapability) {
+                SkillAgentCandidate(definition, setting, exactAllowlistMatch)
+            } else {
+                null
+            }
         }
-        if (byAllowlist != null) {
-            return byAllowlist.id
-        }
-        return enabledDefinitions.firstOrNull()?.id
+        return candidates.firstOrNull { it.exactAllowlistMatch && it.setting.mode == CapabilityMode.AUTO }?.definition?.id
+            ?: candidates.firstOrNull { it.exactAllowlistMatch }?.definition?.id
+            ?: candidates.firstOrNull { it.setting.mode == CapabilityMode.AUTO }?.definition?.id
+            ?: candidates.firstOrNull()?.definition?.id
+            ?: enabledDefinitions.firstOrNull()?.id
     }
 
     private fun inferOperatorSkillName(message: String): String {

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -969,6 +969,37 @@ class DesktopAppServiceTest : FunSpec({
         stateStore.load().skillRuns.single().skill shouldBe "graphify"
     }
 
+    test("operator chat prefers predelegated repository mapper agent over broad approval gates") {
+        val appHome = Files.createTempDirectory("operator-chat-skill-agent-selection-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+        coEvery { gitWorkspaceService.ensureInitializedRepositoryRoot(any(), any()) } returns repoRoot
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true)
+        )
+        val company = service.createCompany(name = "Operator Chat Skill Agent Selection", rootPath = appHome.toString())
+        Path.of(company.rootPath).resolve("graphify-out").also { Files.createDirectories(it) }
+            .resolve("GRAPH_REPORT.md")
+            .toFile()
+            .writeText("# Graph\n\n- predelegated engineering lead path")
+        val engineeringLead = service.listCompanyAgentDefinitions(company.id).first { it.title == "Engineering Lead" }
+
+        val response = service.runOperatorChat(
+            companyId = company.id,
+            message = "graphify 실행해서 리포지토리 구조 알려줘",
+            automationMode = OperatorAutomationMode.FULL_AUTO,
+            confirmFullAuto = true
+        )
+
+        response.actions.any { it.type == "skill-run" && it.status == "COMPLETED" } shouldBe true
+        response.blockedActions.shouldBeEmpty()
+        stateStore.load().skillRuns.single().agentId shouldBe engineeringLead.id
+    }
+
     test("operator chat keeps broad skill status questions on the status path") {
         val appHome = Files.createTempDirectory("operator-chat-skill-status-home")
         val repoRoot = Files.createDirectories(appHome.resolve("repo"))
@@ -9338,6 +9369,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
+        service.stopCompanyRuntime(company.id)
         service.runCompanyRuntimeTick(company.id)
 
         stateStore.load().goals.first { it.id == followUpGoal.id }.status shouldBe GoalStatus.ACTIVE


### PR DESCRIPTION
## 발견된 버그
- 설치된 macOS 앱에서 operator chat이 `graphify 실행해서 리포지토리 구조 알려줘`를 `skill-run`으로 라우팅한 뒤에도 `APPROVAL_REQUIRED`로 막혔습니다.
- 원인은 스킬 실행 에이전트 선택 로직이 `SKILL_RUN` allowlist가 비어 있는 CEO의 broad `APPROVAL_REQUIRED` 권한을 먼저 선택하고, 실제로 `graphify`가 AUTO로 pre-delegation된 Engineering Lead까지 도달하지 못한 것입니다.

## 수정 내용
- `resolveOperatorSkillAgent`가 exact skill allowlist + AUTO 권한을 최우선으로 선택하도록 우선순위를 조정했습니다.
- broad approval gate가 앞에 있어도 `graphify`는 seeded Engineering Lead의 Repository Mapper 권한으로 실행됩니다.
- 설치 앱에서 재현된 경로를 막는 회귀 테스트를 추가했습니다.

## 재테스트 결과
- `./gradlew --no-daemon --no-build-cache --max-workers=1 test --tests com.cotor.app.DesktopAppServiceTest --tests com.cotor.app.SkillRuntimeTest -x jacocoTestReport -x jacocoTestCoverageVerification --stacktrace`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 test -x jacocoTestReport -x jacocoTestCoverageVerification --stacktrace`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 formatCheck --stacktrace`
- `swift build --package-path macos`
- `graphify update .`
- `shell/install-desktop-app.sh`
- Installed app smoke: `operator/chat` returned `skill-run COMPLETED` for `graphify 실행해서 리포지토리 구조 알려줘`, and the Team UI shows `Engineering Lead -> graphify · COMPLETED`.

## 문서
- User-facing behavior docs were not changed; this is a routing/selection bug fix with test and graph refresh only.

## 리스크
- Low. The selection order still falls back to previous broad eligible agents if no exact AUTO skill delegation exists.
