### PR TITLE
fix(qa): preserve blocked issues after stale completions

### DIFF
--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -13105,7 +13105,10 @@ class DesktopAppService(
         issueTasks: List<AgentTask>,
         latestRunsByTaskId: Map<String, AgentRun>
     ): Boolean {
-        if (task.status != DesktopTaskStatus.COMPLETED || issue.status != IssueStatus.BLOCKED) {
+        if (task.status != DesktopTaskStatus.COMPLETED ||
+            issue.status == IssueStatus.DONE ||
+            issue.status == IssueStatus.CANCELED
+        ) {
             return false
         }
         if (task.createdAt > issue.updatedAt) {
@@ -13115,7 +13118,7 @@ class DesktopAppService(
             .filter {
                 it.id != task.id &&
                     it.status in setOf(DesktopTaskStatus.FAILED, DesktopTaskStatus.PARTIAL) &&
-                    it.updatedAt >= issue.updatedAt
+                    (it.updatedAt >= issue.updatedAt || it.updatedAt >= task.createdAt)
             }
             .maxByOrNull { it.updatedAt }
             ?: return false
@@ -13183,6 +13186,26 @@ class DesktopAppService(
                             newStatus = issue.status,
                             source = "reconcileTerminalIssueStates",
                             reason = "Skipped task-to-issue reconciliation because the latest run produced no new diff on an existing PR lineage and existing-PR recovery should run first.",
+                            latestTask = latestTask,
+                            latestRun = latestRun
+                        )
+                        return@forEach
+                    }
+                    val staleCompletionAfterIssueBlocked =
+                        isStaleCompletionBlockedByNewerNonRecoverableFailure(
+                            task = latestTask,
+                            issue = issue,
+                            issueTasks = issueTasks,
+                            latestRunsByTaskId = latestRunsByTaskId
+                        )
+                    if (staleCompletionAfterIssueBlocked) {
+                        informationalTraceEvents += buildCompanyAutomationTraceEvent(
+                            issue = issue,
+                            goal = state.goals.firstOrNull { it.id == issue.goalId },
+                            oldStatus = issue.status,
+                            newStatus = issue.status,
+                            source = "reconcileTerminalIssueStates",
+                            reason = "Skipped stale completed-task reconciliation because a newer non-recoverable failure already blocked the issue.",
                             latestTask = latestTask,
                             latestRun = latestRun
                         )


### PR DESCRIPTION
## Discovered bug

A late completed task could be reconciled after a newer non-recoverable failure had already blocked the same company issue. In that stale ordering, task reconciliation could close the issue as DONE, hiding the real blocker and making the autonomous remediation flow look successful.

During the same QA pass, the installed desktop app and TUI/skill surfaces were exercised directly. The TUI stream-close failure is already covered by the latest master commit; this PR keeps the remaining stale completion guard focused on DesktopAppService.

## Fix

- Broaden stale completion detection so it protects any not-final issue state, while still allowing DONE/CANCELED to remain terminal.
- Treat a newer failed/partial task as blocking when it was updated after the issue block or after the stale completed task started.
- Skip stale completed-task reconciliation before it enters `syncIssueFromTask`, and emit an automation trace explaining why the issue stayed blocked.

## Retest results

- `./gradlew --no-daemon --no-build-cache --max-workers=1 test --rerun-tasks --stacktrace`
- `./gradlew --no-daemon --no-build-cache --max-workers=1 formatCheck --stacktrace`
- `swift test --package-path macos`
- `swift build --package-path macos`
- `graphify update .` was run; generated `GRAPH_REPORT.md` was not committed because this temporary worktree produced a lower-file-count graph than current master.
- Installed `/Applications/Cotor Desktop.app` smoke before final rebase: backend health OK, company UI connected, Repository Mapper skill run completed with evidence, TUI session opened and terminated with no leftover `/api/app/tui/sessions`.

## Risk

Low. The change only prevents stale completed tasks from overriding a newer non-recoverable blocker; terminal DONE/CANCELED issues remain untouched.