### PR TITLE
fix(qa): resolve process execution deadlocks and zombie processes

### DIFF
--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -3052,11 +3052,11 @@ class DesktopAppService(
             .redirectErrorStream(true)
             .start()
         val finished = process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)
-        val output = process.inputStream.bufferedReader().readText()
         if (!finished) {
             process.destroyForcibly()
             error("${command.joinToString(" ")} timed out after ${timeoutSeconds}s.")
         }
+        val output = process.inputStream.bufferedReader().readText()
         if (process.exitValue() != 0) {
             error(output.ifBlank { "${command.joinToString(" ")} failed with exit ${process.exitValue()}." })
         }

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
@@ -73,11 +73,11 @@ class LocalPlaywrightBrowserSkillRunner(
                     .start()
                 val timeoutSeconds = command.maxRuntimeSeconds.coerceAtLeast(15).toLong()
                 val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
-                val output = process.inputStream.bufferedReader().readText().trim()
                 if (!finished) {
                     destroyProcessTree(process)
                     error("Browser skill execution timed out after ${timeoutSeconds}s.")
                 }
+                val output = process.inputStream.bufferedReader().readText().trim()
                 if (process.exitValue() != 0) {
                     error(output.ifBlank { "Browser skill execution failed with exit ${process.exitValue()}." })
                 }
@@ -114,11 +114,11 @@ class LocalPlaywrightBrowserSkillRunner(
         val installTimeoutSeconds = timeoutSeconds.coerceAtLeast(120).toLong()
         try {
             val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
-            val output = process.inputStream.bufferedReader().readText().trim()
             if (!finished) {
                 destroyProcessTree(process)
                 error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
             }
+            val output = process.inputStream.bufferedReader().readText().trim()
             if (process.exitValue() != 0) {
                 error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
             }

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
@@ -52,11 +52,11 @@ class LocalPlaywrightMarketingBrowserRunner(
                     .start()
                 val timeoutSeconds = command.maxRuntimeSeconds.coerceAtLeast(15).toLong()
                 val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
-                val output = process.inputStream.bufferedReader().readText().trim()
                 if (!finished) {
                     destroyProcessTree(process)
                     error("Marketing browser execution timed out after ${timeoutSeconds}s.")
                 }
+                val output = process.inputStream.bufferedReader().readText().trim()
                 if (process.exitValue() != 0) {
                     error(output.ifBlank { "Marketing browser execution failed with exit ${process.exitValue()}." })
                 }
@@ -93,11 +93,11 @@ class LocalPlaywrightMarketingBrowserRunner(
         val installTimeoutSeconds = timeoutSeconds.coerceAtLeast(120).toLong()
         try {
             val finished = process.waitFor(installTimeoutSeconds, TimeUnit.SECONDS)
-            val output = process.inputStream.bufferedReader().readText().trim()
             if (!finished) {
                 destroyProcessTree(process)
                 error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
             }
+            val output = process.inputStream.bufferedReader().readText().trim()
             if (process.exitValue() != 0) {
                 error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
             }

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -814,6 +814,7 @@ class DefaultPipelineOrchestrator(
     private fun getGitCommit(): String {
         return try {
             val process = ProcessBuilder("git", "rev-parse", "--short", "HEAD").start()
+            process.waitFor()
             process.inputStream.bufferedReader().readText().trim()
         } catch (e: Exception) {
             "unknown"


### PR DESCRIPTION
## Bug Fixes

This PR fixes multiple process execution bugs found during comprehensive QA testing:

### Issues Fixed

1. **PipelineOrchestrator.getGitCommit() - Zombie Process Bug**
   - Missing `waitFor()` call after starting git process
   - Could leave zombie processes when reading git commit hash
   - Fix: Added `process.waitFor()` before reading output

2. **DesktopAppService.runSkillProcess() - Deadlock Bug**
   - Process output was read BEFORE checking timeout
   - If external command hung, `readText()` would block indefinitely
   - `destroyForcibly()` could never be called due to the blocking read
   - Fix: Check timeout and destroy process BEFORE reading output

3. **LocalPlaywrightBrowserSkillRunner - Deadlock Bugs**
   - Same timeout-check ordering issue in both `execute()` and `ensurePlaywrightDependency()`
   - Browser skill execution and Playwright installation could deadlock on timeout
   - Fix: Reordered timeout check before output read in both methods

4. **LocalPlaywrightMarketingBrowserRunner - Deadlock Bugs**
   - Same timeout-check ordering issue in browser execution and dependency installation
   - Fix: Reordered timeout check before output read in both methods

### Root Cause

The common pattern across all bugs:
```kotlin
val finished = process.waitFor(timeout, TimeUnit.SECONDS)
val output = process.inputStream.bufferedReader().readText() // Blocks if process still running!
if (!finished) {
    process.destroyForcibly() // Never reached if readText() blocks
}
```

When `waitFor(timeout)` returns `false`, the process is still running. `readText()` blocks waiting for EOF (process exit), causing a deadlock. The fix ensures the process is destroyed first.

### Verification

- `./gradlew test --tests com.cotor.app.SkillRuntimeTest --tests com.cotor.app.SkillModelsTest` ✅
- `./gradlew test --tests com.cotor.domain.orchestrator.*` ✅
- `./gradlew formatCheck` ✅
- `swift build --package-path macos` ✅