### PR TITLE
fix(qa): resolve agent execution and orchestration bugs

### DIFF
--- a/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
+++ b/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
@@ -13,6 +13,8 @@ import com.cotor.data.process.ProcessManager
 import com.cotor.model.*
 import com.cotor.monitoring.NoopObservabilityService
 import com.cotor.monitoring.ObservabilityService
+import com.cotor.runtime.actions.ActionApprovalRequiredException
+import com.cotor.runtime.actions.ActionDeniedException
 import com.cotor.runtime.actions.ActionEvidence
 import com.cotor.runtime.actions.ActionExecutionService
 import com.cotor.runtime.actions.ActionKind
@@ -261,9 +263,13 @@ class DefaultAgentExecutor(
                     isSuccess = false,
                     output = e.stdout.takeIf { it.isNotBlank() },
                     error = "$message (exit=${e.exitCode}): $stderr",
-                    duration = 0,
+                    duration = System.currentTimeMillis() - startedAtMs,
                     metadata = observability.failAgent(observation, metadata, System.currentTimeMillis() - startedAtMs, e)
                 )
+            } catch (e: ActionApprovalRequiredException) {
+                throw e
+            } catch (e: ActionDeniedException) {
+                throw e
             } catch (e: Exception) {
                 logAgentFailure("Agent execution failed: ${agent.name}", e)
                 AgentResult(
@@ -271,7 +277,7 @@ class DefaultAgentExecutor(
                     isSuccess = false,
                     output = null,
                     error = e.message ?: "Unknown error",
-                    duration = 0,
+                    duration = System.currentTimeMillis() - startedAtMs,
                     metadata = observability.failAgent(observation, metadata, System.currentTimeMillis() - startedAtMs, e)
                 )
             }

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -555,6 +555,8 @@ class DefaultPipelineOrchestrator(
             } else {
                 recoveryExecutor.executeWithRecovery(stage, input, pipelineContext)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             val failureResult = AgentResult(
                 agentName = agentName,

--- a/src/main/kotlin/com/cotor/recovery/RecoveryExecutor.kt
+++ b/src/main/kotlin/com/cotor/recovery/RecoveryExecutor.kt
@@ -210,16 +210,36 @@ class RecoveryExecutor(
         input: String?,
         pipelineContext: PipelineContext?
     ): AgentResult {
-        val metadata = AgentExecutionMetadata(
-            pipelineContext = pipelineContext,
-            stageId = stage.id
-        )
+        val metadata = if (pipelineContext != null) {
+            AgentExecutionMetadata(
+                pipelineContext = pipelineContext,
+                stageId = stage.id,
+                repoRoot = resolvePath(pipelineContext.metadata["repoRoot"]),
+                workspaceId = pipelineContext.metadata["workspaceId"] as? String,
+                taskId = pipelineContext.metadata["taskId"] as? String,
+                agentId = pipelineContext.metadata["agentId"] as? String ?: agentConfig.name,
+                baseBranch = pipelineContext.metadata["baseBranch"] as? String,
+                branchName = pipelineContext.metadata["branchName"] as? String,
+                workingDirectory = resolvePath(pipelineContext.metadata["workingDirectory"])
+            )
+        } else {
+            AgentExecutionMetadata(
+                pipelineContext = pipelineContext,
+                stageId = stage.id
+            )
+        }
         val result = agentExecutor.executeAgent(agentConfig, input, metadata)
         if (!result.isSuccess && result.metadata["failureCategory"] == null) {
             val updatedMetadata = result.metadata + ("failureCategory" to FailureCategory.AGENT_ERROR.name)
             return applyValidation(stage, result.copy(metadata = updatedMetadata))
         }
         return applyValidation(stage, result)
+    }
+
+    private fun resolvePath(value: Any?): java.nio.file.Path? = when (value) {
+        is java.nio.file.Path -> value
+        is String -> java.nio.file.Path.of(value)
+        else -> null
     }
 
     private fun applyValidation(stage: PipelineStage, result: AgentResult): AgentResult {

--- a/src/main/kotlin/com/cotor/runtime/actions/ActionExecutionService.kt
+++ b/src/main/kotlin/com/cotor/runtime/actions/ActionExecutionService.kt
@@ -45,7 +45,7 @@ class ActionExecutionService(
         block: suspend () -> T
     ): T {
         val runtimeContext = currentCoroutineContext()[DurableRuntimeContext]
-        val runId = request.subject.runId ?: runtimeContext?.runId ?: "standalone"
+        val runId = request.subject.runId ?: runtimeContext?.runId ?: request.id
         val startedAt = System.currentTimeMillis()
         var decisionId: String? = null
 

--- a/src/test/kotlin/com/cotor/runtime/actions/ActionExecutionServiceTest.kt
+++ b/src/test/kotlin/com/cotor/runtime/actions/ActionExecutionServiceTest.kt
@@ -48,14 +48,13 @@ class ActionExecutionServiceTest : FunSpec({
             interceptors = listOf(PolicyEngine(policyStore))
         )
 
+        val request = ActionRequest(
+            kind = ActionKind.GIT_PUBLISH,
+            label = "git.publish:test-branch"
+        )
         val error = runCatching {
             kotlinx.coroutines.runBlocking {
-                service.run(
-                    request = ActionRequest(
-                        kind = ActionKind.GIT_PUBLISH,
-                        label = "git.publish:test-branch"
-                    )
-                ) {
+                service.run(request = request) {
                     "should-not-run"
                 }
             }
@@ -63,7 +62,7 @@ class ActionExecutionServiceTest : FunSpec({
 
         error shouldNotBe null
         (error is ActionDeniedException) shouldBe true
-        val snapshot = actionStore.load("standalone")
+        val snapshot = actionStore.load(request.id)
         snapshot shouldNotBe null
         snapshot!!.records.single().status shouldBe ActionStatus.DENIED
     }


### PR DESCRIPTION
## 발견된 버그

1. **Approval/Cancellation Exception Swallowing** — AgentExecutor의 generic catch(Exception)이 ActionApprovalRequiredException과 ActionDeniedException을 평범한 실패로 변환하여 approval workflow를 망가뜨림.
2. **Pipeline Cancellation Recorded as Failure** — PipelineOrchestrator.runStage의 generic catch가 CancellationException을 잡아서 실패 이벤트로 기록함.
3. **Recovery Metadata Loss** — RecoveryExecutor.runAgent()가 pipelineContext의 worktree/branch metadata를 전달하지 않아 recovery run이 isolation을 잃음.
4. **Action Log Collision** — ActionExecutionService가 fallback runId로 상수 "standalone"을 사용하여 무관한 실행끼리 로그를 덮어씀.
5. **Failure Duration Hard-coded to 0** — 대부분의 실패 경로에서 duration을 0으로 기록하여 성능 지표를 왜곡함.

## 수정 내용

- AgentExecutor: ActionApprovalRequiredException / ActionDeniedException을 rethrow. 실패 시 실제 경과 duration 기록.
- PipelineOrchestrator: runStage에 CancellationException 전용 catch 추가.
- RecoveryExecutor: pipelineContext.metadata에서 repoRoot, workspaceId, taskId, branchName, workingDirectory 등을 추출하여 AgentExecutionMetadata에 전달.
- ActionExecutionService: fallback runId를 request.id로 변경 (고유 UUID).
- ActionExecutionServiceTest: "standalone" 하드코딩을 request.id 기반 assertion으로 수정.

## 재테스트 결과

- ./gradlew test --rerun-tasks: **798 tests PASSED, 0 FAILED**
- swift build --package-path macos: **Build complete**

## 변경 파일

- src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
- src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
- src/main/kotlin/com/cotor/recovery/RecoveryExecutor.kt
- src/main/kotlin/com/cotor/runtime/actions/ActionExecutionService.kt
- src/test/kotlin/com/cotor/runtime/actions/ActionExecutionServiceTest.kt