### PR TITLE
fix(qa): additional skill routing gaps — video-plan, Korean NLP, prewarm, null-safety

### DIFF
--- a/src/main/kotlin/com/cotor/analysis/DefaultResultAnalyzer.kt
+++ b/src/main/kotlin/com/cotor/analysis/DefaultResultAnalyzer.kt
@@ -49,7 +49,9 @@ class DefaultResultAnalyzer : ResultAnalyzer {
             for (j in i + 1 until comparable.size) {
                 val left = comparable[i]
                 val right = comparable[j]
-                val score = similarity(left.output!!, right.output!!)
+                val leftOutput = checkNotNull(left.output) { "Expected non-null output after filtering" }
+                val rightOutput = checkNotNull(right.output) { "Expected non-null output after filtering" }
+                val score = similarity(leftOutput, rightOutput)
                 pairSimilarities += score
                 if (score < 0.4) {
                     disagreements += "Low agreement between ${left.agentName} and ${right.agentName} (${percent(score)})."

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -6890,7 +6890,7 @@ class DesktopAppService(
         )
     }
 
-    private suspend fun resolveOperatorSkillAgent(companyId: String, skillName: String): String? {
+    internal suspend fun resolveOperatorSkillAgent(companyId: String, skillName: String): String? {
         val state = stateStore.load()
         val enabledDefinitions = state.companyAgentDefinitions.filter { it.companyId == companyId && it.enabled }
         data class SkillAgentCandidate(
@@ -6919,7 +6919,6 @@ class DesktopAppService(
             ?: candidates.firstOrNull { it.exactAllowlistMatch }?.definition?.id
             ?: candidates.firstOrNull { it.setting.mode == CapabilityMode.AUTO }?.definition?.id
             ?: candidates.firstOrNull()?.definition?.id
-            ?: enabledDefinitions.firstOrNull()?.id
     }
 
     internal fun inferOperatorSkillName(message: String): String {

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -387,6 +387,7 @@ class DesktopAppService(
 
     init {
         liveServicesForTesting += this
+        serviceScope.launch { runCatching { browserSkillRunner.prewarm() } }
         // Runtime state is persisted across app-server restarts. Reattach loops eagerly
         // on service startup so companies keep progressing even before the UI polls.
         if (autoStartAutomationRefresh) {
@@ -6821,6 +6822,19 @@ class DesktopAppService(
                 ?: toolCall.args["skillName"]
                 ?: inferOperatorSkillName(userMessage)
             ).trim()
+        if (skillName.isBlank()) {
+            val action = OperatorCommandAction(
+                type = "skill-run",
+                title = "Skill name required",
+                detail = "Could not determine which skill to run. Try naming the skill explicitly, e.g. 'run analytics-reporter'.",
+                status = "FAILED_SETUP"
+            )
+            return OperatorChatToolExecution(
+                blockedActions = listOf(action),
+                answerSources = listOf(OperatorAnswerSource("skill-run", action.title, action.detail)),
+                resultLines = listOf("skill: FAILED_SETUP - skill name could not be inferred")
+            )
+        }
         val agentId = toolCall.args["agentId"]?.trim()?.takeIf { it.isNotBlank() }
             ?: resolveOperatorSkillAgent(companyId, skillName)
         if (agentId.isNullOrBlank()) {
@@ -6958,7 +6972,13 @@ class DesktopAppService(
             "audience-scout",
             "analytics",
             "마케팅",
-            "marketing"
+            "marketing",
+            "소셜",
+            "블로그",
+            "cms",
+            "고객",
+            "타깃",
+            "콘텐츠"
         ).any { it in normalized }
         val executionIntent = listOf(
             "run",
@@ -20498,7 +20518,8 @@ class DesktopAppService(
                     "audience-scout",
                     "content-publisher",
                     "social-publisher",
-                    "analytics-reporter"
+                    "analytics-reporter",
+                    "video-plan"
                 ),
                 requiresEvidence = true,
                 requiresReview = false,

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -3057,7 +3057,7 @@ class DesktopAppService(
             process.destroyForcibly()
             error("${command.joinToString(" ")} timed out after ${timeoutSeconds}s.")
         }
-        val output = process.inputStream.bufferedReader().readText()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
         if (process.exitValue() != 0) {
             error(output.ifBlank { "${command.joinToString(" ")} failed with exit ${process.exitValue()}." })
         }

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
@@ -78,7 +78,7 @@ class LocalPlaywrightBrowserSkillRunner(
                     destroyProcessTree(process)
                     error("Browser skill execution timed out after ${timeoutSeconds}s.")
                 }
-                val output = process.inputStream.bufferedReader().readText().trim()
+                val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
                 if (process.exitValue() != 0) {
                     error(output.ifBlank { "Browser skill execution failed with exit ${process.exitValue()}." })
                 }
@@ -129,7 +129,7 @@ class LocalPlaywrightBrowserSkillRunner(
                 destroyProcessTree(process)
                 error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
             }
-            val output = process.inputStream.bufferedReader().readText().trim()
+            val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
             if (process.exitValue() != 0) {
                 error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
             }

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightMarketingBrowserRunner.kt
@@ -56,7 +56,7 @@ class LocalPlaywrightMarketingBrowserRunner(
                     destroyProcessTree(process)
                     error("Marketing browser execution timed out after ${timeoutSeconds}s.")
                 }
-                val output = process.inputStream.bufferedReader().readText().trim()
+                val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
                 if (process.exitValue() != 0) {
                     error(output.ifBlank { "Marketing browser execution failed with exit ${process.exitValue()}." })
                 }
@@ -97,7 +97,7 @@ class LocalPlaywrightMarketingBrowserRunner(
                 destroyProcessTree(process)
                 error("Playwright dependency install timed out after ${installTimeoutSeconds}s.")
             }
-            val output = process.inputStream.bufferedReader().readText().trim()
+            val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
             if (process.exitValue() != 0) {
                 error(output.ifBlank { "Playwright dependency install failed with exit ${process.exitValue()}." })
             }

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadinessResolver.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyIssueReadinessResolver.kt
@@ -182,7 +182,7 @@ object CompanyIssueReadinessResolver {
             durableRunId = readiness.durableRunId ?: issue.durableRunId,
             reason = readiness.reason,
             createdAt = previous?.createdAt ?: now,
-            updatedAt = if (previous.matches(readiness, issue)) previous!!.updatedAt else now
+            updatedAt = previous?.takeIf { it.matches(readiness, issue) }?.updatedAt ?: now
         )
 
     private fun CompanyRuntimeWorkItem?.matches(readiness: CompanyIssueReadinessResolution, issue: CompanyIssue): Boolean =

--- a/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
+++ b/src/main/kotlin/com/cotor/domain/orchestrator/PipelineOrchestrator.kt
@@ -817,7 +817,7 @@ class DefaultPipelineOrchestrator(
         return try {
             val process = ProcessBuilder("git", "rev-parse", "--short", "HEAD").start()
             process.waitFor()
-            process.inputStream.bufferedReader().readText().trim()
+            process.inputStream.bufferedReader().use { it.readText() }.trim()
         } catch (e: Exception) {
             "unknown"
         }

--- a/src/main/kotlin/com/cotor/validation/output/SyntaxValidator.kt
+++ b/src/main/kotlin/com/cotor/validation/output/SyntaxValidator.kt
@@ -35,7 +35,7 @@ class SyntaxValidator {
                 .redirectErrorStream(true)
                 .start()
             val exitCode = process.waitFor()
-            val output = process.inputStream.bufferedReader().readText()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
 
             if (exitCode == 0) {
                 SyntaxValidationResult(true, "$label syntax valid")

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -279,18 +279,20 @@ class SkillRuntimeTest : FunSpec({
         val repoRoot = Files.createDirectories(appHome.resolve("repo"))
         val service = skillRuntimeService(appHome)
         val company = service.createCompany(name = "No Fallback Co", rootPath = repoRoot.toString())
-        val builder = service.listCompanyAgentDefinitions(company.id).first { it.title == "Builder" }
-        service.updateAgentCapabilities(
-            companyId = company.id,
-            agentId = builder.id,
-            settings = mapOf(
-                CapabilityKey.SKILL_RUN to AgentCapabilitySetting(
-                    enabled = true,
-                    mode = CapabilityMode.AUTO,
-                    skillAllowlist = listOf("graphify")
+        val allAgents = service.listCompanyAgentDefinitions(company.id)
+        for (agent in allAgents) {
+            service.updateAgentCapabilities(
+                companyId = company.id,
+                agentId = agent.id,
+                settings = mapOf(
+                    CapabilityKey.SKILL_RUN to AgentCapabilitySetting(
+                        enabled = true,
+                        mode = CapabilityMode.AUTO,
+                        skillAllowlist = listOf("graphify")
+                    )
                 )
             )
-        )
+        }
 
         val agentId = service.resolveOperatorSkillAgent(company.id, "browser-smoke")
 

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -273,6 +273,29 @@ class SkillRuntimeTest : FunSpec({
         }
         prewarmCalled.get() shouldBe true
     }
+
+    test("resolveOperatorSkillAgent does not fall back to an unskilled agent when no allowlist match exists") {
+        val appHome = Files.createTempDirectory("skill-no-fallback-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val service = skillRuntimeService(appHome)
+        val company = service.createCompany(name = "No Fallback Co", rootPath = repoRoot.toString())
+        val builder = service.listCompanyAgentDefinitions(company.id).first { it.title == "Builder" }
+        service.updateAgentCapabilities(
+            companyId = company.id,
+            agentId = builder.id,
+            settings = mapOf(
+                CapabilityKey.SKILL_RUN to AgentCapabilitySetting(
+                    enabled = true,
+                    mode = CapabilityMode.AUTO,
+                    skillAllowlist = listOf("graphify")
+                )
+            )
+        )
+
+        val agentId = service.resolveOperatorSkillAgent(company.id, "browser-smoke")
+
+        agentId shouldBe null
+    }
 })
 
 private fun skillRuntimeService(

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -226,6 +226,53 @@ class SkillRuntimeTest : FunSpec({
         )
         runner.prewarm()
     }
+
+    test("marketing operator skillAllowlist includes video-plan skill") {
+        val appHome = Files.createTempDirectory("skill-mktg-vidplan-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val service = skillRuntimeService(appHome)
+        val company = service.createCompany(name = "Mktg VideoPlan Co", rootPath = repoRoot.toString())
+        val dashboard = service.dashboard()
+        val marketingAgent = dashboard.companyAgentDefinitions.first {
+            it.companyId == company.id && it.title == "Marketing Operator"
+        }
+        val profile = dashboard.agentCapabilityProfiles.first {
+            it.companyId == company.id && it.agentId == marketingAgent.id
+        }
+        val allowlist = profile.settings.getValue(CapabilityKey.SKILL_RUN).skillAllowlist
+
+        allowlist.contains("video-plan") shouldBe true
+        allowlist.contains("analytics-reporter") shouldBe true
+        allowlist.contains("social-publisher") shouldBe true
+    }
+
+    test("looksLikeOperatorSkillRequest matches Korean social and content keywords") {
+        val service = skillRuntimeService(Files.createTempDirectory("nlp-korean-kw-home"))
+
+        service.looksLikeOperatorSkillRequest("소셜 실행해줘") shouldBe true
+        service.looksLikeOperatorSkillRequest("블로그 실행해줘") shouldBe true
+        service.looksLikeOperatorSkillRequest("cms 돌려") shouldBe true
+        service.looksLikeOperatorSkillRequest("고객 타깃 실행") shouldBe true
+        service.looksLikeOperatorSkillRequest("콘텐츠 run") shouldBe true
+        service.looksLikeOperatorSkillRequest("소셜 요약해줘") shouldBe false
+        service.looksLikeOperatorSkillRequest("콘텐츠 보여줘") shouldBe false
+    }
+
+    test("prewarm is called eagerly when service starts") {
+        val appHome = Files.createTempDirectory("prewarm-startup-home")
+        val prewarmCalled = java.util.concurrent.atomic.AtomicBoolean(false)
+        val runner = object : BrowserSkillRunner {
+            override suspend fun execute(command: BrowserSkillCommand): BrowserSkillResult =
+                error("not expected in this test")
+            override suspend fun prewarm() { prewarmCalled.set(true) }
+        }
+        skillRuntimeService(appHome, runner)
+        val deadline = System.currentTimeMillis() + 2_000L
+        while (!prewarmCalled.get() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20)
+        }
+        prewarmCalled.get() shouldBe true
+    }
 })
 
 private fun skillRuntimeService(


### PR DESCRIPTION
## Summary

- Removed unauthorized unskilled-agent fallback in `resolveOperatorSkillAgent` — now returns `null` when no agent has the requested skill allowlisted
- Fixed test to override ALL seeded agent profiles so the no-fallback assertion isn't defeated by the Engineering Lead's pre-seeded `browser-smoke` allowlist
- Fixed `bufferedReader` resource leak across 5 call sites — `process.inputStream.bufferedReader().readText()` is now wrapped with `.use {}` in `LocalPlaywrightBrowserSkillRunner`, `LocalPlaywrightMarketingBrowserRunner`, `DesktopAppService`, `PipelineOrchestrator`, and `SyntaxValidator`

Previous commits on this branch also included:
- `video-plan` added to Marketing Operator skill allowlist
- Korean social/content keywords added to `looksLikeOperatorSkillRequest`
- Blank-skill guard in `runOperatorSkillTool`
- `prewarm()` called eagerly in `DesktopAppService.init`
- Null-safety fixes in `DefaultResultAnalyzer` and `CompanyIssueReadinessResolver`

## Test plan

- [ ] All 807 tests pass (`./gradlew test jacocoTestCoverageVerification`)
- [ ] `resolveOperatorSkillAgent` test overrides all company agents to `["graphify"]` then asserts `browser-smoke` resolves to `null`
- [ ] Bufferedreader `.use {}` wrapping is a pure resource-hygiene fix; no behavior change under normal execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)