### PR TITLE
fix(security): fix P0/P1 issues from direct chat code review

### DIFF
--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -1037,7 +1037,12 @@ struct DesktopAPI {
                     addHeaders(to: &request)
                     request.httpBody = try JSONEncoder().encode(["message": message])
 
-                    let (bytes, _) = try await URLSession.shared.bytes(for: request)
+                    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+                    if let httpResponse = response as? HTTPURLResponse,
+                       !(200...299).contains(httpResponse.statusCode) {
+                        continuation.finish(throwing: URLError(.badServerResponse))
+                        return
+                    }
                     var lineBuffer = Data()
                     for try await byte in bytes {
                         if Task.isCancelled { break }

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -1780,8 +1780,12 @@ internal fun Application.cotorAppModule(
                                 ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "companyId is required"))
                             val conversationId = call.parameters["conversationId"]
                                 ?: return@delete call.respond(HttpStatusCode.BadRequest, mapOf("error" to "conversationId is required"))
-                            desktopService.deleteDirectChatConversation(conversationId, companyId)
-                            call.respond(HttpStatusCode.NoContent)
+                            val deleted = desktopService.deleteDirectChatConversation(conversationId, companyId)
+                            if (deleted) {
+                                call.respond(HttpStatusCode.NoContent)
+                            } else {
+                                call.respond(HttpStatusCode.NotFound, mapOf("error" to "Conversation not found: $conversationId"))
+                            }
                         }
 
                         post("/{conversationId}/messages") {

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -1737,8 +1737,16 @@ internal fun Application.cotorAppModule(
                 route("/{companyId}/direct-chat") {
                     get("/models") {
                         if (!requireToken(token)) return@get
-                        val baseUrl = call.request.queryParameters["baseUrl"] ?: "http://127.0.0.1:11434"
-                        call.respond(desktopService.listDirectChatModels(baseUrl))
+                        val rawBaseUrl = call.request.queryParameters["baseUrl"]
+                            ?.takeIf { it.isNotBlank() } ?: "http://127.0.0.1:11434"
+                        val baseUrlHost = runCatching { java.net.URI.create(rawBaseUrl).host?.lowercase() }.getOrNull()
+                        if (baseUrlHost !in setOf("127.0.0.1", "localhost", "::1")) {
+                            return@get call.respond(
+                                HttpStatusCode.BadRequest,
+                                mapOf("error" to "Only localhost base URLs are allowed")
+                            )
+                        }
+                        call.respond(desktopService.listDirectChatModels(rawBaseUrl))
                     }
 
                     route("/conversations") {
@@ -1784,8 +1792,21 @@ internal fun Application.cotorAppModule(
                                 ?: return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to "conversationId is required"))
                             val request = call.receive<SendDirectChatMessageRequest>()
                             call.respondTextWriter(ContentType.parse("application/x-ndjson")) {
-                                desktopService.streamDirectChatMessage(conversationId, companyId, request.message).collect { chunk ->
-                                    write(streamJson.encodeToString(DirectChatStreamChunk.serializer(), chunk))
+                                try {
+                                    desktopService.streamDirectChatMessage(conversationId, companyId, request.message).collect { chunk ->
+                                        write(streamJson.encodeToString(DirectChatStreamChunk.serializer(), chunk))
+                                        write("\n")
+                                        flush()
+                                    }
+                                } catch (e: Exception) {
+                                    val errChunk = DirectChatStreamChunk(
+                                        conversationId = conversationId,
+                                        messageId = "error",
+                                        content = "",
+                                        done = true,
+                                        error = e.message ?: "Stream failed"
+                                    )
+                                    write(streamJson.encodeToString(DirectChatStreamChunk.serializer(), errChunk))
                                     write("\n")
                                     flush()
                                 }

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -23973,14 +23973,13 @@ class DesktopAppService(
     suspend fun getDirectChatConversation(id: String): DirectChatConversation? =
         stateStore.load().directChatConversations.firstOrNull { it.id == id }
 
-    suspend fun deleteDirectChatConversation(id: String, companyId: String) {
-        stateMutex.withLock {
+    suspend fun deleteDirectChatConversation(id: String, companyId: String): Boolean {
+        return stateMutex.withLock {
             val state = stateStore.load()
             val target = state.directChatConversations.firstOrNull { it.id == id }
-            if (target != null) {
-                require(target.companyId == companyId) {
-                    "Conversation $id does not belong to company $companyId"
-                }
+                ?: return@withLock false
+            require(target.companyId == companyId) {
+                "Conversation $id does not belong to company $companyId"
             }
             stateStore.save(
                 state.copy(
@@ -23988,6 +23987,7 @@ class DesktopAppService(
                         .filterNot { it.id == id && it.companyId == companyId }
                 )
             )
+            true
         }
     }
 
@@ -24048,18 +24048,19 @@ class DesktopAppService(
 
         val assistantMessageId = UUID.randomUUID().toString()
         val contentBuilder = StringBuilder()
-        var streamError: String? = null
+        var assistantSaved = false
 
         directChatService.streamChat(conversation, userMessage, assistantMessageId).collect { chunk ->
             emit(chunk)
             if (chunk.error != null) {
-                streamError = chunk.error
+                return@collect
             } else {
                 contentBuilder.append(chunk.content)
             }
-            if (chunk.done) {
+            if (chunk.done && !assistantSaved) {
                 val assistantContent = contentBuilder.toString()
                 if (assistantContent.isNotEmpty()) {
+                    assistantSaved = true
                     val assistantMsg = DirectChatMessage(
                         id = assistantMessageId,
                         role = "assistant",

--- a/src/main/kotlin/com/cotor/app/DirectChatService.kt
+++ b/src/main/kotlin/com/cotor/app/DirectChatService.kt
@@ -9,6 +9,8 @@ package com.cotor.app
  */
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
@@ -30,7 +32,10 @@ private val directChatHttpThreadCounter = AtomicInteger()
 private val directChatHttpClient: HttpClient = HttpClient.newBuilder()
     .connectTimeout(Duration.ofSeconds(10))
     .executor(
-        java.util.concurrent.Executors.newCachedThreadPool { runnable ->
+        java.util.concurrent.ThreadPoolExecutor(
+            0, 16, 60L, TimeUnit.SECONDS,
+            java.util.concurrent.SynchronousQueue()
+        ) { runnable ->
             Thread(runnable, "cotor-direct-chat-http-${directChatHttpThreadCounter.incrementAndGet()}").apply {
                 isDaemon = true
             }
@@ -144,6 +149,10 @@ class DirectChatService {
             val response = withContext(Dispatchers.IO) {
                 directChatHttpClient.send(request, HttpResponse.BodyHandlers.ofLines())
             }
+            if (response.statusCode() !in 200..299) {
+                error("Ollama request failed with HTTP ${response.statusCode()}")
+            }
+            var doneSent = false
             response.body().use { lineStream ->
                 val iterator = lineStream.iterator()
                 while (withContext(Dispatchers.IO) { iterator.hasNext() }) {
@@ -162,21 +171,26 @@ class DirectChatService {
                                 done = done
                             )
                         )
-                        if (done) break
+                        if (done) {
+                            doneSent = true
+                            break
+                        }
                     } catch (_: Exception) {
                         // skip malformed lines
                     }
                 }
             }
             // ensure done=true is emitted if the stream ended without an explicit done
-            emit(
-                DirectChatStreamChunk(
-                    conversationId = conversation.id,
-                    messageId = messageId,
-                    content = "",
-                    done = true
+            if (!doneSent) {
+                emit(
+                    DirectChatStreamChunk(
+                        conversationId = conversation.id,
+                        messageId = messageId,
+                        content = "",
+                        done = true
+                    )
                 )
-            )
+            }
         } catch (e: Exception) {
             emit(
                 DirectChatStreamChunk(
@@ -219,6 +233,9 @@ class DirectChatService {
 
             val response = withContext(Dispatchers.IO) {
                 directChatHttpClient.send(request, HttpResponse.BodyHandlers.ofLines())
+            }
+            if (response.statusCode() !in 200..299) {
+                error("LM Studio request failed with HTTP ${response.statusCode()}")
             }
             var doneSent = false
             response.body().use { lineStream ->
@@ -297,15 +314,33 @@ class DirectChatService {
         val prompt = buildClaudeCliPrompt(conversation, userMessage)
         try {
             val output = withContext(Dispatchers.IO) {
-                val process = ProcessBuilder("claude", "-p", prompt)
-                    .redirectErrorStream(true)
-                    .start()
-                val text = process.inputStream.bufferedReader().use { it.readText() }
-                if (!process.waitFor(5, TimeUnit.MINUTES)) {
-                    process.destroyForcibly()
-                    error("claude-cli timed out")
+                coroutineScope {
+                    val process = ProcessBuilder("claude", "-p", prompt)
+                        .redirectErrorStream(true)
+                        .start()
+                    // Read and wait concurrently so killing the process unblocks the read
+                    val readJob = async(Dispatchers.IO) {
+                        val sb = StringBuilder()
+                        process.inputStream.bufferedReader().use { reader ->
+                            val buf = CharArray(8192)
+                            var read: Int
+                            while (reader.read(buf).also { read = it } != -1) {
+                                sb.append(buf, 0, read)
+                                if (sb.length > 1_000_000) {
+                                    process.destroyForcibly()
+                                    error("claude-cli output exceeded 1MB limit")
+                                }
+                            }
+                        }
+                        sb.toString()
+                    }
+                    if (!process.waitFor(5, TimeUnit.MINUTES)) {
+                        process.destroyForcibly()
+                        readJob.cancel()
+                        error("claude-cli timed out after 5 minutes")
+                    }
+                    readJob.await()
                 }
-                text
             }
             emit(
                 DirectChatStreamChunk(
@@ -350,7 +385,7 @@ class DirectChatService {
         if (conversation.systemPrompt.isNotBlank()) {
             append("System: ${conversation.systemPrompt}\n\n")
         }
-        conversation.messages.forEach { msg ->
+        conversation.messages.takeLast(40).forEach { msg ->
             val label = if (msg.role == "user") "Human" else "Assistant"
             append("$label: ${msg.content}\n\n")
         }


### PR DESCRIPTION
## Summary

- **P0-1** `streamClaudeCli` 블로킹 타임아웃 수정: `coroutineScope + async`로 `readText`와 `waitFor`를 동시 실행 — `destroyForcibly()` 호출 시 stdout이 닫혀 읽기 스레드도 즉시 종료됨 (기존: `readText` 완료 후에야 `waitFor` 호출)
- **P0-2** `GET /models?baseUrl=` SSRF 방어: 라우트 레벨에서 localhost 검증 추가, 외부 호스트 → 500 대신 400 반환
- **P0-3** claude-cli 출력 크기 제한: 1MB 초과 시 프로세스 강제 종료 (무한 출력으로 인한 OOM 방지)
- **P1-3** HTTP 스레드풀 상한 설정: `newCachedThreadPool` → `ThreadPoolExecutor(max=16)`
- **P1-4** `buildClaudeCliPrompt` 히스토리 제한: `forEach` → `takeLast(40)` (Ollama와 동일하게 통일)
- **P1-5** `respondTextWriter` 에러 핸들링: 스트림 도중 예외 발생 시 에러 청크를 마지막으로 emit해 클라이언트가 정상 종료 여부 판단 가능

## Test plan
- [ ] `./gradlew compileKotlin` → BUILD SUCCESSFUL ✅
- [ ] `GET /models?baseUrl=http://evil.com` → 400 Bad Request
- [ ] `GET /models?baseUrl=http://127.0.0.1:11434` → 정상 응답
- [ ] claude-cli 5분 초과 시 타임아웃 에러 청크 반환
- [ ] claude-cli 1MB 초과 출력 시 에러 청크 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)