### PR TITLE
fix(perf): migrate desktop state to sqlite and harden runtime hot paths

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kaml)
 
+    // Desktop persistence
+    implementation(libs.sqlite.jdbc)
+
     // Dependency Injection
     implementation(libs.koin.core)
 

--- a/docs/TROUBLESHOOTING.ko.md
+++ b/docs/TROUBLESHOOTING.ko.md
@@ -41,7 +41,9 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 - 회사/런타임 백엔드 오류:
   - `~/Library/Application Support/CotorDesktop/runtime/backend/company-runtime-errors.log`
 - 데스크톱 영속 상태:
-  - `~/Library/Application Support/CotorDesktop/state.json`
+  - `~/Library/Application Support/CotorDesktop/state.sqlite`
+  - 마이그레이션 뒤에도 롤백용 `state.json`과 `state.json.bak`은 보존됩니다.
+  - 긴급 롤백 때만 `COTOR_DESKTOP_STATE_BACKEND=json`으로 기존 JSON backend를 사용합니다.
 - 런타임 port/token/pid 파일:
   - `~/Library/Application Support/CotorDesktop/runtime/app-server.port`
   - `~/Library/Application Support/CotorDesktop/runtime/app-server.token`
@@ -67,12 +69,12 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 | --- | --- | --- |
 | `Cotor Desktop could not start its bundled app server.` | stale launcher/backend 상태, 오래된 설치 앱, packaged 앱 불일치 | `desktop-app.log`, `/health`, runtime pid/port 파일 |
 | 회사 `시작` / `중지`를 누르면 앱 전체가 끊긴 것처럼 보임 | 정상 request cancellation을 오프라인으로 잘못 해석 | `desktop-app.log`의 `cancelled` refresh 기록 |
-| 회사 런타임이 계속 실패하거나 같은 이슈가 반복 흔들림 | 영구적인 GitHub readiness 실패, merge conflict, blocked review 상태 | `state.json`, `company-runtime-errors.log`, 리뷰 큐 |
-| 회사 런타임은 `RUNNING`인데 오래 멈춘 것처럼 보임 | 죽었거나 stale인 `RUNNING` task/run 상태와 느린 idle backoff가 겹침 | `state.json`의 runtime `lastAction`, `adaptiveTickMs`, task/run `processId` |
-| 회사는 연결돼 있는데 비용이 오른 뒤 새 작업이 시작되지 않음 | 설정한 일/월 예상 비용 상한에 도달해서 회사 런타임이 스스로 pause 됨 | 회사 요약 배지, `state.json`의 `todaySpentCents` / `monthSpentCents` / `budgetPausedAt` |
+| 회사 런타임이 계속 실패하거나 같은 이슈가 반복 흔들림 | 영구적인 GitHub readiness 실패, merge conflict, blocked review 상태 | `state.sqlite`, `company-runtime-errors.log`, 리뷰 큐 |
+| 회사 런타임은 `RUNNING`인데 오래 멈춘 것처럼 보임 | 죽었거나 stale인 `RUNNING` task/run 상태와 느린 idle backoff가 겹침 | `state.sqlite`의 runtime `lastAction`, `adaptiveTickMs`, task/run `processId` |
+| 회사는 연결돼 있는데 비용이 오른 뒤 새 작업이 시작되지 않음 | 설정한 일/월 예상 비용 상한에 도달해서 회사 런타임이 스스로 pause 됨 | 회사 요약 배지, `state.sqlite`의 `todaySpentCents` / `monthSpentCents` / `budgetPausedAt` |
 | 회사 모드에 `The data is missing.`가 뜨고 live 업데이트가 멈춤 | 회사 dashboard/event payload를 너무 엄격하게 decode했거나, 설치된 앱/app-server가 현재 wire contract보다 오래됨 | 데스크톱 상태 배너, `desktop-app.log`, company dashboard/event 응답 |
-| 회사 이슈가 시작 직후 다시 `BLOCKED`로 떨어지고 Codex `model_not_found`가 보임 | 런타임이 `gpt-5.3-codex-spark` 같은 은퇴된 Codex 모델 id를 아직 호출하고 있음 | `state.json`의 run `error`, company automation trace, live `codex exec --model ...` 프로세스 |
-| QA 이슈가 `BLOCKED`가 됨 | QA가 `CHANGES_REQUESTED`를 반환했고, 보통 PR 증거/검증 문서가 실제 상태와 안 맞음 | GitHub PR review, `state.json`, 연결된 worktree 파일 |
+| 회사 이슈가 시작 직후 다시 `BLOCKED`로 떨어지고 Codex `model_not_found`가 보임 | 런타임이 `gpt-5.3-codex-spark` 같은 은퇴된 Codex 모델 id를 아직 호출하고 있음 | `state.sqlite`의 run `error`, company automation trace, live `codex exec --model ...` 프로세스 |
+| QA 이슈가 `BLOCKED`가 됨 | QA가 `CHANGES_REQUESTED`를 반환했고, 보통 PR 증거/검증 문서가 실제 상태와 안 맞음 | GitHub PR review, `state.sqlite`, 연결된 worktree 파일 |
 | CEO 승인 이후 머지가 끝나지 않음 | self-approval 제한, 실제 merge conflict, stale approval 상태 | GitHub PR 상태, `gh pr view`, runtime error log |
 | 로컬 `master`에 머지 결과가 안 보임 | 원격에서 merge는 됐지만 로컬 branch가 뒤처짐, 또는 실제 merge가 안 됨 | `git status -sb`, `git log --oneline --decorate -5`, `gh pr view` |
 | `cotor` 인터랙티브/TUI가 시작은 되는데 응답이 이상함 | 얇은 PATH, 인증되지 않은 AI CLI, 잘못된 starter 선택 | `interactive.log`, shell PATH, provider 인증 상태 |
@@ -144,7 +146,7 @@ open "/Applications/Cotor Desktop.app" || open "$HOME/Applications/Cotor Desktop
 
 아래를 봅니다.
 
-- `state.json`
+- `state.sqlite`
 - 회사 review queue 항목
 - `company-runtime-errors.log`
 - 선택한 회사의 blocked issue와 최신 PR
@@ -203,7 +205,7 @@ open "/Applications/Cotor Desktop.app" || open "$HOME/Applications/Cotor Desktop
 
 확인 위치:
 
-- `~/Library/Application Support/CotorDesktop/state.json`의 최신 failed run
+- `~/Library/Application Support/CotorDesktop/state.sqlite`의 최신 failed run
 - `~/Library/Application Support/CotorDesktop/runtime/backend/company-automation-trace.log`
 - live `codex exec --model ...` 프로세스를 보는 `ps`
 
@@ -222,7 +224,7 @@ open "/Applications/Cotor Desktop.app" || open "$HOME/Applications/Cotor Desktop
 아래에서 확인하세요.
 
 - 데스크톱 앱의 회사 요약 배지
-- `~/Library/Application Support/CotorDesktop/state.json`의 `todaySpentCents`, `monthSpentCents`, `budgetPausedAt`
+- `~/Library/Application Support/CotorDesktop/state.sqlite`의 `todaySpentCents`, `monthSpentCents`, `budgetPausedAt`
 - 선택한 회사 설정 패널의 현재 상한과 현재 예상 비용 표시
 
 복구 방법은 의도에 따라 다릅니다.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -41,7 +41,9 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 - Company/runtime backend errors:
   - `~/Library/Application Support/CotorDesktop/runtime/backend/company-runtime-errors.log`
 - Desktop persisted state:
-  - `~/Library/Application Support/CotorDesktop/state.json`
+  - `~/Library/Application Support/CotorDesktop/state.sqlite`
+  - legacy rollback copies remain at `state.json` and `state.json.bak` after migration
+  - set `COTOR_DESKTOP_STATE_BACKEND=json` only for emergency rollback to the legacy JSON backend
 - Runtime port/token/pid files:
   - `~/Library/Application Support/CotorDesktop/runtime/app-server.port`
   - `~/Library/Application Support/CotorDesktop/runtime/app-server.token`
@@ -67,12 +69,12 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 | --- | --- | --- |
 | `Cotor Desktop could not start its bundled app server.` | stale launcher/backend state, old install, or packaged app mismatch | `desktop-app.log`, `/health`, runtime pid/port files |
 | Clicking company `Start` / `Stop` makes the app look globally disconnected | benign request cancellation was misread as offline | `desktop-app.log` with `cancelled` refresh entries |
-| Company runtime keeps failing or the same issue keeps bouncing | permanent GitHub readiness failure, merge conflict, or blocked review state | `state.json`, `company-runtime-errors.log`, review queue |
-| Company runtime says `RUNNING` but the company looks stuck for a long time | dead or stale `RUNNING` task/run state combined with idle backoff | `state.json` runtime `lastAction`, `adaptiveTickMs`, task/run `processId` |
-| Company runtime is connected but no new work starts after spend climbs | the company hit its configured daily or monthly estimated spend cap and paused itself | company summary badges, `state.json` runtime `todaySpentCents` / `monthSpentCents` / `budgetPausedAt` |
+| Company runtime keeps failing or the same issue keeps bouncing | permanent GitHub readiness failure, merge conflict, or blocked review state | `state.sqlite`, `company-runtime-errors.log`, review queue |
+| Company runtime says `RUNNING` but the company looks stuck for a long time | dead or stale `RUNNING` task/run state combined with idle backoff | `state.sqlite` runtime `lastAction`, `adaptiveTickMs`, task/run `processId` |
+| Company runtime is connected but no new work starts after spend climbs | the company hit its configured daily or monthly estimated spend cap and paused itself | company summary badges, `state.sqlite` runtime `todaySpentCents` / `monthSpentCents` / `budgetPausedAt` |
 | Company mode shows `The data is missing.` and live updates stop | company dashboard/event payload was decoded too strictly, or the installed app/app-server is older than the current wire contract | desktop status pill, `desktop-app.log`, company dashboard/event responses |
-| Company issues start and immediately fall back to `BLOCKED` with Codex `model_not_found` | the runtime is still trying to call a retired Codex model id such as `gpt-5.3-codex-spark` | `state.json` run `error`, company automation trace, `ps` for live `codex exec --model ...` |
-| QA issue becomes `BLOCKED` | QA returned `CHANGES_REQUESTED`, usually because proof or validation output does not match the PR state | GitHub PR review, `state.json`, linked worktree files |
+| Company issues start and immediately fall back to `BLOCKED` with Codex `model_not_found` | the runtime is still trying to call a retired Codex model id such as `gpt-5.3-codex-spark` | `state.sqlite` run `error`, company automation trace, `ps` for live `codex exec --model ...` |
+| QA issue becomes `BLOCKED` | QA returned `CHANGES_REQUESTED`, usually because proof or validation output does not match the PR state | GitHub PR review, `state.sqlite`, linked worktree files |
 | CEO approval never reaches merge | self-approval restriction, real merge conflict, or stale approval state | GitHub PR status, `gh pr view`, runtime error log |
 | Local `master` does not show merged work | PR merged remotely but local branch is behind, or merge never actually happened | `git status -sb`, `git log --oneline --decorate -5`, `gh pr view` |
 | `cotor` interactive/TUI starts but does not answer well | thin PATH, unauthenticated AI CLI, or wrong starter selection | `interactive.log`, shell PATH, provider auth status |
@@ -144,7 +146,7 @@ Do not treat every company failure as a desktop connectivity problem.
 
 Check:
 
-- `state.json`
+- `state.sqlite`
 - company review queue items
 - `company-runtime-errors.log`
 - the selected company’s blocked issues and latest PRs
@@ -203,7 +205,7 @@ Current builds should:
 
 Confirm with:
 
-- the latest failed run in `~/Library/Application Support/CotorDesktop/state.json`
+- the latest failed run in `~/Library/Application Support/CotorDesktop/state.sqlite`
 - `~/Library/Application Support/CotorDesktop/runtime/backend/company-automation-trace.log`
 - `ps` output for live `codex exec --model ...` commands
 
@@ -222,7 +224,7 @@ When current builds estimate that the company has reached its configured daily o
 Confirm with:
 
 - the company summary badges in the desktop app
-- `todaySpentCents`, `monthSpentCents`, and `budgetPausedAt` in `~/Library/Application Support/CotorDesktop/state.json`
+- `todaySpentCents`, `monthSpentCents`, and `budgetPausedAt` in `~/Library/Application Support/CotorDesktop/state.sqlite`
 - the selected company settings panel, which should show the current cap and the current estimated spend
 
 Recovery depends on intent:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktor = "3.0.3"
 kotest = "5.8.0"
 mockk = "1.13.8"
 jline = "3.26.3"
+sqliteJdbc = "3.53.1.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -40,6 +41,7 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 jline = { module = "org.jline:jline", version.ref = "jline" }
+sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqliteJdbc" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor  (2026-05-26)
+# Graph Report - cotor-qa-auto-performance-20260527  (2026-05-27)
 
 ## Corpus Check
-- 364 files · ~627,478 words
+- 362 files · ~622,352 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4832 nodes · 6761 edges · 308 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 823 edges (avg confidence: 0.8)
+- 4844 nodes · 6737 edges · 308 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 830 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -187,7 +187,6 @@
 - [[_COMMUNITY_Community 174|Community 174]]
 - [[_COMMUNITY_Community 175|Community 175]]
 - [[_COMMUNITY_Community 176|Community 176]]
-- [[_COMMUNITY_Community 177|Community 177]]
 - [[_COMMUNITY_Community 178|Community 178]]
 - [[_COMMUNITY_Community 179|Community 179]]
 - [[_COMMUNITY_Community 180|Community 180]]
@@ -221,7 +220,7 @@
 - [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
 - [[_COMMUNITY_Community 210|Community 210]]
-- [[_COMMUNITY_Community 212|Community 212]]
+- [[_COMMUNITY_Community 211|Community 211]]
 - [[_COMMUNITY_Community 213|Community 213]]
 - [[_COMMUNITY_Community 214|Community 214]]
 - [[_COMMUNITY_Community 215|Community 215]]
@@ -231,7 +230,7 @@
 - [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
-- [[_COMMUNITY_Community 223|Community 223]]
+- [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
 - [[_COMMUNITY_Community 226|Community 226]]
@@ -315,6 +314,7 @@
 - [[_COMMUNITY_Community 304|Community 304]]
 - [[_COMMUNITY_Community 305|Community 305]]
 - [[_COMMUNITY_Community 306|Community 306]]
+- [[_COMMUNITY_Community 307|Community 307]]
 - [[_COMMUNITY_Community 309|Community 309]]
 - [[_COMMUNITY_Community 311|Community 311]]
 - [[_COMMUNITY_Community 312|Community 312]]
@@ -322,14 +322,14 @@
 ## God Nodes (most connected - your core abstractions)
 1. `DesktopStore` - 260 edges
 2. `DesktopTextKey` - 128 edges
-3. `CodingKeys` - 106 edges
-4. `DesktopAPI` - 99 edges
-5. `GitWorkspaceService` - 78 edges
+3. `DesktopAPI` - 109 edges
+4. `CodingKeys` - 106 edges
+5. `GitWorkspaceService` - 79 edges
 6. `DesktopStoreTests` - 69 edges
 7. `language` - 58 edges
-8. `ModelsTests` - 35 edges
-9. `Data` - 34 edges
-10. `DesktopStateStore` - 30 edges
+8. `DesktopStateStore` - 48 edges
+9. `ModelsTests` - 35 edges
+10. `Data` - 34 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `language` --calls--> `userFacingIssueKind()`  [INFERRED]
@@ -338,60 +338,60 @@
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
 - `language` --calls--> `localizedSourceKind()`  [INFERRED]
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `preparedBrandMark()` --calls--> `Data`  [INFERRED]
-  macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+- `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]
+  macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/Models.swift
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.0
-Nodes (50): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+42 more)
+Nodes (52): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+44 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (29): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings(), startCompanyRuntime() (+21 more)
+Cohesion: 0.01
+Nodes (158): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+150 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (261): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+253 more)
+Cohesion: 0.02
+Nodes (19): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+11 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (152): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+144 more)
+Cohesion: 0.02
+Nodes (38): ActionStore, RetryingFileChannel, DirectChatMessage, VideoBaseCommand, AppLogger, CompanySidebarDisclosureState, APIError, http (+30 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.03
-Nodes (16): AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload, nonEmpty(), TestBackendPayload (+8 more)
+Nodes (135): Codable, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, Array, IssueRecord, MeetingRoomAgentResolver (+127 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
-Nodes (127): DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents, appHome, appLocation, appName (+119 more)
+Nodes (158): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+150 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.02
-Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
+Cohesion: 0.01
+Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (39): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+31 more)
+Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, id, label, relation (+116 more)
+Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, label, relation, source (+116 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
 Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.04
-Nodes (20): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Scanner, quotedGoal(), EmbeddedBackendHealthPayload (+12 more)
+Cohesion: 0.02
+Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+72 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (79): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+71 more)
+Cohesion: 0.04
+Nodes (19): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+11 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
@@ -407,39 +407,39 @@ Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, Meet
 
 ### Community 15 - "Community 15"
 Cohesion: 0.05
-Nodes (49): ChatAgentProposal, ChatBackendAction, restart, start, stop, ChatBackendProposal, ChatCompanyRequestProposal, ChatDelegationProposal (+41 more)
+Nodes (21): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView, WebView (+13 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.04
-Nodes (48): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+40 more)
+Nodes (4): CachedState, DesktopStateStore, SqliteCachedState, StateCollection
 
 ### Community 17 - "Community 17"
 Cohesion: 0.04
-Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
+Nodes (52): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+44 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
+Cohesion: 0.1
+Nodes (5): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DesktopStoreTests
 
 ### Community 19 - "Community 19"
-Cohesion: 0.13
-Nodes (4): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, Color
+Cohesion: 0.04
+Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
 ### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
+Cohesion: 0.13
+Nodes (3): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas
 
 ### Community 22 - "Community 22"
 Cohesion: 0.06
-Nodes (2): CachedState, DesktopStateStore
+Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
 ### Community 23 - "Community 23"
 Cohesion: 0.06
-Nodes (7): FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
+Nodes (8): ConcurrentGitMutationProcessManager, FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
 
 ### Community 24 - "Community 24"
 Cohesion: 0.06
@@ -459,43 +459,43 @@ Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipe
 
 ### Community 28 - "Community 28"
 Cohesion: 0.07
-Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
+Nodes (8): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, LateProcessStartAgentExecutor, SyncCall
 
 ### Community 29 - "Community 29"
-Cohesion: 0.08
-Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
+Cohesion: 0.07
+Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
 ### Community 30 - "Community 30"
-Cohesion: 0.15
-Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
+Cohesion: 0.08
+Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
 ### Community 32 - "Community 32"
-Cohesion: 0.08
-Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
-
-### Community 33 - "Community 33"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 35 - "Community 35"
+### Community 34 - "Community 34"
 Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
-### Community 36 - "Community 36"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, StageExecution, StageStats, StatsDetails, StatsManager (+1 more)
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
+
+### Community 37 - "Community 37"
+Cohesion: 0.11
+Nodes (3): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel
 
 ### Community 38 - "Community 38"
 Cohesion: 0.11
@@ -503,39 +503,39 @@ Nodes (2): CoroutineProcessManager, ProcessManager
 
 ### Community 39 - "Community 39"
 Cohesion: 0.11
-Nodes (1): Parser
-
-### Community 40 - "Community 40"
-Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.12
 Nodes (1): A2aRouter
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (1): DurableRuntimeService
 
-### Community 43 - "Community 43"
+### Community 42 - "Community 42"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
 
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.12
 Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (1): AgentCapabilityGuard
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
+
+### Community 47 - "Community 47"
+Cohesion: 0.12
+Nodes (1): RecoveryExecutor
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
@@ -547,103 +547,103 @@ Nodes (1): StarterAgentSpec
 
 ### Community 50 - "Community 50"
 Cohesion: 0.13
-Nodes (14): LocalProposalKind, agent, backend, companyRequest, decomposition, delegation, execution, generalNote (+6 more)
+Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
 ### Community 51 - "Community 51"
 Cohesion: 0.13
-Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
+Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
 ### Community 52 - "Community 52"
 Cohesion: 0.13
-Nodes (1): RecoveryExecutor
-
-### Community 53 - "Community 53"
-Cohesion: 0.13
-Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
-
-### Community 54 - "Community 54"
-Cohesion: 0.13
 Nodes (1): ConditionEvaluator
 
-### Community 55 - "Community 55"
+### Community 53 - "Community 53"
 Cohesion: 0.14
 Nodes (1): BoardControllerTest
 
-### Community 56 - "Community 56"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
-### Community 57 - "Community 57"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
-### Community 58 - "Community 58"
+### Community 56 - "Community 56"
 Cohesion: 0.14
 Nodes (2): DefaultSecurityValidator, SecurityValidator
 
-### Community 59 - "Community 59"
+### Community 57 - "Community 57"
 Cohesion: 0.14
 Nodes (1): DurableRuntimeStore
 
-### Community 60 - "Community 60"
+### Community 58 - "Community 58"
 Cohesion: 0.14
 Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
-### Community 61 - "Community 61"
+### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
-### Community 62 - "Community 62"
+### Community 60 - "Community 60"
 Cohesion: 0.14
 Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
-### Community 63 - "Community 63"
+### Community 61 - "Community 61"
 Cohesion: 0.15
 Nodes (12): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, ReplayApprovalRequiredException (+4 more)
 
-### Community 64 - "Community 64"
+### Community 62 - "Community 62"
 Cohesion: 0.15
 Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
-### Community 65 - "Community 65"
+### Community 63 - "Community 63"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
-### Community 66 - "Community 66"
+### Community 64 - "Community 64"
 Cohesion: 0.17
 Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
-### Community 67 - "Community 67"
+### Community 65 - "Community 65"
 Cohesion: 0.17
 Nodes (1): GoalDrivenTaskPlannerTest
 
-### Community 68 - "Community 68"
+### Community 66 - "Community 66"
 Cohesion: 0.17
 Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
-### Community 69 - "Community 69"
+### Community 67 - "Community 67"
 Cohesion: 0.17
 Nodes (11): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionRequest, ActionResult (+3 more)
 
-### Community 70 - "Community 70"
+### Community 68 - "Community 68"
 Cohesion: 0.17
 Nodes (4): PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
-### Community 71 - "Community 71"
+### Community 69 - "Community 69"
 Cohesion: 0.17
 Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
-### Community 72 - "Community 72"
+### Community 70 - "Community 70"
 Cohesion: 0.18
 Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
-### Community 73 - "Community 73"
+### Community 71 - "Community 71"
 Cohesion: 0.18
 Nodes (1): BoardServiceTest
 
-### Community 74 - "Community 74"
+### Community 72 - "Community 72"
+Cohesion: 0.18
+Nodes (1): DirectChatService
+
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+
+### Community 74 - "Community 74"
+Cohesion: 0.18
+Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
 ### Community 75 - "Community 75"
 Cohesion: 0.18
@@ -679,27 +679,27 @@ Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (3): CoroutineEventBus, EventBus, EventSubscription
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (1): StatsCommand
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
-Nodes (1): DoctorCommand
+Nodes (1): StatsCommand
 
 ### Community 86 - "Community 86"
-Cohesion: 0.2
-Nodes (1): TemplateEngineTest
+Cohesion: 0.18
+Nodes (1): DoctorCommand
 
 ### Community 87 - "Community 87"
 Cohesion: 0.2
-Nodes (1): ChatTranscriptWriter
+Nodes (1): TemplateEngineTest
 
 ### Community 88 - "Community 88"
 Cohesion: 0.2
-Nodes (1): A2aArtifactStore
+Nodes (1): ChatTranscriptWriter
 
 ### Community 89 - "Community 89"
 Cohesion: 0.2
@@ -735,267 +735,267 @@ Nodes (1): BoardService
 
 ### Community 97 - "Community 97"
 Cohesion: 0.22
-Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
+Nodes (3): RecordingBrowserSkillRunner, RecordingSecurityValidator, SkillRuntimeTest
 
 ### Community 98 - "Community 98"
 Cohesion: 0.22
-Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
+Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
 ### Community 99 - "Community 99"
 Cohesion: 0.22
-Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
+Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
 ### Community 100 - "Community 100"
 Cohesion: 0.22
-Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
+Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
 
 ### Community 101 - "Community 101"
 Cohesion: 0.22
-Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
+Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
 ### Community 102 - "Community 102"
 Cohesion: 0.22
-Nodes (1): LocalModelDefaults
+Nodes (3): BoundCompanyRuntime, CachedValue, CompanyRuntimeBindingService
 
 ### Community 103 - "Community 103"
 Cohesion: 0.22
-Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
+Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
 ### Community 104 - "Community 104"
 Cohesion: 0.22
-Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
+Nodes (1): LocalModelDefaults
 
 ### Community 105 - "Community 105"
 Cohesion: 0.22
-Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
+Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
 ### Community 106 - "Community 106"
-Cohesion: 0.25
-Nodes (1): BoardController
+Cohesion: 0.22
+Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
 ### Community 107 - "Community 107"
-Cohesion: 0.25
-Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
+Cohesion: 0.22
+Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
 ### Community 108 - "Community 108"
 Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+Nodes (1): DesktopAppServiceRuntimeCleanupTest
 
 ### Community 109 - "Community 109"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (1): BoardController
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
 ### Community 111 - "Community 111"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (1): CompanyIssueReadiness
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (1): ChatSession
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (2): Linter, LintResult
+Nodes (1): OpenCodeDefaults
 
 ### Community 116 - "Community 116"
 Cohesion: 0.25
-Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
+Nodes (2): JsonParser, YamlParser
 
 ### Community 117 - "Community 117"
-Cohesion: 0.29
-Nodes (1): ActionStore
+Cohesion: 0.25
+Nodes (1): DiagramGenerator
 
 ### Community 118 - "Community 118"
-Cohesion: 0.29
-Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
+Cohesion: 0.25
+Nodes (2): Linter, LintResult
 
 ### Community 119 - "Community 119"
-Cohesion: 0.29
-Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
+Cohesion: 0.25
+Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
 ### Community 120 - "Community 120"
 Cohesion: 0.29
-Nodes (1): LocalModelPluginTest
+Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
 ### Community 121 - "Community 121"
 Cohesion: 0.29
-Nodes (1): DefaultResultAnalyzer
+Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
 ### Community 122 - "Community 122"
 Cohesion: 0.29
-Nodes (2): A2aDedupeStore, StoredAck
+Nodes (1): LocalModelPluginTest
 
 ### Community 123 - "Community 123"
 Cohesion: 0.29
-Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
+Nodes (1): DefaultResultAnalyzer
 
 ### Community 124 - "Community 124"
 Cohesion: 0.29
-Nodes (2): A2aSessionPersistenceStore, Snapshot
+Nodes (2): A2aDedupeStore, StoredAck
 
 ### Community 125 - "Community 125"
 Cohesion: 0.29
-Nodes (1): DurableResumeCoordinator
+Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
 ### Community 126 - "Community 126"
 Cohesion: 0.29
-Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
+Nodes (2): A2aSessionPersistenceStore, Snapshot
 
 ### Community 127 - "Community 127"
 Cohesion: 0.29
-Nodes (1): FileReaderPlugin
+Nodes (1): DurableResumeCoordinator
 
 ### Community 128 - "Community 128"
 Cohesion: 0.29
-Nodes (1): OpenAIPlugin
+Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
 ### Community 129 - "Community 129"
 Cohesion: 0.29
-Nodes (1): InteractiveCommandCompleter
+Nodes (1): FileReaderPlugin
 
 ### Community 130 - "Community 130"
 Cohesion: 0.29
-Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
+Nodes (1): OpenAIPlugin
 
 ### Community 131 - "Community 131"
-Cohesion: 0.33
-Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
+Cohesion: 0.29
+Nodes (1): InteractiveCommandCompleter
 
 ### Community 132 - "Community 132"
-Cohesion: 0.33
-Nodes (1): CompanyRuntimeBindingServiceTest
+Cohesion: 0.29
+Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
 ### Community 133 - "Community 133"
 Cohesion: 0.33
-Nodes (1): ProductionReliabilityBaselineTest
+Nodes (1): DesktopStateStoreTest
 
 ### Community 134 - "Community 134"
 Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
+Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
 ### Community 135 - "Community 135"
 Cohesion: 0.33
-Nodes (2): CompanyVerificationDecision, CompanyVerifierService
+Nodes (1): CompanyRuntimeBindingServiceTest
 
 ### Community 136 - "Community 136"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (1): ProductionReliabilityBaselineTest
 
 ### Community 137 - "Community 137"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 138 - "Community 138"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (1): GitHubControlPlaneService
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
+Nodes (1): QaVerificationPlugin
 
 ### Community 141 - "Community 141"
 Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): CommandPlugin
 
 ### Community 142 - "Community 142"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 143 - "Community 143"
-Cohesion: 0.4
-Nodes (3): find_primes(), find_primes_up_to_n(), N까지의 모든 소수를 찾는 함수 (에라토스테네스의 체 알고리즘 사용)      :param n: 소수를 찾을 범위의 상한값 (n > 1)
+Cohesion: 0.33
+Nodes (1): CodexDashboardCommand
 
 ### Community 144 - "Community 144"
-Cohesion: 0.4
-Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
+Cohesion: 0.33
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 145 - "Community 145"
-Cohesion: 0.4
-Nodes (1): OpenCodePluginTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 146 - "Community 146"
 Cohesion: 0.4
-Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
+Nodes (1): OpenCodePluginTest
 
 ### Community 147 - "Community 147"
 Cohesion: 0.4
-Nodes (1): CliGoldenSnapshotTest
+Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
 ### Community 148 - "Community 148"
 Cohesion: 0.4
-Nodes (1): DesktopEndpointPolicy
+Nodes (1): CliGoldenSnapshotTest
 
 ### Community 149 - "Community 149"
 Cohesion: 0.4
-Nodes (1): LocalPlaywrightMarketingBrowserRunner
+Nodes (1): DesktopEndpointPolicy
 
 ### Community 150 - "Community 150"
 Cohesion: 0.4
-Nodes (1): EvidencePathPolicy
+Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
 ### Community 151 - "Community 151"
 Cohesion: 0.4
-Nodes (1): CompanyRuntimeMachine
+Nodes (1): EvidencePathPolicy
 
 ### Community 152 - "Community 152"
 Cohesion: 0.4
-Nodes (1): WorkQueue
+Nodes (1): CompanyRuntimeMachine
 
 ### Community 153 - "Community 153"
 Cohesion: 0.4
-Nodes (1): NetworkEndpointPolicy
+Nodes (1): WorkQueue
 
 ### Community 154 - "Community 154"
 Cohesion: 0.4
-Nodes (1): CheckpointGraphStore
+Nodes (1): NetworkEndpointPolicy
 
 ### Community 155 - "Community 155"
 Cohesion: 0.4
-Nodes (1): SideEffectJournalStore
+Nodes (1): CheckpointGraphStore
 
 ### Community 156 - "Community 156"
 Cohesion: 0.4
-Nodes (1): ProvenanceStore
+Nodes (1): SideEffectJournalStore
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (1): CodexDefaults
+Nodes (1): ProvenanceStore
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
-Nodes (1): CotorHttpClients
+Nodes (1): CodexDefaults
 
 ### Community 159 - "Community 159"
 Cohesion: 0.4
-Nodes (2): StuckDetector, StuckSignal
+Nodes (1): CotorHttpClients
 
 ### Community 160 - "Community 160"
 Cohesion: 0.4
-Nodes (1): AppServerCommand
+Nodes (2): StuckDetector, StuckSignal
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
-Nodes (2): SyntaxValidationResult, SyntaxValidator
+Nodes (1): AppServerCommand
 
 ### Community 162 - "Community 162"
-Cohesion: 0.5
-Nodes (1): findPrimes()
+Cohesion: 0.4
+Nodes (2): SyntaxValidationResult, SyntaxValidator
 
 ### Community 163 - "Community 163"
 Cohesion: 0.5
@@ -1023,295 +1023,291 @@ Nodes (1): Post
 
 ### Community 169 - "Community 169"
 Cohesion: 0.5
-Nodes (1): AgentCapabilityGuardTest
+Nodes (1): findPrimes()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceOwnershipTest
+Nodes (1): AgentCapabilityGuardTest
 
 ### Community 171 - "Community 171"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceAgentModelNormalizationTest
+Nodes (1): DesktopAppServiceOwnershipTest
 
 ### Community 172 - "Community 172"
 Cohesion: 0.5
-Nodes (2): CapturingProcessManager, QaVerificationPluginTest
+Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
 ### Community 173 - "Community 173"
 Cohesion: 0.5
-Nodes (2): CommandPluginTest, RecordingProcessManager
+Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
 ### Community 174 - "Community 174"
 Cohesion: 0.5
-Nodes (2): FileReaderPluginTest, NoopProcessManager
+Nodes (2): CommandPluginTest, RecordingProcessManager
 
 ### Community 175 - "Community 175"
 Cohesion: 0.5
-Nodes (1): PipelineOrchestratorPropertyTest
+Nodes (2): FileReaderPluginTest, NoopProcessManager
 
 ### Community 176 - "Community 176"
 Cohesion: 0.5
-Nodes (2): ProviderCatalogEntry, ProviderScanResult
-
-### Community 177 - "Community 177"
-Cohesion: 0.5
-Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
+Nodes (1): PipelineOrchestratorPropertyTest
 
 ### Community 178 - "Community 178"
 Cohesion: 0.5
-Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
+Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
 ### Community 179 - "Community 179"
 Cohesion: 0.5
-Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
+Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
-Nodes (1): StateRepository
+Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (3): ChatMessage, ChatMode, ChatRole
+Nodes (1): StateRepository
 
 ### Community 182 - "Community 182"
 Cohesion: 0.5
-Nodes (1): DurableRuntimeFlags
+Nodes (3): ChatMessage, ChatMode, ChatRole
 
 ### Community 183 - "Community 183"
 Cohesion: 0.5
-Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
+Nodes (1): DurableRuntimeFlags
 
 ### Community 184 - "Community 184"
 Cohesion: 0.5
-Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
+Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
-Nodes (2): TimelineCollector, TimelineResult
+Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
 ### Community 186 - "Community 186"
 Cohesion: 0.5
-Nodes (1): StageConflictDetector
+Nodes (2): TimelineCollector, TimelineResult
 
 ### Community 187 - "Community 187"
 Cohesion: 0.5
-Nodes (1): SimpleCLI
+Nodes (1): StageConflictDetector
 
 ### Community 188 - "Community 188"
 Cohesion: 0.5
-Nodes (2): OutputValidator, StageValidationOutcome
+Nodes (1): SimpleCLI
 
 ### Community 189 - "Community 189"
-Cohesion: 0.67
-Nodes (1): PostCreateRequest
+Cohesion: 0.5
+Nodes (2): OutputValidator, StageValidationOutcome
 
 ### Community 190 - "Community 190"
 Cohesion: 0.67
-Nodes (1): PostUpdateRequest
+Nodes (1): PostCreateRequest
 
 ### Community 191 - "Community 191"
 Cohesion: 0.67
-Nodes (1): VersionConflictException
+Nodes (1): PostUpdateRequest
 
 ### Community 192 - "Community 192"
 Cohesion: 0.67
-Nodes (1): PostNotFoundException
+Nodes (1): VersionConflictException
 
 ### Community 193 - "Community 193"
 Cohesion: 0.67
-Nodes (1): PermissionDeniedException
+Nodes (1): PostNotFoundException
 
 ### Community 194 - "Community 194"
 Cohesion: 0.67
-Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
+Nodes (1): PermissionDeniedException
 
 ### Community 195 - "Community 195"
 Cohesion: 0.67
-Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
+Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
 ### Community 196 - "Community 196"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIntegrationHarness
+Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
 ### Community 197 - "Community 197"
 Cohesion: 0.67
-Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
+Nodes (1): DesktopAppServiceIntegrationHarness
 
 ### Community 198 - "Community 198"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceExecutionMemoryTest
+Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
 ### Community 199 - "Community 199"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
+Nodes (1): DesktopAppServiceExecutionMemoryTest
 
 ### Community 200 - "Community 200"
 Cohesion: 0.67
-Nodes (1): CheckpointFixtureProcess
+Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
 ### Community 201 - "Community 201"
 Cohesion: 0.67
-Nodes (1): CheckpointResumeIntegrationTest
+Nodes (1): CheckpointFixtureProcess
 
 ### Community 202 - "Community 202"
 Cohesion: 0.67
-Nodes (1): RuntimeConstructorConsistencyTest
+Nodes (1): CheckpointResumeIntegrationTest
 
 ### Community 203 - "Community 203"
 Cohesion: 0.67
-Nodes (1): PipelineOrchestratorMapTest
+Nodes (1): RuntimeConstructorConsistencyTest
 
 ### Community 204 - "Community 204"
 Cohesion: 0.67
-Nodes (1): TemplateCommandTest
+Nodes (1): PipelineOrchestratorMapTest
 
 ### Community 205 - "Community 205"
 Cohesion: 0.67
-Nodes (1): InitCommandTest
+Nodes (1): TemplateCommandTest
 
 ### Community 206 - "Community 206"
 Cohesion: 0.67
-Nodes (1): ValidateCommandTest
+Nodes (1): InitCommandTest
 
 ### Community 207 - "Community 207"
 Cohesion: 0.67
-Nodes (1): DesktopLifecycleCommandTest
+Nodes (1): ValidateCommandTest
 
 ### Community 208 - "Community 208"
 Cohesion: 0.67
-Nodes (1): ResultAnalyzer
+Nodes (1): DesktopLifecycleCommandTest
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
+Nodes (1): ResultAnalyzer
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (2): VideoPlanRequest, VideoPlanResult
+Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 212 - "Community 212"
+### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (1): DurableRuntimeContext
+Nodes (2): VideoPlanRequest, VideoPlanResult
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
-Nodes (1): HelloCommand
+Nodes (1): DurableRuntimeContext
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
-Nodes (1): WebCommand
+Nodes (1): HelloCommand
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (1): LintCommand
+Nodes (1): WebCommand
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (1): ExplainCommand
+Nodes (1): LintCommand
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): CheckpointGCCommand
+Nodes (1): ExplainCommand
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
-Nodes (2): StageTimelineEntry, StageTimelineState
+Nodes (1): CheckpointGCCommand
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (1): PipelineTemplateValidator
+Nodes (2): StageTimelineEntry, StageTimelineState
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
-Nodes (1): DefaultOutputValidator
+Nodes (1): PipelineTemplateValidator
 
 ### Community 221 - "Community 221"
+Cohesion: 0.67
+Nodes (1): DefaultOutputValidator
+
+### Community 222 - "Community 222"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 1.0
 Nodes (1): KotestProjectConfig
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 242 - "Community 242"
-Cohesion: 1.0
-Nodes (1): DesktopAppServiceMergeConfirmationTest
-
 ### Community 243 - "Community 243"
 Cohesion: 1.0
-Nodes (1): DesktopStateStoreTest
+Nodes (1): DesktopAppServiceMergeConfirmationTest
 
 ### Community 244 - "Community 244"
 Cohesion: 1.0
@@ -1331,237 +1327,241 @@ Nodes (1): CompanyRuntimeMachineTest
 
 ### Community 248 - "Community 248"
 Cohesion: 1.0
-Nodes (1): ChatTranscriptWriterTest
+Nodes (1): WorkQueueTest
 
 ### Community 249 - "Community 249"
 Cohesion: 1.0
-Nodes (1): ChatSessionTest
+Nodes (1): ChatTranscriptWriterTest
 
 ### Community 250 - "Community 250"
 Cohesion: 1.0
-Nodes (1): NetworkEndpointPolicyTest
+Nodes (1): ChatSessionTest
 
 ### Community 251 - "Community 251"
 Cohesion: 1.0
-Nodes (1): SecurityValidatorTest
+Nodes (1): NetworkEndpointPolicyTest
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (1): A2aArtifactStoreTest
+Nodes (1): SecurityValidatorTest
 
 ### Community 253 - "Community 253"
 Cohesion: 1.0
-Nodes (1): A2aApiTest
+Nodes (1): A2aArtifactStoreTest
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (1): A2aSessionStoreTest
+Nodes (1): A2aApiTest
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (1): A2aDedupeStoreTest
+Nodes (1): A2aSessionStoreTest
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (1): RecoveryExecutorTest
+Nodes (1): A2aDedupeStoreTest
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): GitHubControlPlaneServiceTest
+Nodes (1): RecoveryExecutorTest
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): StoreConcurrencyTest
+Nodes (1): GitHubControlPlaneServiceTest
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): DurableRuntimeServiceTest
+Nodes (1): StoreConcurrencyTest
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): DurableResumeCoordinatorTest
+Nodes (1): DurableRuntimeServiceTest
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): ActionExecutionServiceTest
+Nodes (1): DurableResumeCoordinatorTest
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (1): LinearClientEndpointPolicyTest
+Nodes (1): ActionExecutionServiceTest
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): VerificationBundleServiceTest
+Nodes (1): LinearClientEndpointPolicyTest
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): KnowledgeServiceTest
+Nodes (1): VerificationBundleServiceTest
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): LocalModelDefaultsTest
+Nodes (1): KnowledgeServiceTest
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): ObservabilityServiceTest
+Nodes (1): LocalModelDefaultsTest
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): FileConfigRepositoryTest
+Nodes (1): ObservabilityServiceTest
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): QaTestGenerationFixtureTest
+Nodes (1): FileConfigRepositoryTest
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): ConfigRepositoryImportTest
+Nodes (1): QaTestGenerationFixtureTest
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): ExampleConfigSmokeTest
+Nodes (1): ConfigRepositoryImportTest
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): YamlParserTest
+Nodes (1): ExampleConfigSmokeTest
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): CodexPluginTest
+Nodes (1): YamlParserTest
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): CotorHttpClientsTest
+Nodes (1): CodexPluginTest
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): ProcessManagerTest
+Nodes (1): CotorHttpClientsTest
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): ErrorHelperTest
+Nodes (1): ProcessManagerTest
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): ResultAggregatorTest
+Nodes (1): ErrorHelperTest
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): ConditionEvaluatorTest
+Nodes (1): ResultAggregatorTest
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): AgentExecutorTest
+Nodes (1): ConditionEvaluatorTest
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): StuckDetectorTest
+Nodes (1): AgentExecutorTest
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): PipelineGuardServiceTest
+Nodes (1): StuckDetectorTest
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorDagValidationTest
+Nodes (1): PipelineGuardServiceTest
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): StageConflictDetectorTest
+Nodes (1): PipelineOrchestratorDagValidationTest
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorTemplatingTest
+Nodes (1): StageConflictDetectorTest
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): CoroutineEventBusTest
+Nodes (1): PipelineOrchestratorTemplatingTest
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): WebServerTest
+Nodes (1): CoroutineEventBusTest
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): CompletionCommandTest
+Nodes (1): WebServerTest
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): HelpCommandTest
+Nodes (1): CompletionCommandTest
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): AppServerCommandTest
+Nodes (1): HelpCommandTest
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): StarterAgentResolverTest
+Nodes (1): AppServerCommandTest
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandCompleterTest
+Nodes (1): StarterAgentResolverTest
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): AgentCommandTest
+Nodes (1): InteractiveCommandCompleterTest
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): PluginCommandTest
+Nodes (1): AgentCommandTest
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): AuthCommandTest
+Nodes (1): PluginCommandTest
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): HelloCommandTest
+Nodes (1): AuthCommandTest
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): LintCommandTest
+Nodes (1): HelloCommandTest
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): CompanyCommandTest
+Nodes (1): LintCommandTest
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandTest
+Nodes (1): CompanyCommandTest
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): StatsCommandTest
+Nodes (1): InteractiveCommandTest
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): CodexDashboardCommandTest
+Nodes (1): StatsCommandTest
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): StatsManagerTest
+Nodes (1): CodexDashboardCommandTest
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorTest
+Nodes (1): StatsManagerTest
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorExtTest
+Nodes (1): PipelineValidatorTest
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): LinterTest
+Nodes (1): PipelineValidatorExtTest
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): DefaultOutputValidatorTest
+Nodes (1): LinterTest
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): PolicyEngineTest
+Nodes (1): DefaultOutputValidatorTest
 
 ### Community 306 - "Community 306"
+Cohesion: 1.0
+Nodes (1): PolicyEngineTest
+
+### Community 307 - "Community 307"
 Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
@@ -1578,49 +1578,47 @@ Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **1002 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+997 more)
+- **992 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+987 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 22`** (34 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendStateLoadLog()`, `.appHome()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.moveWithAtomicFallback()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 25`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 29`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 31`** (25 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 38`** (18 nodes): `buildEffectivePath()`, `cleanupSurvivingDescendants()`, `CoroutineProcessManager`, `.executeProcess()`, `.executeProcessInternal()`, `.executeProcessWithInputFile()`, `destroyProcessTree()`, `effectiveUserHome()`, `joinReader()`, `ProcessManager`, `.executeProcess()`, `.executeProcessWithInputFile()`, `redactedCommandForLogs()`, `resolveExecutablePath()`, `resolveProcessCommand()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessManager.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (18 nodes): `Parser`, `.advance()`, `.and()`, `.check()`, `.comparison()`, `.consume()`, `.equality()`, `.expression()`, `.isAtEnd()`, `.match()`, `.or()`, `.parse()`, `.peek()`, `.previous()`, `.primary()`, `.term()`, `.unary()`, `Parser.kt`
+- **Thin community `Community 39`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 40`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 40`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 41`** (17 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `A2aRouter.kt`
+- **Thin community `Community 41`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (17 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 42`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 45`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 47`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 49`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (15 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 52`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 53`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 55`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 56`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
+- **Thin community `Community 57`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (14 nodes): `defaultDurableRuntimeRoot()`, `DurableRuntimeStore`, `.deleteRun()`, `.listRuns()`, `.loadRun()`, `.loadRunUnlocked()`, `.replaceRun()`, `.runPath()`, `.runsDir()`, `.saveRun()`, `.updateRun()`, `.withRunLock()`, `.writeRun()`, `DurableRuntimeStore.kt`
+- **Thin community `Community 62`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 64`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 65`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 71`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 73`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 72`** (11 nodes): `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 73`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 76`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1628,15 +1626,13 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 82`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 85`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 86`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 87`** (10 nodes): `TemplateEngineTest`, `.setUp()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (10 nodes): `A2aArtifactStore`, `.append()`, `.count()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `.scopedOpsMetrics()`, `A2aArtifactStore.kt`
+- **Thin community `Community 88`** (10 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 90`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1646,109 +1642,109 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 96`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 102`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 100`** (9 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `AutonomousDiscoveryService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 106`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 104`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 107`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 108`** (8 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 109`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 110`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 112`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 113`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 114`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 115`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 116`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (7 nodes): `ActionStore`, `.actionsDir()`, `.listSnapshots()`, `.load()`, `.replace()`, `.save()`, `ActionStore.kt`
+- **Thin community `Community 117`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 118`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 121`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 122`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 123`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 124`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 125`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 126`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 127`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 129`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 130`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 131`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 133`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 134`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 135`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 136`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 137`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 138`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 139`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 140`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 141`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 142`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 143`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 144`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 145`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 146`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 147`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 148`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 149`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 150`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 151`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 152`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 153`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 154`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 155`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 156`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 157`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 158`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 159`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 160`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 161`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 162`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 163`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1762,143 +1758,141 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 168`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 169`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 170`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 171`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 172`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 173`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 174`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 175`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 176`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 178`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 179`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 181`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 183`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 186`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 187`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 188`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 189`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 190`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 191`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 192`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 193`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 194`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 195`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 196`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 197`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 200`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 201`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 202`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 203`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 204`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 206`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 207`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 208`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 209`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 210`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 211`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 213`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 215`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 216`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 217`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 218`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 219`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 220`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 221`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 222`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 224`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 225`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 226`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 227`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 229`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 230`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 231`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 234`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 235`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 236`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 237`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 238`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 240`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 241`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 242`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 243`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 244`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1908,123 +1902,125 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 247`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 248`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 249`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 250`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 251`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 252`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 253`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 254`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 255`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 256`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 257`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 258`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 259`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 260`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 261`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 262`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 263`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 264`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 265`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 266`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 267`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 268`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 269`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 270`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 271`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 272`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 273`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 274`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 275`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 276`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 277`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 278`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 279`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 280`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 281`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 282`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 283`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 284`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 285`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 286`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 287`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 288`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 289`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 290`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 291`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 296`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 297`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 298`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 299`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 300`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 301`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 302`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 303`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 304`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 305`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 306`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 307`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 309`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2036,17 +2032,17 @@ Nodes (1): RealtimeEvent
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 7`, `Community 10`, `Community 15`, `Community 18`, `Community 88`?**
-  _High betweenness centrality (0.097) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 5` to `Community 1`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 15`, `Community 18`?**
+  _High betweenness centrality (0.102) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 6` to `Community 2`?**
+  _High betweenness centrality (0.037) - this node is a cross-community bridge._
 - **Are the 38 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
   _`DesktopStore` has 38 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
-  _1002 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Are the 12 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
+  _`DesktopAPI` has 12 INFERRED edges - model-reasoned connections that need verification._
+- **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
+  _992 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -37,6 +37,7 @@ import com.cotor.model.Pipeline
 import com.cotor.model.PipelineContext
 import com.cotor.model.PipelineStage
 import com.cotor.model.ProcessExecutionException
+import com.cotor.model.SecurityConfig
 import com.cotor.model.StageType
 import com.cotor.policy.PolicyDecision
 import com.cotor.policy.PolicyEngine
@@ -61,6 +62,8 @@ import com.cotor.runtime.durable.DurableRuntimeFlags
 import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.runtime.durable.DurableRuntimeStore
 import com.cotor.runtime.durable.ReplayMode
+import com.cotor.security.DefaultSecurityValidator
+import com.cotor.security.SecurityValidator
 import com.cotor.verification.VerificationBundle
 import com.cotor.verification.VerificationBundleService
 import kotlinx.coroutines.CancellationException
@@ -265,6 +268,10 @@ class DesktopAppService(
     private val companyVerifierService: CompanyVerifierService = CompanyVerifierService(verificationBundleService),
     private val autonomousDiscoveryService: AutonomousDiscoveryService = AutonomousDiscoveryService(),
     private val companyRuntimeRetention: CompanyRuntimeRetention = CompanyRuntimeRetention(),
+    private val securityValidator: SecurityValidator = DefaultSecurityValidator(
+        SecurityConfig(useWhitelist = false, enablePathValidation = false),
+        org.slf4j.LoggerFactory.getLogger("Cotor")
+    ),
     private val marketingBrowserRunner: MarketingBrowserRunner = LocalPlaywrightMarketingBrowserRunner(
         appHomeProvider = { stateStore.appHome() },
         commandAvailability = commandAvailability
@@ -287,6 +294,7 @@ class DesktopAppService(
         private const val SUPERSEDED_PR_RECONCILIATION_INTERVAL_MS = 5L * 60_000L
         private const val NO_OP_PR_REUSE_REFRESH_INTERVAL_MS = 60_000L
         private const val PR_METADATA_REFRESH_CACHE_MS = 60_000L
+        private const val AUTOMATION_REFRESH_DEBOUNCE_MS = 15_000L
         private const val AGENT_MODEL_DISCOVERY_CACHE_MS = 5L * 60_000L
         private const val CEO_PLANNING_SOURCE = "ceo-planning"
         private const val FALLBACK_PLANNING_SOURCE_PREFIX = "fallback-planning:"
@@ -349,6 +357,7 @@ class DesktopAppService(
     private val companyRuntimeJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val companyRuntimeWakeSignals = ConcurrentHashMap<String, MutableSharedFlow<Unit>>()
     private val automationRefreshJobs: MutableMap<String, Job> = ConcurrentHashMap()
+    private val automationRefreshQueuedAt = ConcurrentHashMap<String, Long>()
     private val activeTaskJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val intentionallyInterruptedTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val recentCompanyAutomationTraceKeys = ConcurrentHashMap<String, Long>()
@@ -515,7 +524,6 @@ class DesktopAppService(
         // restart. The read path stays cheap, but it nudges the automation layer back into the
         // expected steady state before serializing the full desktop snapshot.
         queueAutomationRefresh()
-        migrateLegacyOpenCodeCompanyAgentModels()
         val state = stateStore.load().withDerivedMetrics()
         val orgProfiles = ensureOrgProfiles(state.orgProfiles, state.companyAgentDefinitions, state.companies)
         val boundIssuesById = mutableMapOf<String, CompanyIssue>()
@@ -566,7 +574,10 @@ class DesktopAppService(
     }
 
     suspend fun companyDashboard(companyId: String? = null): CompanyDashboardResponse {
-        return companyDashboardPrepared(companyId)
+        pruneRuntimeCaches()
+        queueAutomationRefresh(companyId)
+        val state = stateStore.load().withDerivedMetrics()
+        return companyDashboardSnapshot(state, companyId).redactedForApi()
     }
 
     suspend fun companyDashboardPrepared(companyId: String? = null): CompanyDashboardResponse {
@@ -1134,6 +1145,11 @@ class DesktopAppService(
         if (automationRefreshJobs[key]?.isActive == true) {
             return
         }
+        val now = System.currentTimeMillis()
+        automationRefreshQueuedAt[key]
+            ?.takeIf { now - it < AUTOMATION_REFRESH_DEBOUNCE_MS }
+            ?.let { return }
+        automationRefreshQueuedAt[key] = now
         automationRefreshJobs[key] = serviceScope.launch {
             try {
                 prepareCompanyAutomationState(companyId)
@@ -1151,6 +1167,7 @@ class DesktopAppService(
 
     private suspend fun prepareCompanyAutomationState(companyId: String? = null) {
         migrateLegacyCompanyRosters(companyId)
+        migrateLegacyOpenCodeCompanyAgentModels(companyId)
         ensureBaselineAgentCapabilityProfiles(companyId)
         migrateLegacyFollowUpGoals(companyId)
         reconcileStaleAgentRuns(companyId)
@@ -3050,6 +3067,7 @@ class DesktopAppService(
         workingDirectory: Path,
         timeoutSeconds: Long
     ): String = withContext(Dispatchers.IO) {
+        securityValidator.validateCommand(command)
         val process = ProcessBuilder(command)
             .directory(workingDirectory.toFile())
             .redirectErrorStream(true)
@@ -10703,6 +10721,7 @@ class DesktopAppService(
 
     suspend fun stopCompanyRuntime(companyId: String): CompanyRuntimeSnapshot {
         val interruptedBeforeStop = interruptActiveCompanyTasksForRuntimeStop(companyId)
+        cancelActiveTaskJobs(interruptedBeforeStop.taskIds)
         val terminatedBeforeStop = terminateProcessIds(interruptedBeforeStop.processIds)
         val runtimeJob = companyRuntimeJobs.remove(companyId)
         runtimeJob?.cancel()
@@ -10759,6 +10778,7 @@ class DesktopAppService(
 
     private data class RuntimeStopInterruption(
         val taskCount: Int,
+        val taskIds: Set<String>,
         val processIds: List<Long>
     )
 
@@ -10774,7 +10794,7 @@ class DesktopAppService(
                     task.issueId?.let { issueId -> issuesById[issueId]?.companyId == companyId } == true
             }
             if (activeTasks.isEmpty()) {
-                return@withLock RuntimeStopInterruption(taskCount = 0, processIds = emptyList())
+                return@withLock RuntimeStopInterruption(taskCount = 0, taskIds = emptySet(), processIds = emptyList())
             }
 
             val interruptedTaskIds = activeTasks.mapTo(linkedSetOf()) { it.id }
@@ -10861,10 +10881,16 @@ class DesktopAppService(
                 severity = "warning"
             ).withDerivedMetrics()
             stateStore.save(nextState)
-            RuntimeStopInterruption(taskCount = activeTasks.size, processIds = activeProcessIds)
+            RuntimeStopInterruption(taskCount = activeTasks.size, taskIds = interruptedTaskIds, processIds = activeProcessIds)
         }
         traceEvents.forEach(::appendCompanyAutomationTrace)
         return result
+    }
+
+    private fun cancelActiveTaskJobs(taskIds: Set<String>) {
+        taskIds.forEach { taskId ->
+            activeTaskJobs[taskId]?.cancel(CancellationException(INTERRUPTED_RUN_ERROR))
+        }
     }
 
     private suspend fun terminateActiveCompanyRunProcesses(companyId: String): Int {
@@ -10890,17 +10916,15 @@ class DesktopAppService(
         if (processIds.isEmpty()) {
             return 0
         }
-        return withContext(Dispatchers.IO) {
-            processIds.distinct().count { processId -> terminateProcessTree(processId) }
-        }
+        return processIds.distinct().count { processId -> terminateProcessTree(processId) }
     }
 
-    private fun terminateProcessTree(processId: Long): Boolean {
+    private suspend fun terminateProcessTree(processId: Long): Boolean {
         val root = ProcessHandle.of(processId).orElse(null) ?: return false
         if (!root.isAlive) {
             return false
         }
-        val handles = root.descendants().toList().asReversed() + root
+        val handles = withContext(Dispatchers.IO) { root.descendants().toList().asReversed() + root }
         handles.forEach { handle ->
             runCatching {
                 if (handle.isAlive) {
@@ -10910,7 +10934,7 @@ class DesktopAppService(
         }
         val deadline = System.currentTimeMillis() + RUN_PROCESS_TERMINATION_TIMEOUT_MS
         while (System.currentTimeMillis() < deadline && handles.any { it.isAlive }) {
-            Thread.sleep(25)
+            delay(25)
         }
         handles.forEach { handle ->
             runCatching {
@@ -13332,6 +13356,17 @@ class DesktopAppService(
                 .filter { it.companyId == companyId && it.status == IssueStatus.DONE }
                 .groupBy { issue -> issue.kind.lowercase() to issue.title.trim().lowercase() }
                 .mapValues { (_, issues) -> issues.maxOf { it.updatedAt } }
+            val approvalIssueByExecutionId = state.issues
+                .asSequence()
+                .filter { it.companyId == companyId && it.kind.equals("approval", ignoreCase = true) }
+                .mapNotNull { approvalIssue -> relatedExecutionIssueId(approvalIssue)?.let { executionIssueId -> executionIssueId to approvalIssue } }
+                .groupBy({ it.first }, { it.second })
+                .mapValues { (_, approvals) -> approvals.maxByOrNull { it.updatedAt }!! }
+            val mergedReviewQueueByIssueId = state.reviewQueue
+                .asSequence()
+                .filter { it.companyId == companyId && it.status == ReviewQueueStatus.MERGED }
+                .groupBy { it.issueId }
+                .mapValues { (_, items) -> items.maxByOrNull { it.updatedAt }!! }
             val nextIssues = state.issues.map { issue ->
                 if (issue.companyId != companyId) {
                     return@map issue
@@ -13340,9 +13375,7 @@ class DesktopAppService(
                 val goal = goalsById[issue.goalId]
                 val workflowDrivenIssue = issue.kind.lowercase() in setOf("execution", "review", "approval")
                 val linkedApprovalIssue = if (issue.kind.equals("execution", ignoreCase = true)) {
-                    state.issues.firstOrNull {
-                        relatedExecutionIssueId(it) == issue.id && it.kind.equals("approval", ignoreCase = true)
-                    }
+                    approvalIssueByExecutionId[issue.id]
                 } else {
                     null
                 }
@@ -13352,7 +13385,7 @@ class DesktopAppService(
                     null
                 }
                 val mergedReviewQueueItem = if (issue.kind.equals("execution", ignoreCase = true)) {
-                    state.reviewQueue.firstOrNull { it.issueId == issue.id && it.status == ReviewQueueStatus.MERGED }
+                    mergedReviewQueueByIssueId[issue.id]
                 } else {
                     null
                 }
@@ -16240,12 +16273,7 @@ class DesktopAppService(
                 workingDirectory = binding.worktreePath,
                 onProcessStarted = { processId ->
                     runBlocking {
-                        replaceRun(
-                            startedRun.copy(
-                                processId = processId,
-                                updatedAt = System.currentTimeMillis()
-                            )
-                        )
+                        recordRunProcessStarted(startedRun.id, task.id, processId)
                     }
                 },
                 onStdoutChunk = handler@{ chunk ->
@@ -16664,6 +16692,10 @@ class DesktopAppService(
     private suspend fun replaceRun(run: AgentRun) {
         stateMutex.withLock {
             val state = stateStore.load()
+            val existingRun = state.runs.firstOrNull { existing -> existing.id == run.id }
+            if (existingRun != null && shouldIgnoreStaleRunReplacement(existingRun, run)) {
+                return@withLock
+            }
             val nextRuns = if (state.runs.any { existing -> existing.id == run.id }) {
                 state.runs.map { existing -> if (existing.id == run.id) run else existing }
             } else {
@@ -16699,6 +16731,43 @@ class DesktopAppService(
                     tasks = nextTasks
                 )
             )
+        }
+    }
+
+    private fun shouldIgnoreStaleRunReplacement(existing: AgentRun, incoming: AgentRun): Boolean {
+        val existingTerminal = existing.status == AgentRunStatus.COMPLETED || existing.status == AgentRunStatus.FAILED
+        val incomingActive = incoming.status == AgentRunStatus.QUEUED || incoming.status == AgentRunStatus.RUNNING
+        return (existingTerminal && incomingActive) ||
+            (existingTerminal && existing.error == INTERRUPTED_RUN_ERROR) ||
+            (existingTerminal && incoming.taskId in intentionallyInterruptedTaskIds)
+    }
+
+    private suspend fun recordRunProcessStarted(runId: String, taskId: String, processId: Long) {
+        var shouldTerminate = taskId in intentionallyInterruptedTaskIds
+        stateMutex.withLock {
+            val state = stateStore.load()
+            val existing = state.runs.firstOrNull { it.id == runId }
+            if (
+                existing == null ||
+                existing.status == AgentRunStatus.COMPLETED ||
+                existing.status == AgentRunStatus.FAILED ||
+                taskId in intentionallyInterruptedTaskIds
+            ) {
+                shouldTerminate = true
+                return@withLock
+            }
+            val updated = existing.copy(
+                processId = processId,
+                updatedAt = System.currentTimeMillis()
+            )
+            stateStore.save(
+                state.copy(
+                    runs = state.runs.map { run -> if (run.id == runId) updated else run }
+                )
+            )
+        }
+        if (shouldTerminate) {
+            terminateProcessIds(listOf(processId))
         }
     }
 
@@ -24040,7 +24109,9 @@ class DesktopAppService(
                     directChatConversations = state.directChatConversations.map { conv ->
                         if (conv.id == conversationId) {
                             conv.copy(messages = conv.messages + userMsg, updatedAt = now)
-                        } else conv
+                        } else {
+                            conv
+                        }
                     }
                 )
             )
@@ -24075,7 +24146,9 @@ class DesktopAppService(
                                 directChatConversations = state.directChatConversations.map { conv ->
                                     if (conv.id == conversationId) {
                                         conv.copy(messages = conv.messages + assistantMsg, updatedAt = now)
-                                    } else conv
+                                    } else {
+                                        conv
+                                    }
                                 }
                             )
                         )

--- a/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -25,6 +26,10 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.readText
@@ -54,6 +59,8 @@ class DesktopStateStore(
 
         @Volatile
         private var lastStateLoadLogAt: Long = 0L
+
+        private val processStateFileLocks = ConcurrentHashMap<String, Mutex>()
     }
 
     private data class CachedState(
@@ -61,6 +68,24 @@ class DesktopStateStore(
         val lastModifiedAtMillis: Long,
         val sizeInBytes: Long
     )
+
+    private data class SqliteCachedState(
+        val state: DesktopAppState,
+        val revision: Long
+    )
+
+    private class StateCollection<T>(
+        val name: String,
+        private val serializer: KSerializer<T>,
+        private val read: (DesktopAppState) -> T,
+        private val write: (DesktopAppState, T) -> DesktopAppState
+    ) {
+        fun encode(state: DesktopAppState, json: Json): String =
+            json.encodeToString(serializer, read(state))
+
+        fun apply(state: DesktopAppState, payload: String, json: Json): DesktopAppState =
+            write(state, json.decodeFromString(serializer, payload))
+    }
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -70,6 +95,39 @@ class DesktopStateStore(
         encodeDefaults = true
     }
 
+    private val stateCollections: List<StateCollection<*>> = listOf(
+        StateCollection("companies", ListSerializer(Company.serializer()), DesktopAppState::companies) { state, value -> state.copy(companies = value) },
+        StateCollection("companyAgentDefinitions", ListSerializer(CompanyAgentDefinition.serializer()), DesktopAppState::companyAgentDefinitions) { state, value -> state.copy(companyAgentDefinitions = value) },
+        StateCollection("agentCapabilityProfiles", ListSerializer(AgentCapabilityProfile.serializer()), DesktopAppState::agentCapabilityProfiles) { state, value -> state.copy(agentCapabilityProfiles = value) },
+        StateCollection("projectContexts", ListSerializer(CompanyProjectContext.serializer()), DesktopAppState::projectContexts) { state, value -> state.copy(projectContexts = value) },
+        StateCollection("repositories", ListSerializer(ManagedRepository.serializer()), DesktopAppState::repositories) { state, value -> state.copy(repositories = value) },
+        StateCollection("workspaces", ListSerializer(Workspace.serializer()), DesktopAppState::workspaces) { state, value -> state.copy(workspaces = value) },
+        StateCollection("tasks", ListSerializer(AgentTask.serializer()), DesktopAppState::tasks) { state, value -> state.copy(tasks = value) },
+        StateCollection("runs", ListSerializer(AgentRun.serializer()), DesktopAppState::runs) { state, value -> state.copy(runs = value) },
+        StateCollection("goals", ListSerializer(CompanyGoal.serializer()), DesktopAppState::goals) { state, value -> state.copy(goals = value) },
+        StateCollection("issues", ListSerializer(CompanyIssue.serializer()), DesktopAppState::issues) { state, value -> state.copy(issues = value) },
+        StateCollection("issueDependencies", ListSerializer(IssueDependency.serializer()), DesktopAppState::issueDependencies) { state, value -> state.copy(issueDependencies = value) },
+        StateCollection("orgProfiles", ListSerializer(OrgAgentProfile.serializer()), DesktopAppState::orgProfiles) { state, value -> state.copy(orgProfiles = value) },
+        StateCollection("workflowTopologies", ListSerializer(WorkflowTopologySnapshot.serializer()), DesktopAppState::workflowTopologies) { state, value -> state.copy(workflowTopologies = value) },
+        StateCollection("goalDecisions", ListSerializer(GoalOrchestrationDecision.serializer()), DesktopAppState::goalDecisions) { state, value -> state.copy(goalDecisions = value) },
+        StateCollection("reviewQueue", ListSerializer(ReviewQueueItem.serializer()), DesktopAppState::reviewQueue) { state, value -> state.copy(reviewQueue = value) },
+        StateCollection("companyActivity", ListSerializer(CompanyActivityItem.serializer()), DesktopAppState::companyActivity) { state, value -> state.copy(companyActivity = value) },
+        StateCollection("opsMetrics", OpsMetricSnapshot.serializer(), DesktopAppState::opsMetrics) { state, value -> state.copy(opsMetrics = value) },
+        StateCollection("signals", ListSerializer(OpsSignal.serializer()), DesktopAppState::signals) { state, value -> state.copy(signals = value) },
+        StateCollection("backendSettings", DesktopBackendSettings.serializer(), DesktopAppState::backendSettings) { state, value -> state.copy(backendSettings = value) },
+        StateCollection("linearSettings", DesktopLinearSettings.serializer(), DesktopAppState::linearSettings) { state, value -> state.copy(linearSettings = value) },
+        StateCollection("runtime", CompanyRuntimeSnapshot.serializer(), DesktopAppState::runtime) { state, value -> state.copy(runtime = value) },
+        StateCollection("companyRuntimes", ListSerializer(CompanyRuntimeSnapshot.serializer()), DesktopAppState::companyRuntimes) { state, value -> state.copy(companyRuntimes = value) },
+        StateCollection("workflowPipelines", ListSerializer(WorkflowPipelineDefinition.serializer()), DesktopAppState::workflowPipelines) { state, value -> state.copy(workflowPipelines = value) },
+        StateCollection("agentContextEntries", ListSerializer(AgentContextEntry.serializer()), DesktopAppState::agentContextEntries) { state, value -> state.copy(agentContextEntries = value) },
+        StateCollection("agentMessages", ListSerializer(AgentMessage.serializer()), DesktopAppState::agentMessages) { state, value -> state.copy(agentMessages = value) },
+        StateCollection("marketingDelegationPolicies", ListSerializer(MarketingDelegationPolicy.serializer()), DesktopAppState::marketingDelegationPolicies) { state, value -> state.copy(marketingDelegationPolicies = value) },
+        StateCollection("marketingRuns", ListSerializer(MarketingRunRecord.serializer()), DesktopAppState::marketingRuns) { state, value -> state.copy(marketingRuns = value) },
+        StateCollection("skillRuns", ListSerializer(SkillRunRecord.serializer()), DesktopAppState::skillRuns) { state, value -> state.copy(skillRuns = value) },
+        StateCollection("companyRuntimeWorkItems", ListSerializer(CompanyRuntimeWorkItem.serializer()), DesktopAppState::companyRuntimeWorkItems) { state, value -> state.copy(companyRuntimeWorkItems = value) },
+        StateCollection("problemSignals", ListSerializer(CompanyProblemSignal.serializer()), DesktopAppState::problemSignals) { state, value -> state.copy(problemSignals = value) }
+    )
+
     // A single process can finish multiple background runs nearly at once, so writes
     // need to be serialized even though the backing file is small.
     private val mutex = Mutex()
@@ -77,11 +135,21 @@ class DesktopStateStore(
     @Volatile
     private var cachedState: CachedState? = null
 
+    @Volatile
+    private var cachedSqliteState: SqliteCachedState? = null
+
     fun appHome(): Path = appHomeProvider()
 
     fun managedReposRoot(): Path = appHome().resolve("ManagedRepos")
 
-    override suspend fun load(): DesktopAppState = withContext(Dispatchers.IO) {
+    override suspend fun load(): DesktopAppState =
+        if (useJsonBackend()) {
+            loadJson()
+        } else {
+            loadSqlite()
+        }
+
+    private suspend fun loadJson(): DesktopAppState = withContext(Dispatchers.IO) {
         val stateFile = stateFile()
         if (!stateFile.exists()) {
             return@withContext withStateFileLock {
@@ -113,7 +181,7 @@ class DesktopStateStore(
             decodeState(raw)?.also { decoded ->
                 val compacted = normalizeStateForPersistence(decoded)
                 if (raw != json.encodeToString(DesktopAppState.serializer(), compacted)) {
-                    saveLocked(compacted)
+                    saveJsonLocked(compacted)
                 } else {
                     updateCache(stateFile, compacted)
                 }
@@ -123,7 +191,7 @@ class DesktopStateStore(
                 val backupRaw = runCatching { backupFile.readText() }.getOrNull()
                 decodeState(backupRaw.orEmpty())?.also { recovered ->
                     val compacted = normalizeStateForPersistence(recovered)
-                    saveLocked(compacted)
+                    saveJsonLocked(compacted)
                     return@withStateFileLock compacted
                 }
             }
@@ -132,10 +200,18 @@ class DesktopStateStore(
     }
 
     override suspend fun save(state: DesktopAppState) {
+        if (useJsonBackend()) {
+            saveJson(state)
+        } else {
+            saveSqlite(state)
+        }
+    }
+
+    private suspend fun saveJson(state: DesktopAppState) {
         mutex.withLock {
             withContext(Dispatchers.IO) {
                 withStateFileLock {
-                    saveLocked(state)
+                    saveJsonLocked(state)
                 }
             }
         }
@@ -145,11 +221,13 @@ class DesktopStateStore(
 
     private fun backupStateFile(): Path = appHome().resolve("state.json.bak")
 
+    private fun sqliteStateFile(): Path = appHome().resolve("state.sqlite")
+
     private fun lockFile(): Path = appHome().resolve("state.lock")
 
     private fun lockMetadataFile(): Path = appHome().resolve("state.lock.json")
 
-    private fun saveLocked(state: DesktopAppState) {
+    private fun saveJsonLocked(state: DesktopAppState) {
         val file = stateFile()
         val backupFile = backupStateFile()
         // Always create the parent directories before the first write so the
@@ -170,6 +248,228 @@ class DesktopStateStore(
         moveWithAtomicFallback(backupTempFile, backupFile)
         enforceOwnerOnlyPermissions(backupFile)
         updateCache(file, compactedState)
+    }
+
+    private suspend fun loadSqlite(): DesktopAppState = withContext(Dispatchers.IO) {
+        withStateFileLock {
+            cleanupStateTempFiles(appHome())
+            sqliteConnection().use { connection ->
+                ensureSqliteSchema(connection)
+                migrateJsonStateIfNeeded(connection)
+                val revision = sqliteRevision(connection)
+                cachedSqliteState?.takeIf { it.revision == revision }?.let { return@withStateFileLock it.state }
+                val state = loadSqliteState(connection)
+                cachedSqliteState = SqliteCachedState(state, revision)
+                state
+            }
+        }
+    }
+
+    private suspend fun saveSqlite(state: DesktopAppState) {
+        mutex.withLock {
+            withContext(Dispatchers.IO) {
+                withStateFileLock {
+                    cleanupStateTempFiles(appHome())
+                    sqliteConnection().use { connection ->
+                        ensureSqliteSchema(connection)
+                        saveSqliteState(connection, state)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sqliteConnection(): Connection {
+        val file = sqliteStateFile()
+        file.parent?.createDirectories()
+        managedReposRoot().createDirectories()
+        val connection = DriverManager.getConnection("jdbc:sqlite:${file.toAbsolutePath().normalize()}")
+        connection.createStatement().use { statement ->
+            statement.execute("PRAGMA busy_timeout = 3000")
+            statement.execute("PRAGMA journal_mode = WAL")
+            statement.execute("PRAGMA synchronous = NORMAL")
+        }
+        return connection
+    }
+
+    private fun ensureSqliteSchema(connection: Connection) {
+        connection.createStatement().use { statement ->
+            statement.execute(
+                """
+                CREATE TABLE IF NOT EXISTS state_collections (
+                    name TEXT PRIMARY KEY,
+                    payload TEXT NOT NULL,
+                    payload_sha256 TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            statement.execute(
+                """
+                CREATE TABLE IF NOT EXISTS state_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """.trimIndent()
+            )
+        }
+        if (sqliteMeta(connection, "schema_version") == null) {
+            setSqliteMeta(connection, "schema_version", "1")
+        }
+    }
+
+    private fun migrateJsonStateIfNeeded(connection: Connection) {
+        if (sqliteCollectionCount(connection) > 0L) {
+            return
+        }
+        val migrated = readJsonStateForMigration() ?: return
+        saveSqliteState(connection, migrated)
+        setSqliteMeta(connection, "migrated_from_json_at", System.currentTimeMillis().toString())
+    }
+
+    private fun readJsonStateForMigration(): DesktopAppState? {
+        val primary = stateFile()
+        if (primary.exists()) {
+            val raw = runCatching { primary.readText() }.getOrNull()
+            decodeState(raw.orEmpty())?.let { return normalizeStateForPersistence(it) }
+        }
+        val backup = backupStateFile()
+        if (backup.exists()) {
+            val raw = runCatching { backup.readText() }.getOrNull()
+            decodeState(raw.orEmpty())?.let { return normalizeStateForPersistence(it) }
+        }
+        return null
+    }
+
+    private fun loadSqliteState(connection: Connection): DesktopAppState {
+        val rows = mutableMapOf<String, String>()
+        connection.prepareStatement("SELECT name, payload FROM state_collections").use { statement ->
+            statement.executeQuery().use { result ->
+                while (result.next()) {
+                    rows[result.getString("name")] = result.getString("payload")
+                }
+            }
+        }
+        if (rows.isEmpty()) {
+            return DesktopAppState()
+        }
+        val decoded = stateCollections.fold(DesktopAppState()) { state, collection ->
+            val payload = rows[collection.name] ?: return@fold state
+            runCatching { collection.apply(state, payload, json) }
+                .onFailure { error ->
+                    appendStateLoadLog(
+                        "Recovered SQLite state without invalid collection ${collection.name}: " +
+                            (error.message ?: error::class.simpleName.orEmpty())
+                    )
+                }
+                .getOrDefault(state)
+        }
+        return normalizeStateForPersistence(decoded)
+    }
+
+    private fun saveSqliteState(connection: Connection, state: DesktopAppState) {
+        val compactedState = normalizeStateForPersistence(state)
+        val existingHashes = sqliteCollectionHashes(connection)
+        val now = System.currentTimeMillis()
+        var changed = false
+        connection.autoCommit = false
+        try {
+            stateCollections.forEach { collection ->
+                val payload = collection.encode(compactedState, json)
+                val hash = sha256(payload)
+                if (existingHashes[collection.name] == hash) {
+                    return@forEach
+                }
+                connection.prepareStatement(
+                    """
+                    INSERT INTO state_collections(name, payload, payload_sha256, updated_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(name) DO UPDATE SET
+                        payload = excluded.payload,
+                        payload_sha256 = excluded.payload_sha256,
+                        updated_at = excluded.updated_at
+                    """.trimIndent()
+                ).use { statement ->
+                    statement.setString(1, collection.name)
+                    statement.setString(2, payload)
+                    statement.setString(3, hash)
+                    statement.setLong(4, now)
+                    statement.executeUpdate()
+                }
+                changed = true
+            }
+            val currentRevision = sqliteRevision(connection)
+            val nextRevision = if (changed || currentRevision == 0L) {
+                currentRevision + 1L
+            } else {
+                currentRevision
+            }
+            if (nextRevision != currentRevision) {
+                setSqliteMeta(connection, "revision", nextRevision.toString())
+            }
+            connection.commit()
+            cachedSqliteState = SqliteCachedState(compactedState, nextRevision)
+        } catch (error: Throwable) {
+            runCatching { connection.rollback() }
+            throw error
+        } finally {
+            connection.autoCommit = true
+        }
+    }
+
+    private fun sqliteCollectionCount(connection: Connection): Long =
+        connection.prepareStatement("SELECT COUNT(*) FROM state_collections").use { statement ->
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getLong(1) else 0L
+            }
+        }
+
+    private fun sqliteCollectionHashes(connection: Connection): Map<String, String> {
+        val hashes = mutableMapOf<String, String>()
+        connection.prepareStatement("SELECT name, payload_sha256 FROM state_collections").use { statement ->
+            statement.executeQuery().use { result ->
+                while (result.next()) {
+                    hashes[result.getString("name")] = result.getString("payload_sha256")
+                }
+            }
+        }
+        return hashes
+    }
+
+    private fun sqliteRevision(connection: Connection): Long =
+        sqliteMeta(connection, "revision")?.toLongOrNull() ?: 0L
+
+    private fun sqliteMeta(connection: Connection, key: String): String? =
+        connection.prepareStatement("SELECT value FROM state_meta WHERE key = ?").use { statement ->
+            statement.setString(1, key)
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getString(1) else null
+            }
+        }
+
+    private fun setSqliteMeta(connection: Connection, key: String, value: String) {
+        connection.prepareStatement(
+            """
+            INSERT INTO state_meta(key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """.trimIndent()
+        ).use { statement ->
+            statement.setString(1, key)
+            statement.setString(2, value)
+            statement.executeUpdate()
+        }
+    }
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+    private fun useJsonBackend(): Boolean {
+        val configured = System.getenv("COTOR_DESKTOP_STATE_BACKEND")
+            ?: System.getProperty("cotor.desktop.state.backend")
+        return configured.equals("json", ignoreCase = true)
     }
 
     private fun cleanupStateTempFiles(directory: Path?) {
@@ -314,50 +614,52 @@ class DesktopStateStore(
         val metadataPath = lockMetadataFile()
         lockPath.parent?.createDirectories()
         metadataPath.parent?.createDirectories()
-        return try {
-            FileChannel.open(
-                lockPath,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE
-            ).use { channel ->
-                val deadline = System.currentTimeMillis() + STATE_LOCK_TIMEOUT_MS
-                while (true) {
-                    val lock = channel.tryLock()
-                    if (lock != null) {
-                        return@use lock.use {
-                            writeLockMetadata(metadataPath)
-                            try {
-                                block()
-                            } finally {
-                                clearLockMetadata(metadataPath)
-                            }
-                        }
-                    }
-                    if (System.currentTimeMillis() >= deadline) {
-                        val holder = runCatching { metadataPath.readText() }.getOrNull()?.trim()
-                        error(
-                            buildString {
-                                append("state.lock acquisition timed out after ")
-                                append(STATE_LOCK_TIMEOUT_MS)
-                                append("ms; path=")
-                                append(lockPath)
-                                if (!holder.isNullOrBlank()) {
-                                    append("; holder=")
-                                    append(holder)
+        val processLock = processStateFileLocks.getOrPut(lockPath.toAbsolutePath().normalize().toString()) { Mutex() }
+        return processLock.withLock {
+            try {
+                FileChannel.open(
+                    lockPath,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE
+                ).use { channel ->
+                    val deadline = System.currentTimeMillis() + STATE_LOCK_TIMEOUT_MS
+                    while (true) {
+                        val lock = channel.tryLock()
+                        if (lock != null) {
+                            return@use lock.use {
+                                writeLockMetadata(metadataPath)
+                                try {
+                                    block()
+                                } finally {
+                                    clearLockMetadata(metadataPath)
                                 }
                             }
-                        )
+                        }
+                        if (System.currentTimeMillis() >= deadline) {
+                            val holder = runCatching { metadataPath.readText() }.getOrNull()?.trim()
+                            error(
+                                buildString {
+                                    append("state.lock acquisition timed out after ")
+                                    append(STATE_LOCK_TIMEOUT_MS)
+                                    append("ms; path=")
+                                    append(lockPath)
+                                    if (!holder.isNullOrBlank()) {
+                                        append("; holder=")
+                                        append(holder)
+                                    }
+                                }
+                            )
+                        }
+                        delay(STATE_LOCK_RETRY_DELAY_MS)
                     }
-                    delay(STATE_LOCK_RETRY_DELAY_MS)
+                    error("Unreachable")
                 }
-                error("Unreachable")
+            } catch (_: OverlappingFileLockException) {
+                // The process-level coroutine mutex above serializes same-JVM
+                // access. The file-channel lock still protects cross-process use
+                // whenever the JVM can acquire it.
+                block()
             }
-        } catch (_: OverlappingFileLockException) {
-            // The same JVM can legitimately re-enter state reads/writes while a
-            // sibling coroutine still holds the process-wide file lock. In that
-            // case the in-process mutexes already provide serialization, so we
-            // only need the inter-process lock when it is available.
-            block()
         }
     }
 

--- a/src/main/kotlin/com/cotor/app/DirectChatService.kt
+++ b/src/main/kotlin/com/cotor/app/DirectChatService.kt
@@ -33,7 +33,10 @@ private val directChatHttpClient: HttpClient = HttpClient.newBuilder()
     .connectTimeout(Duration.ofSeconds(10))
     .executor(
         java.util.concurrent.ThreadPoolExecutor(
-            0, 16, 60L, TimeUnit.SECONDS,
+            0,
+            16,
+            60L,
+            TimeUnit.SECONDS,
             java.util.concurrent.SynchronousQueue()
         ) { runnable ->
             Thread(runnable, "cotor-direct-chat-http-${directChatHttpThreadCounter.incrementAndGet()}").apply {
@@ -97,8 +100,11 @@ class DirectChatService {
             "lmstudio" -> "http://127.0.0.1:1234"
             else -> ""
         }
-        val effectiveBase = if (defaultBase.isBlank()) defaultBase
-        else validateAndNormalizeBaseUrl(conversation.baseUrl, defaultBase)
+        val effectiveBase = if (defaultBase.isBlank()) {
+            defaultBase
+        } else {
+            validateAndNormalizeBaseUrl(conversation.baseUrl, defaultBase)
+        }
 
         when (provider) {
             "ollama" -> streamOllama(conversation, userMessage, messageId, effectiveBase)
@@ -277,7 +283,10 @@ class DirectChatService {
                                 done = done
                             )
                         )
-                        if (done) { doneSent = true; break }
+                        if (done) {
+                            doneSent = true
+                            break
+                        }
                     } catch (_: Exception) {
                         // skip malformed SSE lines
                     }
@@ -396,7 +405,7 @@ class DirectChatService {
         val sb = StringBuilder("\"")
         for (ch in value) {
             when {
-                ch == '"'  -> sb.append("\\\"")
+                ch == '"' -> sb.append("\\\"")
                 ch == '\\' -> sb.append("\\\\")
                 ch == '\n' -> sb.append("\\n")
                 ch == '\r' -> sb.append("\\r")

--- a/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
+++ b/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
@@ -43,6 +43,7 @@ import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.invariantSeparatorsPathString
@@ -134,6 +135,7 @@ class GitWorkspaceService(
     @Volatile private var cachedGitHubTokenAtMs: Long = 0L
     private val githubLoginCacheMutex = Mutex()
     private val githubTokenCacheMutex = Mutex()
+    private val repositoryMutationLocks = ConcurrentHashMap<String, Mutex>()
 
     private fun githubHttpEnabled(): Boolean {
         return githubHttpEnabledProvider()
@@ -360,37 +362,39 @@ class GitWorkspaceService(
                 ActionEvidence(branchName = binding.branchName)
             }
         ) {
-            ensureBootstrapCommit(repositoryRoot)
-            val agentSlug = slugify(agentName).ifBlank { "agent" }
-            val taskSlug = slugify(taskTitle).ifBlank { "task" }
-            val branchName = "codex/cotor/$taskSlug-${taskId.take(8)}/$agentSlug"
-            val worktreePath = repositoryRoot
-                .resolve(".cotor")
-                .resolve("worktrees")
-                .resolve(taskId)
-                .resolve(agentSlug)
-                .toAbsolutePath()
-                .normalize()
+            withRepositoryMutationLock(repositoryRoot) {
+                ensureBootstrapCommit(repositoryRoot)
+                val agentSlug = slugify(agentName).ifBlank { "agent" }
+                val taskSlug = slugify(taskTitle).ifBlank { "task" }
+                val branchName = "codex/cotor/$taskSlug-${taskId.take(8)}/$agentSlug"
+                val worktreePath = repositoryRoot
+                    .resolve(".cotor")
+                    .resolve("worktrees")
+                    .resolve(taskId)
+                    .resolve(agentSlug)
+                    .toAbsolutePath()
+                    .normalize()
 
-            if (worktreePath.exists()) {
-                WorktreeBinding(branchName = branchName, worktreePath = worktreePath)
-            } else {
-                worktreePath.parent?.createDirectories()
-                if (hasBranch(repositoryRoot, branchName)) {
-                    runGit(repositoryRoot, "worktree", "add", worktreePath.toString(), branchName)
+                if (worktreePath.exists()) {
+                    WorktreeBinding(branchName = branchName, worktreePath = worktreePath)
                 } else {
-                    val baseReference = resolveLatestBaseReference(repositoryRoot, baseBranch)
-                    runGit(
-                        repositoryRoot,
-                        "worktree",
-                        "add",
-                        "-b",
-                        branchName,
-                        worktreePath.toString(),
-                        baseReference.startPoint
-                    )
+                    worktreePath.parent?.createDirectories()
+                    if (hasBranch(repositoryRoot, branchName)) {
+                        runGit(repositoryRoot, "worktree", "add", worktreePath.toString(), branchName)
+                    } else {
+                        val baseReference = resolveLatestBaseReference(repositoryRoot, baseBranch)
+                        runGit(
+                            repositoryRoot,
+                            "worktree",
+                            "add",
+                            "-b",
+                            branchName,
+                            worktreePath.toString(),
+                            baseReference.startPoint
+                        )
+                    }
+                    WorktreeBinding(branchName = branchName, worktreePath = worktreePath)
                 }
-                WorktreeBinding(branchName = branchName, worktreePath = worktreePath)
             }
         }
     }
@@ -400,12 +404,12 @@ class GitWorkspaceService(
         branchName: String,
         worktreePath: Path,
         baseBranch: String
-    ): WorktreeBinding {
+    ): WorktreeBinding = withRepositoryMutationLock(repositoryRoot) {
         ensureBootstrapCommit(repositoryRoot)
         val normalizedPath = worktreePath.toAbsolutePath().normalize()
         if (normalizedPath.exists()) {
             verifyExistingWorktreeLineage(repositoryRoot, branchName, normalizedPath)
-            return WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
+            return@withRepositoryMutationLock WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
         }
 
         normalizedPath.parent?.createDirectories()
@@ -424,7 +428,7 @@ class GitWorkspaceService(
             )
         }
 
-        return WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
+        return@withRepositoryMutationLock WorktreeBinding(branchName = branchName, worktreePath = normalizedPath)
     }
 
     private suspend fun verifyExistingWorktreeLineage(
@@ -1187,90 +1191,92 @@ class GitWorkspaceService(
         }
 
         val repositoryRoot = repositoryCommonRoot(worktreePath)
-        if (!hasOriginRemote(repositoryRoot)) {
-            return BaseBranchSyncResult(skippedReason = "No origin remote configured for post-merge sync.")
-        }
-
-        val remoteTrackingRef = "refs/remotes/origin/$normalizedBaseBranch"
-        val fetchResult = runGit(
-            repositoryRoot,
-            "fetch",
-            "--no-tags",
-            "origin",
-            "refs/heads/$normalizedBaseBranch:$remoteTrackingRef",
-            failOnError = false,
-            timeoutMs = 30_000
-        )
-        if (!fetchResult.isSuccess) {
-            logger.warn("Could not fetch origin/$normalizedBaseBranch after merge")
-            return BaseBranchSyncResult(skippedReason = "Could not fetch origin/$normalizedBaseBranch after merge.")
-        }
-
-        val currentBranch = runGit(
-            repositoryRoot,
-            "rev-parse",
-            "--abbrev-ref",
-            "HEAD",
-            failOnError = false,
-            timeoutMs = 10_000
-        ).stdout.trim()
-
-        if (currentBranch == normalizedBaseBranch) {
-            if (!hasOnlyBenignCotorArtifacts(repositoryRoot)) {
-                return BaseBranchSyncResult(
-                    skippedReason = "Skipped post-merge sync for $normalizedBaseBranch because the repository root has uncommitted changes."
-                )
+        return withRepositoryMutationLock(repositoryRoot) {
+            if (!hasOriginRemote(repositoryRoot)) {
+                return@withRepositoryMutationLock BaseBranchSyncResult(skippedReason = "No origin remote configured for post-merge sync.")
             }
-            val fastForwardResult = runGit(
+
+            val remoteTrackingRef = "refs/remotes/origin/$normalizedBaseBranch"
+            val fetchResult = runGit(
                 repositoryRoot,
-                "merge",
-                "--ff-only",
-                remoteTrackingRef,
+                "fetch",
+                "--no-tags",
+                "origin",
+                "refs/heads/$normalizedBaseBranch:$remoteTrackingRef",
                 failOnError = false,
                 timeoutMs = 30_000
             )
-            if (!fastForwardResult.isSuccess) {
-                logger.warn("Could not fast-forward $normalizedBaseBranch to $remoteTrackingRef after merge")
-                return BaseBranchSyncResult(skippedReason = "Could not fast-forward local $normalizedBaseBranch after merge.")
+            if (!fetchResult.isSuccess) {
+                logger.warn("Could not fetch origin/$normalizedBaseBranch after merge")
+                return@withRepositoryMutationLock BaseBranchSyncResult(skippedReason = "Could not fetch origin/$normalizedBaseBranch after merge.")
             }
-            return BaseBranchSyncResult(synced = true, workingTreeUpdated = true)
-        }
 
-        val localBaseBranchExists = runGit(
-            repositoryRoot,
-            "show-ref",
-            "--verify",
-            "--quiet",
-            "refs/heads/$normalizedBaseBranch",
-            failOnError = false,
-            timeoutMs = 10_000
-        ).isSuccess
-        val updateRefResult = if (localBaseBranchExists) {
-            runGit(
+            val currentBranch = runGit(
                 repositoryRoot,
-                "branch",
-                "-f",
-                normalizedBaseBranch,
-                remoteTrackingRef,
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD",
                 failOnError = false,
                 timeoutMs = 10_000
-            )
-        } else {
-            runGit(
+            ).stdout.trim()
+
+            if (currentBranch == normalizedBaseBranch) {
+                if (!hasOnlyBenignCotorArtifacts(repositoryRoot)) {
+                    return@withRepositoryMutationLock BaseBranchSyncResult(
+                        skippedReason = "Skipped post-merge sync for $normalizedBaseBranch because the repository root has uncommitted changes."
+                    )
+                }
+                val fastForwardResult = runGit(
+                    repositoryRoot,
+                    "merge",
+                    "--ff-only",
+                    remoteTrackingRef,
+                    failOnError = false,
+                    timeoutMs = 30_000
+                )
+                if (!fastForwardResult.isSuccess) {
+                    logger.warn("Could not fast-forward $normalizedBaseBranch to $remoteTrackingRef after merge")
+                    return@withRepositoryMutationLock BaseBranchSyncResult(skippedReason = "Could not fast-forward local $normalizedBaseBranch after merge.")
+                }
+                return@withRepositoryMutationLock BaseBranchSyncResult(synced = true, workingTreeUpdated = true)
+            }
+
+            val localBaseBranchExists = runGit(
                 repositoryRoot,
-                "branch",
-                normalizedBaseBranch,
-                remoteTrackingRef,
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/heads/$normalizedBaseBranch",
                 failOnError = false,
                 timeoutMs = 10_000
-            )
-        }
-        if (!updateRefResult.isSuccess) {
-            logger.warn("Could not update local $normalizedBaseBranch ref to $remoteTrackingRef after merge")
-            return BaseBranchSyncResult(skippedReason = "Could not update local $normalizedBaseBranch ref after merge.")
-        }
+            ).isSuccess
+            val updateRefResult = if (localBaseBranchExists) {
+                runGit(
+                    repositoryRoot,
+                    "branch",
+                    "-f",
+                    normalizedBaseBranch,
+                    remoteTrackingRef,
+                    failOnError = false,
+                    timeoutMs = 10_000
+                )
+            } else {
+                runGit(
+                    repositoryRoot,
+                    "branch",
+                    normalizedBaseBranch,
+                    remoteTrackingRef,
+                    failOnError = false,
+                    timeoutMs = 10_000
+                )
+            }
+            if (!updateRefResult.isSuccess) {
+                logger.warn("Could not update local $normalizedBaseBranch ref to $remoteTrackingRef after merge")
+                return@withRepositoryMutationLock BaseBranchSyncResult(skippedReason = "Could not update local $normalizedBaseBranch ref after merge.")
+            }
 
-        return BaseBranchSyncResult(synced = true, workingTreeUpdated = false)
+            return@withRepositoryMutationLock BaseBranchSyncResult(synced = true, workingTreeUpdated = false)
+        }
     }
 
     private suspend fun hasOriginRemote(repositoryRoot: Path): Boolean {
@@ -1805,6 +1811,12 @@ class GitWorkspaceService(
     private suspend fun hasBranch(repositoryRoot: Path, branchName: String): Boolean {
         val result = runGit(repositoryRoot, "show-ref", "--verify", "--quiet", "refs/heads/$branchName", failOnError = false)
         return result.isSuccess
+    }
+
+    private suspend fun <T> withRepositoryMutationLock(repositoryRoot: Path, block: suspend () -> T): T {
+        val key = repositoryRoot.toAbsolutePath().normalize().toString()
+        val lock = repositoryMutationLocks.computeIfAbsent(key) { Mutex() }
+        return lock.withLock { block() }
     }
 
     private suspend fun hasUncommittedChanges(worktreePath: Path): Boolean {

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
@@ -9,10 +9,14 @@ import com.cotor.app.IssueStatus
 import com.cotor.app.ReviewQueueItem
 import com.cotor.policy.PolicyEngine
 import com.cotor.providers.github.GitHubControlPlaneService
+import com.cotor.providers.github.PullRequestSnapshot
+import com.cotor.runtime.actions.ActionLogSnapshot
 import com.cotor.runtime.actions.ActionStatus
 import com.cotor.runtime.actions.ActionStore
+import com.cotor.runtime.durable.DurableRunSnapshot
 import com.cotor.runtime.durable.DurableRunStatus
 import com.cotor.runtime.durable.DurableRuntimeService
+import java.util.concurrent.ConcurrentHashMap
 
 data class BoundCompanyRuntime(
     val runtime: CompanyRuntimeSnapshot,
@@ -24,8 +28,16 @@ class CompanyRuntimeBindingService(
     private val durableRuntimeService: DurableRuntimeService = DurableRuntimeService(),
     private val actionStore: ActionStore = ActionStore(),
     private val policyEngine: PolicyEngine = PolicyEngine(),
-    private val gitHubControlPlaneService: GitHubControlPlaneService = GitHubControlPlaneService()
+    private val gitHubControlPlaneService: GitHubControlPlaneService = GitHubControlPlaneService(),
+    private val cacheTtlMs: Long = 5_000L,
+    private val nowProvider: () -> Long = { System.currentTimeMillis() }
 ) {
+    private data class CachedValue<T>(val value: T, val storedAt: Long)
+
+    private val durableRunListCache = ConcurrentHashMap<String, CachedValue<List<DurableRunSnapshot>>>()
+    private val actionSnapshotListCache = ConcurrentHashMap<String, CachedValue<List<ActionLogSnapshot>>>()
+    private val githubPullRequestCache = ConcurrentHashMap<String, CachedValue<List<PullRequestSnapshot>>>()
+
     fun bind(state: DesktopAppState, companyId: String, runtime: CompanyRuntimeSnapshot): BoundCompanyRuntime {
         val boundRunIds = state.issues
             .filter { it.companyId == companyId }
@@ -45,7 +57,7 @@ class CompanyRuntimeBindingService(
             directRuns
         } else {
             (
-                directRuns + durableRuntimeService.listRuns().filter { run ->
+                directRuns + cachedDurableRuns(companyId).filter { run ->
                     run.runId in boundRunIds ||
                         run.pipelineName in boundPipelineIds ||
                         run.checkpoints.any { node -> node.metadata["companyId"] == companyId } ||
@@ -53,12 +65,12 @@ class CompanyRuntimeBindingService(
                 }
                 ).distinctBy { it.runId }
         }
-        val githubPullRequests = gitHubControlPlaneService.listPullRequests(companyId)
+        val githubPullRequests = cachedGithubPullRequests(companyId)
         val directActionLogs = boundRunIds.mapNotNull(actionStore::load)
         val actionLogs = if (boundRunIds.isNotEmpty() && directActionLogs.size == boundRunIds.size) {
             directActionLogs
         } else {
-            (directActionLogs + actionStore.listSnapshots()).distinctBy { it.runId }
+            (directActionLogs + cachedActionSnapshots(companyId)).distinctBy { it.runId }
         }
 
         val resumableRunIds = runs
@@ -202,10 +214,31 @@ class CompanyRuntimeBindingService(
                 pendingIssueIds = pendingIssueIds,
                 blockedIssueIds = blockedIssueIds,
                 reviewQueueAttentionIds = reviewQueueAttentionIds,
-                lastReconciliationAt = System.currentTimeMillis()
+                lastReconciliationAt = nowProvider()
             ),
             issues = boundIssues,
             reviewQueue = boundQueue
         )
+    }
+
+    private fun cachedDurableRuns(companyId: String): List<DurableRunSnapshot> =
+        cached(companyId, durableRunListCache) { durableRuntimeService.listRuns() }
+
+    private fun cachedActionSnapshots(companyId: String): List<ActionLogSnapshot> =
+        cached(companyId, actionSnapshotListCache) { actionStore.listSnapshots() }
+
+    private fun cachedGithubPullRequests(companyId: String): List<PullRequestSnapshot> =
+        cached(companyId, githubPullRequestCache) { gitHubControlPlaneService.listPullRequests(companyId) }
+
+    private fun <T> cached(
+        companyId: String,
+        cache: ConcurrentHashMap<String, CachedValue<List<T>>>,
+        loader: () -> List<T>
+    ): List<T> {
+        val now = nowProvider()
+        cache[companyId]?.takeIf { now - it.storedAt <= cacheTtlMs }?.let { return it.value }
+        val loaded = loader()
+        cache[companyId] = CachedValue(loaded, now)
+        return loaded
     }
 }

--- a/src/main/kotlin/com/cotor/app/runtime/WorkQueue.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/WorkQueue.kt
@@ -1,17 +1,20 @@
 package com.cotor.app.runtime
 
+import java.util.concurrent.ConcurrentLinkedQueue
+
 class WorkQueue {
-    private val commands = ArrayDeque<RuntimeCommand>()
+    private val commands = ConcurrentLinkedQueue<RuntimeCommand>()
 
     fun enqueue(command: RuntimeCommand) {
-        commands += command
+        commands.add(command)
     }
 
     fun isEmpty(): Boolean = commands.isEmpty()
 
     suspend fun drain(executor: suspend (RuntimeCommand) -> Unit) {
-        while (commands.isNotEmpty()) {
-            executor(commands.removeFirst())
+        while (true) {
+            val command = commands.poll() ?: return
+            executor(command)
         }
     }
 }

--- a/src/main/kotlin/com/cotor/di/KoinModules.kt
+++ b/src/main/kotlin/com/cotor/di/KoinModules.kt
@@ -26,6 +26,7 @@ import com.cotor.data.plugin.PluginLoader
 import com.cotor.data.plugin.ReflectionPluginLoader
 import com.cotor.data.process.CoroutineProcessManager
 import com.cotor.data.process.ProcessManager
+import com.cotor.data.process.resolveExecutablePath
 import com.cotor.data.registry.AgentRegistry
 import com.cotor.data.registry.InMemoryAgentRegistry
 import com.cotor.domain.aggregator.DefaultResultAggregator
@@ -66,6 +67,8 @@ import com.cotor.verification.VerificationBundleService
 import org.koin.dsl.module
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -130,33 +133,19 @@ val cotorModule = module {
             gitHubControlPlaneService = get(),
             knowledgeService = get(),
             durableRuntimeService = get(),
-            verificationBundleService = get()
+            verificationBundleService = get(),
+            securityValidator = get()
         )
     }
     single { DesktopTuiSessionService(get(), get(), get(), get()) }
 
     // Security
     single<SecurityConfig> {
+        val allowedExecutables = defaultAllowedExecutables()
         SecurityConfig(
             useWhitelist = true,
-            allowedExecutables = setOf(
-                "python3", "node", "java", "git", "gh", "lsof",
-                "claude", "codex", "copilot", "gemini", "cursor-cli", "opencode", "qwen"
-            ),
-            allowedDirectories = listOf(
-                Path("/usr/bin"),
-                Path("/bin"),
-                Path("/usr/sbin"),
-                Path("/sbin"),
-                Path("/usr/local/bin"),
-                Path("/usr/local/Cellar"),
-                Path("/usr/local/opt"),
-                Path("/opt/homebrew/bin"),
-                Path("/opt/homebrew/Cellar"),
-                Path("/opt/homebrew/opt"),
-                Path("/opt/cotor"),
-                Path(System.getProperty("user.home")).resolve("Library").resolve("Application Support").resolve("CotorDesktop")
-            )
+            allowedExecutables = allowedExecutables,
+            allowedDirectories = defaultAllowedDirectories(allowedExecutables)
         )
     }
     single<SecurityValidator> { DefaultSecurityValidator(get(), get()) }
@@ -198,4 +187,40 @@ fun initializeCotor() {
     org.koin.core.context.startKoin {
         modules(cotorModule)
     }
+}
+
+private fun defaultAllowedExecutables(): Set<String> = setOf(
+    "python3", "node", "java", "git", "gh", "lsof",
+    "claude", "codex", "copilot", "gemini", "cursor-cli", "opencode", "qwen", "graphify"
+)
+
+private fun defaultAllowedDirectories(allowedExecutables: Set<String>): List<Path> {
+    val pathDirectories = System.getenv("PATH")
+        .orEmpty()
+        .split(File.pathSeparator)
+        .mapNotNull { it.trim().takeIf(String::isNotBlank) }
+        .map { Path(it).toAbsolutePath().normalize() }
+    val executableDirectories = allowedExecutables.mapNotNull { executable ->
+        runCatching { resolveExecutablePath(executable)?.parent }.getOrNull()
+    }
+    val userHome = Path(System.getProperty("user.home")).toAbsolutePath().normalize()
+    val conventionalDirectories = listOf(
+        Path("/usr/bin"),
+        Path("/bin"),
+        Path("/usr/sbin"),
+        Path("/sbin"),
+        Path("/usr/local/bin"),
+        Path("/usr/local/Cellar"),
+        Path("/usr/local/opt"),
+        Path("/opt/homebrew/bin"),
+        Path("/opt/homebrew/Cellar"),
+        Path("/opt/homebrew/opt"),
+        Path("/opt/cotor"),
+        userHome.resolve("Library").resolve("Python"),
+        userHome.resolve("Library").resolve("Application Support").resolve("CotorDesktop")
+    )
+    return (pathDirectories + executableDirectories + conventionalDirectories)
+        .map { it.toAbsolutePath().normalize() }
+        .filter { Files.exists(it) }
+        .distinct()
 }

--- a/src/main/kotlin/com/cotor/security/SecurityValidator.kt
+++ b/src/main/kotlin/com/cotor/security/SecurityValidator.kt
@@ -162,11 +162,10 @@ class DefaultSecurityValidator(
     }
 
     private fun containsInjectionPattern(input: String): Boolean {
-        val injectionPatterns = listOf("`", "$(", "\n", "\r", " ")
-
-        return injectionPatterns.any { pattern ->
-            input.contains(pattern)
-        }
+        // Commands are executed as argv lists, not through a shell. Shell
+        // metacharacters such as >, <, and | are valid prompt text in that
+        // model; the actual shell execution path is blocked separately above.
+        return input.any { it == '\u0000' || it == '\n' || it == '\r' }
     }
 
     private fun isShellInterpreter(executableName: String): Boolean {
@@ -175,7 +174,20 @@ class DefaultSecurityValidator(
 
     private fun isShellExecuteOption(arg: String): Boolean {
         val normalized = arg.trim().lowercase()
-        return normalized in setOf("/c", "-c", "--command", "-command",
-            "-encodedcommand", "-encodedarguments")
+        if (normalized in setOf(
+                "/c",
+                "-c",
+                "--command",
+                "-command",
+                "-encodedcommand",
+                "-encodedarguments"
+            )
+        ) {
+            return true
+        }
+        return normalized.startsWith("-") &&
+            !normalized.startsWith("--") &&
+            normalized.length > 2 &&
+            normalized.drop(1).contains('c')
     }
 }

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -48,6 +48,15 @@ class A2aApiTest : FunSpec({
         val appHome = System.getProperty("cotor.desktop.app.home")?.let(java.nio.file.Paths::get)
         System.clearProperty("cotor.desktop.app.home")
         if (appHome != null && appHome.exists()) {
+            repeat(5) { attempt ->
+                val deleted = runCatching { appHome.deleteRecursively() }.isSuccess
+                if (deleted || !appHome.exists()) {
+                    return@afterTest
+                }
+                if (attempt < 4) {
+                    Thread.sleep(25)
+                }
+            }
             appHome.deleteRecursively()
         }
     }

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRequeueOrphanedTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRequeueOrphanedTest.kt
@@ -254,7 +254,10 @@ class DesktopAppServiceRequeueOrphanedTest : FunSpec({
 
             withTimeout(30_000) {
                 while (true) {
-                    if (stateStore.load().tasks.count { it.issueId == issue.id } == 2) {
+                    val current = stateStore.load()
+                    val currentIssue = current.issues.single { it.id == issue.id }
+                    val issueTasks = current.tasks.filter { it.issueId == issue.id }
+                    if (currentIssue.status != IssueStatus.BLOCKED || issueTasks.size > 1) {
                         return@withTimeout
                     }
                     delay(25)

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -15,10 +15,12 @@ import com.cotor.domain.executor.AgentExecutor
 import com.cotor.integrations.linear.LinearIssueMirror
 import com.cotor.integrations.linear.LinearTrackerAdapter
 import com.cotor.model.AgentConfig
+import com.cotor.model.AgentExecutionMetadata
 import com.cotor.model.AgentResult
 import com.cotor.model.OpenCodeDefaults
 import com.cotor.model.ProcessExecutionException
 import com.cotor.model.ProcessResult
+import com.cotor.model.RetryPolicy
 import com.cotor.testsupport.withDesktopServiceShutdown
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.annotation.Isolate
@@ -40,7 +42,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
@@ -1111,7 +1115,8 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore,
             gitWorkspaceService = mockk(relaxed = true),
             configRepository = mockk(relaxed = true),
-            agentExecutor = mockk(relaxed = true)
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
         )
         val company = service.createCompany(name = "HR Operator", rootPath = appHome.toString())
         val initial = stateStore.load()
@@ -6025,7 +6030,7 @@ class DesktopAppServiceTest : FunSpec({
         )
 
         service.prepareCompanyAutomationStateForTesting(company.id)
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         val runtime = stateStore.load().companyRuntimes.single { it.companyId == company.id }
         runtime.status shouldBe CompanyRuntimeStatus.STOPPED
@@ -6191,6 +6196,92 @@ class DesktopAppServiceTest : FunSpec({
                 process.destroyForcibly()
             }
         }
+    }
+
+    test("stopCompanyRuntime terminates a process that starts after task interruption") {
+        val appHome = Files.createTempDirectory("desktop-runtime-stop-late-process-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-stop-late-process-test").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
+        coEvery {
+            gitWorkspaceService.ensureWorktree(
+                repositoryRoot = any(),
+                taskId = any(),
+                taskTitle = any(),
+                agentName = any(),
+                baseBranch = any()
+            )
+        } returns WorktreeBinding(
+            branchName = "codex/cotor/late-process/opencode",
+            worktreePath = repoRoot
+        )
+        val executor = LateProcessStartAgentExecutor()
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = gitWorkspaceService,
+            configRepository = mockk(relaxed = true),
+            agentExecutor = executor,
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(
+            name = "Stop Late Process Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Stop a late process",
+            description = "Runtime stop should also cover process ids that appear after interruption.",
+            autonomyEnabled = false
+        )
+        val issue = service.listIssues(goal.id).first { it.kind == "execution" }
+        val workspace = stateStore.load().workspaces.first { it.id == issue.workspaceId }
+        val now = System.currentTimeMillis()
+        val task = AgentTask(
+            id = "task-late-process",
+            workspaceId = workspace.id,
+            issueId = issue.id,
+            title = issue.title,
+            prompt = "Start after stop.",
+            agents = listOf("opencode"),
+            status = DesktopTaskStatus.QUEUED,
+            createdAt = now,
+            updatedAt = now
+        )
+        stateStore.save(stateStore.load().copy(tasks = stateStore.load().tasks + task))
+
+        service.runTask(task.id)
+        withTimeout(5_000) { executor.executeEntered.await() }
+
+        val stopped = service.stopCompanyRuntime(company.id)
+        stopped.status shouldBe CompanyRuntimeStatus.STOPPED
+
+        executor.releaseProcessStart.complete(Unit)
+        val process = withTimeout(5_000) { executor.processStarted.await() }
+        try {
+            withTimeout(5_000) {
+                while (process.isAlive) {
+                    delay(25)
+                }
+            }
+        } finally {
+            executor.finish.complete(Unit)
+            if (process.isAlive) {
+                process.destroyForcibly()
+            }
+        }
+
+        withTimeout(5_000) {
+            while (stateStore.load().runs.any { it.status == AgentRunStatus.RUNNING || it.status == AgentRunStatus.QUEUED }) {
+                delay(25)
+            }
+        }
+        val run = stateStore.load().runs.single { it.taskId == task.id }
+        val storedTask = stateStore.load().tasks.single { it.id == task.id }
+        run.status shouldBe AgentRunStatus.FAILED
+        run.error shouldContain "Execution was interrupted"
+        storedTask.status shouldBe DesktopTaskStatus.FAILED
     }
 
     test("company budgets can be saved, cleared, and survive runtime restarts") {
@@ -6507,7 +6598,7 @@ class DesktopAppServiceTest : FunSpec({
             commandAvailability = { command -> command == "opencode" || command == "codex" }
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         val definitions = service.listCompanyAgentDefinitions(company.id)
         definitions.map { it.agentCli }.distinct() shouldBe listOf("opencode")
@@ -6722,7 +6813,7 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
@@ -6846,7 +6937,7 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
@@ -6984,7 +7075,7 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
@@ -7108,7 +7199,7 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
@@ -9718,7 +9809,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         val refreshedState = stateStore.load()
         val refreshedGoal = refreshedState.goals.first { it.id == legacyFollowUpGoal.id }
@@ -12453,7 +12544,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         val settled = stateStore.load()
         val settledIssue = settled.issues.first { it.id == issue.id }
@@ -13020,7 +13111,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         val refreshed = stateStore.load()
         val refreshedQueue = refreshed.reviewQueue.first { it.id == queueItem.id }
@@ -13901,7 +13992,7 @@ class DesktopAppServiceTest : FunSpec({
         refreshedQueue.status shouldBe ReviewQueueStatus.CHANGES_REQUESTED
     }
 
-    test("company dashboard read requeues legacy blocked execution issues for dirty CEO merge conflicts while stopped") {
+    test("company dashboard prepared requeues legacy blocked execution issues for dirty CEO merge conflicts while stopped") {
         val appHome = Files.createTempDirectory("desktop-app-service-dashboard-merge-conflict-requeue")
         val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-app-service-dashboard-merge-conflict-requeue-repo").resolve("repo"))
         val stateStore = DesktopStateStore { appHome }
@@ -14008,12 +14099,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
-        service.companyDashboard(company.id)
-        withTimeout(2_000) {
-            while (stateStore.load().issues.first { it.id == executionIssue.id }.status != IssueStatus.PLANNED) {
-                delay(25)
-            }
-        }
+        service.companyDashboardPrepared(company.id)
 
         val refreshedState = stateStore.load()
         val refreshedExecution = refreshedState.issues.first { it.id == executionIssue.id }
@@ -15632,6 +15718,49 @@ private class FakeLinearTrackerAdapter : LinearTrackerAdapter {
         commentCalls += CommentCall(linearIssueId, body)
         return Result.success(Unit)
     }
+}
+
+private class LateProcessStartAgentExecutor : AgentExecutor {
+    val executeEntered = CompletableDeferred<Unit>()
+    val releaseProcessStart = CompletableDeferred<Unit>()
+    val processStarted = CompletableDeferred<Process>()
+    val finish = CompletableDeferred<Unit>()
+
+    override suspend fun executeAgent(
+        agent: AgentConfig,
+        input: String?,
+        metadata: AgentExecutionMetadata
+    ): AgentResult = withContext(NonCancellable) {
+        executeEntered.complete(Unit)
+        releaseProcessStart.await()
+        val process = ProcessBuilder("sleep", "30").start()
+        processStarted.complete(process)
+        metadata.onProcessStarted?.invoke(process.pid())
+        withTimeoutOrNull(5_000) {
+            while (process.isAlive && !finish.isCompleted) {
+                delay(25)
+            }
+        }
+        if (process.isAlive && finish.isCompleted) {
+            process.destroyForcibly()
+        }
+        AgentResult(
+            agentName = agent.name,
+            isSuccess = false,
+            output = null,
+            error = "Stopped during test.",
+            duration = 0,
+            metadata = emptyMap(),
+            processId = process.pid()
+        )
+    }
+
+    override suspend fun executeWithRetry(
+        agent: AgentConfig,
+        input: String?,
+        retryPolicy: RetryPolicy,
+        metadata: AgentExecutionMetadata
+    ): AgentResult = executeAgent(agent, input, metadata)
 }
 
 private class FakeGitProcessManager(

--- a/src/test/kotlin/com/cotor/app/DesktopStateStoreLockTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopStateStoreLockTest.kt
@@ -4,6 +4,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import kotlin.io.path.exists
@@ -34,8 +37,37 @@ class DesktopStateStoreLockTest : FunSpec({
             )
         }
 
-        appHome.resolve("state.json").exists() shouldBe true
+        appHome.resolve("state.sqlite").exists() shouldBe true
         appHome.resolve("state.lock.json").exists() shouldBe false
+    }
+
+    test("concurrent sqlite saves from separate store instances serialize inside one JVM") {
+        val appHome = Files.createTempDirectory("desktop-state-lock-same-jvm-home")
+
+        runBlocking {
+            (0 until 12).map { index ->
+                async(Dispatchers.Default) {
+                    DesktopStateStore { appHome }.save(
+                        DesktopAppState(
+                            companies = listOf(
+                                Company(
+                                    id = "company-$index",
+                                    name = "Company $index",
+                                    rootPath = "/tmp/company-$index",
+                                    repositoryId = "repo-$index",
+                                    defaultBaseBranch = "master",
+                                    createdAt = index.toLong(),
+                                    updatedAt = index.toLong()
+                                )
+                            )
+                        )
+                    )
+                }
+            }.awaitAll()
+        }
+
+        appHome.resolve("state.sqlite").exists() shouldBe true
+        DesktopStateStore { appHome }.load().companies.size shouldBe 1
     }
 
     test("save fails fast with diagnostics when another process holds state.lock") {

--- a/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.string.shouldNotContain
 import kotlinx.serialization.json.Json
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
+import java.sql.DriverManager
 import kotlin.io.path.readText
 
 class DesktopStateStoreTest : FunSpec({
@@ -62,8 +63,34 @@ class DesktopStateStoreTest : FunSpec({
         store.save(DesktopAppState())
 
         stateTempFilesToClean(appHome) shouldBe emptyList()
-        appHome.resolve("state.json").toFile().exists() shouldBe true
-        appHome.resolve("state.json.bak").toFile().exists() shouldBe true
+        appHome.resolve("state.sqlite").toFile().exists() shouldBe true
+    }
+
+    test("load migrates legacy json state into sqlite without deleting rollback files") {
+        val appHome = Files.createTempDirectory("desktop-state-store-json-migration-home")
+        val legacyState = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Migrated Company",
+                    rootPath = "/tmp/migrated-company",
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            )
+        )
+        saveLegacyJsonState(appHome, legacyState)
+        val legacyPayload = appHome.resolve("state.json").readText()
+
+        val loaded = DesktopStateStore { appHome }.load()
+
+        loaded.companies.map { it.name } shouldBe listOf("Migrated Company")
+        appHome.resolve("state.sqlite").toFile().exists() shouldBe true
+        appHome.resolve("state.json").readText() shouldBe legacyPayload
+        appHome.resolve("state.json.bak").readText() shouldBe legacyPayload
+        readSqliteCollection(appHome, "companies") shouldContain "Migrated Company"
     }
 
     test("fresh state temp files are not cleaned while another save may still be moving them") {
@@ -195,7 +222,7 @@ class DesktopStateStoreTest : FunSpec({
             )
         )
 
-        store.save(validState)
+        saveLegacyJsonState(appHome, validState)
         Files.writeString(
             appHome.resolve("state.json"),
             "{\n  \"companies\": [\n    {\n      \"id\": \"broken\"\n"
@@ -205,6 +232,7 @@ class DesktopStateStoreTest : FunSpec({
 
         recovered.companies.map { it.name } shouldBe listOf("Recovered From Backup")
         Files.readString(appHome.resolve("state.json.bak")).contains("Recovered From Backup") shouldBe true
+        appHome.resolve("state.sqlite").toFile().exists() shouldBe true
     }
 
     test("load restores the backup when the primary state file is corrupted in the middle") {
@@ -224,7 +252,7 @@ class DesktopStateStoreTest : FunSpec({
             )
         )
 
-        store.save(validState)
+        saveLegacyJsonState(appHome, validState)
         val validPayload = appHome.resolve("state.json").readText()
         val insertionPoint = validPayload.indexOf("\"name\":")
         val corruptedPayload = buildString {
@@ -292,19 +320,189 @@ class DesktopStateStoreTest : FunSpec({
         )
 
         store.save(validState)
-        val statePath = appHome.resolve("state.json")
-        val corruptedPayload = statePath.readText().replaceFirst(
+        val corruptedPayload = readSqliteCollection(appHome, "tasks").replaceFirst(
             "\"status\": \"COMPLETED\"",
             "\"status\": \"NOT_A_REAL_STATUS\""
         )
-        Files.writeString(statePath, corruptedPayload)
+        writeSqliteCollection(appHome, "tasks", corruptedPayload)
 
         val recovered = store.load()
 
         recovered.companies.map { it.name } shouldBe listOf("Lenient Company")
         recovered.goals.map { it.title } shouldBe listOf("Keep working")
         recovered.tasks shouldBe emptyList()
-        Files.readString(appHome.resolve("runtime").resolve("backend").resolve("state-load.log")) shouldContain "Recovered state with lenient decode"
+        Files.readString(appHome.resolve("runtime").resolve("backend").resolve("state-load.log")) shouldContain
+            "Recovered SQLite state without invalid collection tasks"
+    }
+
+    test("load returns sqlite revision cache when the database revision is unchanged") {
+        val appHome = Files.createTempDirectory("desktop-state-store-sqlite-cache-home")
+        val store = DesktopStateStore { appHome }
+        val state = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Cached Company",
+                    rootPath = "/tmp/cached-company",
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            )
+        )
+
+        store.save(state)
+        val mutatedPayload = readSqliteCollection(appHome, "companies").replace("Cached Company", "Unrevised Company")
+        writeSqliteCollection(appHome, "companies", mutatedPayload, bumpRevision = false)
+
+        store.load().companies.map { it.name } shouldBe listOf("Cached Company")
+    }
+
+    test("save rewrites only sqlite collections whose payload changed") {
+        val appHome = Files.createTempDirectory("desktop-state-store-partial-update-home")
+        val store = DesktopStateStore { appHome }
+        val state = DesktopAppState(
+            companies = listOf(
+                Company(
+                    id = "company-1",
+                    name = "Stable Company",
+                    rootPath = "/tmp/stable-company",
+                    repositoryId = "repo-1",
+                    defaultBaseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            tasks = listOf(
+                AgentTask(
+                    id = "task-1",
+                    workspaceId = "workspace-1",
+                    title = "Original task",
+                    prompt = "prompt",
+                    agents = listOf("codex"),
+                    status = DesktopTaskStatus.QUEUED,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            )
+        )
+
+        store.save(state)
+        val companyUpdatedAt = readSqliteCollectionUpdatedAt(appHome, "companies")
+        val taskUpdatedAt = readSqliteCollectionUpdatedAt(appHome, "tasks")
+        Thread.sleep(5L)
+        store.save(state.copy(tasks = state.tasks.map { it.copy(title = "Updated task", updatedAt = 2L) }))
+
+        readSqliteCollectionUpdatedAt(appHome, "companies") shouldBe companyUpdatedAt
+        (readSqliteCollectionUpdatedAt(appHome, "tasks") > taskUpdatedAt) shouldBe true
+    }
+
+    test("large state small mutation updates only the changed sqlite collection") {
+        val appHome = Files.createTempDirectory("desktop-state-store-large-partial-home")
+        val store = DesktopStateStore { appHome }
+        val company = Company(
+            id = "company-large",
+            name = "Large Company",
+            rootPath = "/tmp/large-company",
+            repositoryId = "repo-large",
+            defaultBaseBranch = "master",
+            createdAt = 1L,
+            updatedAt = 1L
+        )
+        val state = DesktopAppState(
+            companies = listOf(company),
+            repositories = listOf(
+                ManagedRepository(
+                    id = "repo-large",
+                    name = "Large Repo",
+                    localPath = "/tmp/large-company",
+                    sourceKind = RepositorySourceKind.LOCAL,
+                    defaultBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            workspaces = listOf(
+                Workspace(
+                    id = "workspace-large",
+                    repositoryId = "repo-large",
+                    name = "Large workspace",
+                    baseBranch = "master",
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            goals = listOf(
+                CompanyGoal(
+                    id = "goal-large",
+                    companyId = company.id,
+                    title = "Large goal",
+                    description = "Large goal",
+                    status = GoalStatus.ACTIVE,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            ),
+            issues = (0 until 1_000).map { index ->
+                CompanyIssue(
+                    id = "issue-$index",
+                    companyId = company.id,
+                    goalId = "goal-large",
+                    workspaceId = "workspace-large",
+                    title = "Issue $index",
+                    description = "Issue $index",
+                    status = IssueStatus.PLANNED,
+                    createdAt = index.toLong(),
+                    updatedAt = index.toLong()
+                )
+            },
+            tasks = (0 until 2_000).map { index ->
+                AgentTask(
+                    id = "task-$index",
+                    workspaceId = "workspace-large",
+                    issueId = "issue-${index % 1_000}",
+                    title = "Task $index",
+                    prompt = "Prompt $index",
+                    agents = listOf("codex"),
+                    status = DesktopTaskStatus.QUEUED,
+                    createdAt = index.toLong(),
+                    updatedAt = index.toLong()
+                )
+            },
+            runs = (0 until 5_000).map { index ->
+                AgentRun(
+                    id = "run-$index",
+                    taskId = "task-${index % 2_000}",
+                    workspaceId = "workspace-large",
+                    repositoryId = "repo-large",
+                    agentName = "codex",
+                    branchName = "branch-$index",
+                    worktreePath = "/tmp/large-company/.cotor/worktrees/task-${index % 2_000}/codex",
+                    status = AgentRunStatus.COMPLETED,
+                    createdAt = index.toLong(),
+                    updatedAt = index.toLong()
+                )
+            }
+        )
+
+        store.save(state)
+        val issuesUpdatedAt = readSqliteCollectionUpdatedAt(appHome, "issues")
+        val runsUpdatedAt = readSqliteCollectionUpdatedAt(appHome, "runs")
+        val taskUpdatedAt = readSqliteCollectionUpdatedAt(appHome, "tasks")
+        Thread.sleep(5L)
+        store.save(
+            state.copy(
+                tasks = state.tasks.mapIndexed { index, task ->
+                    if (index == 0) task.copy(status = DesktopTaskStatus.COMPLETED, updatedAt = 9_999L) else task
+                }
+            )
+        )
+
+        readSqliteCollectionUpdatedAt(appHome, "issues") shouldBe issuesUpdatedAt
+        readSqliteCollectionUpdatedAt(appHome, "runs") shouldBe runsUpdatedAt
+        (readSqliteCollectionUpdatedAt(appHome, "tasks") > taskUpdatedAt) shouldBe true
+        store.load().tasks.first { it.id == "task-0" }.status shouldBe DesktopTaskStatus.COMPLETED
     }
 
     test("lenient recovery preserves workflow pipelines, agent context entries, and agent messages") {
@@ -371,12 +569,11 @@ class DesktopStateStoreTest : FunSpec({
         )
 
         store.save(state)
-        val statePath = appHome.resolve("state.json")
-        val corruptedPayload = statePath.readText().replaceFirst(
+        val corruptedPayload = readSqliteCollection(appHome, "tasks").replaceFirst(
             "\"status\": \"COMPLETED\"",
             "\"status\": \"NOT_A_REAL_STATUS\""
         )
-        Files.writeString(statePath, corruptedPayload)
+        writeSqliteCollection(appHome, "tasks", corruptedPayload)
 
         val recovered = store.load()
 
@@ -434,7 +631,7 @@ class DesktopStateStoreTest : FunSpec({
         )
 
         store.save(state)
-        val persisted = appHome.resolve("state.json").readText()
+        val persisted = readSqliteCollection(appHome, "tasks") + readSqliteCollection(appHome, "runs")
 
         persisted.shouldContain("[compacted ")
         persisted.shouldNotContain(longPrompt)
@@ -510,7 +707,7 @@ class DesktopStateStoreTest : FunSpec({
         )
 
         store.save(state)
-        val persisted = appHome.resolve("state.json").readText()
+        val persisted = readSqliteCollection(appHome, "tasks")
 
         persisted.shouldContain(longPrompt.take(200))
         persisted.shouldNotContain("[compacted ")
@@ -600,9 +797,64 @@ class DesktopStateStoreTest : FunSpec({
         )
 
         store.save(state)
-        val persisted = appHome.resolve("state.json").readText()
+        val persisted = readSqliteCollection(appHome, "runs")
 
         store.load().runs.single().output shouldBe longOutput
         persisted.shouldNotContain("[compacted ")
     }
 })
+
+private suspend fun saveLegacyJsonState(appHome: java.nio.file.Path, state: DesktopAppState) {
+    val previous = System.getProperty("cotor.desktop.state.backend")
+    System.setProperty("cotor.desktop.state.backend", "json")
+    try {
+        DesktopStateStore { appHome }.save(state)
+    } finally {
+        if (previous == null) {
+            System.clearProperty("cotor.desktop.state.backend")
+        } else {
+            System.setProperty("cotor.desktop.state.backend", previous)
+        }
+    }
+}
+
+private fun readSqliteCollection(appHome: java.nio.file.Path, name: String): String =
+    DriverManager.getConnection("jdbc:sqlite:${appHome.resolve("state.sqlite").toAbsolutePath().normalize()}").use { connection ->
+        connection.prepareStatement("SELECT payload FROM state_collections WHERE name = ?").use { statement ->
+            statement.setString(1, name)
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getString(1) else ""
+            }
+        }
+    }
+
+private fun readSqliteCollectionUpdatedAt(appHome: java.nio.file.Path, name: String): Long =
+    DriverManager.getConnection("jdbc:sqlite:${appHome.resolve("state.sqlite").toAbsolutePath().normalize()}").use { connection ->
+        connection.prepareStatement("SELECT updated_at FROM state_collections WHERE name = ?").use { statement ->
+            statement.setString(1, name)
+            statement.executeQuery().use { result ->
+                if (result.next()) result.getLong(1) else 0L
+            }
+        }
+    }
+
+private fun writeSqliteCollection(
+    appHome: java.nio.file.Path,
+    name: String,
+    payload: String,
+    bumpRevision: Boolean = true
+) {
+    DriverManager.getConnection("jdbc:sqlite:${appHome.resolve("state.sqlite").toAbsolutePath().normalize()}").use { connection ->
+        connection.prepareStatement("UPDATE state_collections SET payload = ?, payload_sha256 = 'corrupted', updated_at = ? WHERE name = ?").use { statement ->
+            statement.setString(1, payload)
+            statement.setLong(2, System.currentTimeMillis())
+            statement.setString(3, name)
+            statement.executeUpdate()
+        }
+        if (bumpRevision) {
+            connection.prepareStatement("UPDATE state_meta SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT) WHERE key = 'revision'").use { statement ->
+                statement.executeUpdate()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
@@ -24,6 +24,10 @@ import io.kotest.matchers.string.shouldContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import java.net.Authenticator
 import java.net.CookieHandler
@@ -41,6 +45,7 @@ import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.Flow
+import java.util.concurrent.atomic.AtomicInteger
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLParameters
 import javax.net.ssl.SSLSession
@@ -122,6 +127,28 @@ class GitWorkspaceServiceTest : FunSpec({
         first.branchName shouldContain "task-a-1"
         second.branchName shouldContain "task-b-2"
         processManager.remainingSteps() shouldBe 0
+    }
+
+    test("ensureWorktree serializes common git directory mutations for the same repository") {
+        val repositoryRoot = Files.createTempDirectory("git-workspace-concurrent-repo")
+        val processManager = ConcurrentGitMutationProcessManager()
+        val service = GitWorkspaceService(processManager, mockk(relaxed = true), mockk<Logger>(relaxed = true))
+
+        runBlocking {
+            (0 until 4).map { index ->
+                async {
+                    service.ensureWorktree(
+                        repositoryRoot = repositoryRoot,
+                        taskId = "task-$index",
+                        taskTitle = "Concurrent mutation $index",
+                        agentName = "codex",
+                        baseBranch = "master"
+                    )
+                }
+            }.awaitAll()
+        }
+
+        processManager.maxConcurrentWorktreeAdds.get() shouldBe 1
     }
 
     test("ensureWorktree creates new execution branches from origin when the remote base is newer") {
@@ -1877,6 +1904,44 @@ private fun HttpRequest.readBody(): String {
         }
     })
     return completed.join()
+}
+
+private class ConcurrentGitMutationProcessManager : ProcessManager {
+    val maxConcurrentWorktreeAdds = AtomicInteger(0)
+    private val activeWorktreeAdds = AtomicInteger(0)
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        return when {
+            command == listOf("git", "rev-parse", "--verify", "HEAD") ->
+                ProcessResult(0, "abc1234567890\n", "", true)
+
+            command.take(4) == listOf("git", "show-ref", "--verify", "--quiet") ->
+                ProcessResult(1, "", "", false)
+
+            command == listOf("git", "config", "--get", "remote.origin.url") ->
+                ProcessResult(1, "", "", false)
+
+            command.size >= 3 && command[0] == "git" && command[1] == "worktree" && command[2] == "add" -> {
+                val active = activeWorktreeAdds.incrementAndGet()
+                maxConcurrentWorktreeAdds.updateAndGet { current -> maxOf(current, active) }
+                try {
+                    delay(25L)
+                    ProcessResult(0, "", "", true)
+                } finally {
+                    activeWorktreeAdds.decrementAndGet()
+                }
+            }
+
+            else -> error("Unexpected command: ${command.joinToString(" ")}")
+        }
+    }
 }
 
 private class FakeProcessManager(

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -2,6 +2,9 @@ package com.cotor.app
 
 import com.cotor.data.config.ConfigRepository
 import com.cotor.domain.executor.AgentExecutor
+import com.cotor.model.AgentConfig
+import com.cotor.model.SecurityException
+import com.cotor.security.SecurityValidator
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -90,6 +93,28 @@ class SkillRuntimeTest : FunSpec({
         result.output shouldContain "DesktopAppService"
         result.evidence.single().path shouldContain "GRAPH_REPORT.md"
         service.dashboard().skillRuns.first().status shouldBe "COMPLETED"
+    }
+
+    test("runSkill validates graphify process commands before launch") {
+        val appHome = Files.createTempDirectory("skill-graphify-security-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val validator = RecordingSecurityValidator(SecurityException("blocked by test validator"))
+        val service = skillRuntimeService(appHome, securityValidator = validator)
+        val company = service.createCompany(name = "Graph Security Co", rootPath = repoRoot.toString())
+        val engineeringLead = service.dashboard().companyAgentDefinitions.first {
+            it.companyId == company.id && it.title == "Engineering Lead"
+        }
+
+        val result = service.runSkill(
+            name = "graphify",
+            companyId = company.id,
+            agentId = engineeringLead.id,
+            parameters = mapOf("refresh" to "true")
+        )
+
+        result.status shouldBe "FAILED"
+        result.error shouldContain "blocked by test validator"
+        validator.commands shouldBe listOf(listOf("graphify", "update", "."))
     }
 
     test("runSkill executes browser-smoke with browser evidence") {
@@ -230,7 +255,8 @@ class SkillRuntimeTest : FunSpec({
 
 private fun skillRuntimeService(
     appHome: java.nio.file.Path,
-    browserRunner: BrowserSkillRunner = RecordingBrowserSkillRunner()
+    browserRunner: BrowserSkillRunner = RecordingBrowserSkillRunner(),
+    securityValidator: SecurityValidator = RecordingSecurityValidator()
 ): DesktopAppService {
     val gitWorkspaceService = mockk<GitWorkspaceService>(relaxed = true)
     coEvery { gitWorkspaceService.ensureInitializedRepositoryRoot(any(), any()) } answers { firstArg() }
@@ -240,8 +266,24 @@ private fun skillRuntimeService(
         configRepository = mockk<ConfigRepository>(relaxed = true),
         agentExecutor = mockk<AgentExecutor>(relaxed = true),
         commandAvailability = { command -> command in setOf("graphify", "node", "npm") },
-        browserSkillRunner = browserRunner
+        browserSkillRunner = browserRunner,
+        securityValidator = securityValidator
     )
+}
+
+private class RecordingSecurityValidator(
+    private val failure: Throwable? = null
+) : SecurityValidator {
+    val commands = mutableListOf<List<String>>()
+
+    override fun validate(agent: AgentConfig) = Unit
+
+    override fun validateCommand(command: List<String>) {
+        commands += command
+        failure?.let { throw it }
+    }
+
+    override fun validatePath(path: java.nio.file.Path) = Unit
 }
 
 private class RecordingBrowserSkillRunner : BrowserSkillRunner {

--- a/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingServiceTest.kt
@@ -482,6 +482,98 @@ class CompanyRuntimeBindingServiceTest : FunSpec({
         bound.runtime.pendingIssueIds shouldNotContain issueId
         bound.runtime.blockedIssueIds shouldContain issueId
     }
+
+    test("bind reuses fallback durable action and github scans inside cache ttl") {
+        val appHome = Files.createTempDirectory("company-runtime-binding-cache")
+        val runStore = DurableRuntimeStore(appHome.resolve("runtime"))
+        val actionStore = ActionStore { appHome }
+        val githubStore = GitHubControlPlaneStore { appHome }
+        val companyId = "company-cache"
+        val issueId = "issue-cache"
+        val runId = "run-cache"
+        val pipelineId = "pipeline-cache"
+        var now = 1_000L
+        val service = CompanyRuntimeBindingService(
+            durableRuntimeService = DurableRuntimeService(runtimeStore = runStore),
+            actionStore = actionStore,
+            policyEngine = PolicyEngine(PolicyStore { appHome }),
+            gitHubControlPlaneService = GitHubControlPlaneService(store = githubStore),
+            cacheTtlMs = 1_000L,
+            nowProvider = { now }
+        )
+        val state = DesktopAppState(
+            companies = listOf(testCompany(companyId)),
+            issues = listOf(
+                CompanyIssue(
+                    id = issueId,
+                    companyId = companyId,
+                    goalId = "goal-cache",
+                    workspaceId = "workspace-cache",
+                    title = "Cache issue",
+                    description = "Cache issue",
+                    status = IssueStatus.IN_PROGRESS,
+                    pipelineId = pipelineId,
+                    createdAt = 1L,
+                    updatedAt = 1L
+                )
+            )
+        )
+        fun bind() = service.bind(
+            state = state,
+            companyId = companyId,
+            runtime = CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+        )
+
+        bind().runtime.resumableRunCount shouldBe 0
+        runStore.saveRun(
+            DurableRunSnapshot(
+                runId = runId,
+                pipelineName = pipelineId,
+                status = DurableRunStatus.RUNNING,
+                createdAt = 1L,
+                updatedAt = 2L
+            )
+        )
+        actionStore.append(
+            runId,
+            ActionExecutionRecord(
+                id = "action-cache",
+                runId = runId,
+                request = ActionRequest(
+                    kind = ActionKind.GITHUB_MERGE,
+                    label = "github.merge:44",
+                    scope = ActionScope.COMPANY,
+                    subject = ActionSubject(runId = runId, companyId = companyId, issueId = issueId)
+                ),
+                status = ActionStatus.DENIED,
+                createdAt = 2L,
+                updatedAt = 3L
+            )
+        )
+        GitHubControlPlaneService(store = githubStore).recordSnapshot(
+            PullRequestSnapshot(
+                number = 44,
+                state = "OPEN",
+                checksSummary = "ci=COMPLETED/FAILURE",
+                companyId = companyId,
+                issueId = issueId,
+                runId = runId
+            ),
+            eventType = "sync",
+            detail = "sync"
+        )
+
+        val cached = bind()
+        cached.runtime.resumableRunCount shouldBe 0
+        cached.runtime.blockedByPolicyCount shouldBe 0
+        cached.runtime.blockedByCiCount shouldBe 0
+
+        now += 1_001L
+        val refreshed = bind()
+        refreshed.runtime.resumableRunCount shouldBe 1
+        refreshed.runtime.blockedByPolicyCount shouldBe 1
+        refreshed.runtime.blockedByCiCount shouldBe 1
+    }
 })
 
 private fun bindSingleIssueForRuntimeDisposition(

--- a/src/test/kotlin/com/cotor/app/runtime/WorkQueueTest.kt
+++ b/src/test/kotlin/com/cotor/app/runtime/WorkQueueTest.kt
@@ -1,0 +1,70 @@
+package com.cotor.app.runtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class WorkQueueTest : FunSpec({
+    test("enqueue and drain tolerate concurrent producers") {
+        val queue = WorkQueue()
+        val expected = (0 until 200).map { "issue-$it" }
+
+        runBlocking {
+            expected.chunked(20).map { chunk ->
+                async(Dispatchers.Default) {
+                    chunk.forEach { issueId ->
+                        queue.enqueue(RuntimeCommand.StartIssue(issueId))
+                    }
+                }
+            }.awaitAll()
+        }
+
+        val drained = mutableListOf<String>()
+        runBlocking {
+            withContext(Dispatchers.Default) {
+                queue.drain { command ->
+                    drained += (command as RuntimeCommand.StartIssue).issueId
+                }
+            }
+        }
+
+        drained.size shouldBe expected.size
+        drained shouldContainExactlyInAnyOrder expected
+    }
+
+    test("drain remains safe while producers enqueue additional commands") {
+        val queue = WorkQueue()
+        val initial = (0 until 100).map { "initial-$it" }
+        val late = (0 until 100).map { "late-$it" }
+        initial.forEach { queue.enqueue(RuntimeCommand.StartIssue(it)) }
+
+        val drained = mutableListOf<String>()
+        runBlocking {
+            val drainer = async(Dispatchers.Default) {
+                queue.drain { command ->
+                    drained += (command as RuntimeCommand.StartIssue).issueId
+                    delay(1L)
+                }
+            }
+            val producer = async(Dispatchers.Default) {
+                late.forEach { issueId ->
+                    queue.enqueue(RuntimeCommand.StartIssue(issueId))
+                    delay(1L)
+                }
+            }
+            awaitAll(drainer, producer)
+            queue.drain { command ->
+                drained += (command as RuntimeCommand.StartIssue).issueId
+            }
+        }
+
+        drained.size shouldBe initial.size + late.size
+        drained shouldContainExactlyInAnyOrder initial + late
+    }
+})

--- a/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
@@ -62,6 +62,35 @@ class SecurityValidatorTest : FunSpec({
         }
     }
 
+    test("command validation allows markdown and comparison text in argv arguments") {
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(allowedExecutables = setOf("graphify")),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        validator.validateCommand(
+            listOf(
+                "graphify",
+                "explain",
+                "Fix the bug where x > 0, render <div>, and preserve A | B markdown table text."
+            )
+        )
+    }
+
+    test("command validation rejects newline and nul bytes in argv arguments") {
+        val validator = DefaultSecurityValidator(
+            SecurityConfig(allowedExecutables = setOf("graphify")),
+            LoggerFactory.getLogger("SecurityValidatorTest")
+        )
+
+        shouldThrow<SecurityException> {
+            validator.validateCommand(listOf("graphify", "explain", "bad\nargument"))
+        }
+        shouldThrow<SecurityException> {
+            validator.validateCommand(listOf("graphify", "explain", "bad\u0000argument"))
+        }
+    }
+
     test("command validation checks resolved absolute path against allowed directories") {
         val blockedDir = Files.createTempDirectory("cotor-blocked-bin")
         val executable = blockedDir.resolve("qwen").toFile()


### PR DESCRIPTION
## 발견된 버그 / 병목
- Desktop state가 단일 JSON 파일에 집중되어 dashboard/runtime hot path에서 전체 decode/encode 및 전체 저장 비용이 반복됨.
- dashboard/companyDashboard 읽기 경로가 무거운 migration/automation maintenance를 동기 실행해 polling 비용을 키움.
- runtime binding이 durable run/action snapshot과 GitHub PR 목록을 반복 full scan함.
- skill 실행 경로가 `runSkillProcess()`에서 command validation을 우회하고, SecurityConfig가 macOS/Homebrew 중심 path에 묶여 실제 PATH executable을 차단할 수 있음.
- argv 기반 command validation이 prompt 텍스트의 `<`, `>`, `|` 같은 정상 markdown/comparison 문자를 shell injection처럼 과잉 차단함.
- Git worktree/common git-dir mutation이 병렬 agent 실행에서 index lock 경합을 일으킬 수 있음.
- runtime stop과 process start callback 사이 레이스로, stop 이후 늦게 도착한 process id가 run을 다시 RUNNING으로 되살리고 opencode 프로세스가 남을 수 있음.
- SQLite WAL sidecar가 생긴 test appHome cleanup에서 delete race가 발생할 수 있음.

## 수정 내용
- `org.xerial:sqlite-jdbc:3.53.1.0` 추가 및 `DesktopStateStore` 기본 backend를 SQLite로 전환.
- `state_collections`/`state_meta` schema, collection별 SHA-256 저장, revision cache, JSON -> SQLite 1회 migration, `COTOR_DESKTOP_STATE_BACKEND=json` rollback 지원 추가.
- dashboard/companyDashboard의 synchronous maintenance를 debounce된 background refresh/prepared path로 분리하고, automation normalization의 반복 issue/review 탐색을 인덱스 기반으로 개선.
- `CompanyRuntimeBindingService` durable/action/GitHub 조회에 짧은 TTL cache 추가.
- `runSkillProcess()`에 `SecurityValidator.validateCommand()` 적용, SecurityConfig allowed directories를 PATH/executable parent/Cotor app home 기반으로 동적 구성.
- SecurityValidator는 shell interpreter execution option과 destructive executable/newline/NUL은 차단하되 argv prompt의 markdown/comparison 문자는 허용.
- `terminateProcessTree()`를 cancellable `delay()` 기반 suspend 함수로 변경.
- `WorkQueue`를 thread-safe queue로 교체.
- `GitWorkspaceService`에 repository common root별 `Mutex`를 추가해 worktree/base branch mutation을 직렬화.
- runtime stop 시 active task job cancel, stale run replacement 방지, stop 이후 늦게 시작된 process 즉시 종료 로직 추가.
- EN/KO troubleshooting docs에 `state.sqlite`, JSON rollback, backend override 문서화.

## 재테스트 결과
- `./gradlew --no-daemon formatCheck` PASS
- `./gradlew test` PASS
- `swift test --package-path macos` PASS
- `graphify update .` PASS, weird `Path*` directory 없음
- `./script/build_and_run.sh --verify` PASS
- `./shell/build-desktop-app-bundle.sh` PASS
- backend bundle jar에 `org/sqlite` 및 `sqlite-jdbc` 포함 확인
- Manual desktop smoke on `/Users/Projects/bssm-oss/cotor-organization/cotor-test`:
  - `/health` OK, dashboard loads with runningSessions=0
  - graphify skill run COMPLETED
  - runtime start -> stop returns STOPPED, after_stop runningSessions=0, activeTasks=[], no opencode process remains
  - `state.sqlite` 생성 확인, 기존 `state.json`/`state.json.bak` 보존 확인

## Known risk / deferred work
- God Class/God Store decomposition and SwiftUI store slicing are intentionally deferred to follow-up architecture PRs.
- This PR preserves current app-server payloads and Swift DTO contracts.
