### PR TITLE
fix(desktop): coordinate startup warmup and shutdown cleanup

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor-qa-auto-performance-20260527  (2026-05-27)
+# Graph Report - cotor-lifecycle-supervisor-20260527  (2026-05-27)
 
 ## Corpus Check
-- 362 files · ~622,352 words
+- 362 files · ~623,331 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4844 nodes · 6737 edges · 308 communities detected
-- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 830 edges (avg confidence: 0.8)
+- 4860 nodes · 6768 edges · 307 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 834 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -186,7 +186,7 @@
 - [[_COMMUNITY_Community 173|Community 173]]
 - [[_COMMUNITY_Community 174|Community 174]]
 - [[_COMMUNITY_Community 175|Community 175]]
-- [[_COMMUNITY_Community 176|Community 176]]
+- [[_COMMUNITY_Community 177|Community 177]]
 - [[_COMMUNITY_Community 178|Community 178]]
 - [[_COMMUNITY_Community 179|Community 179]]
 - [[_COMMUNITY_Community 180|Community 180]]
@@ -220,7 +220,7 @@
 - [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
 - [[_COMMUNITY_Community 210|Community 210]]
-- [[_COMMUNITY_Community 211|Community 211]]
+- [[_COMMUNITY_Community 212|Community 212]]
 - [[_COMMUNITY_Community 213|Community 213]]
 - [[_COMMUNITY_Community 214|Community 214]]
 - [[_COMMUNITY_Community 215|Community 215]]
@@ -230,7 +230,7 @@
 - [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
-- [[_COMMUNITY_Community 222|Community 222]]
+- [[_COMMUNITY_Community 223|Community 223]]
 - [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
 - [[_COMMUNITY_Community 226|Community 226]]
@@ -314,30 +314,29 @@
 - [[_COMMUNITY_Community 304|Community 304]]
 - [[_COMMUNITY_Community 305|Community 305]]
 - [[_COMMUNITY_Community 306|Community 306]]
-- [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 308|Community 308]]
+- [[_COMMUNITY_Community 310|Community 310]]
 - [[_COMMUNITY_Community 311|Community 311]]
-- [[_COMMUNITY_Community 312|Community 312]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 260 edges
+1. `DesktopStore` - 261 edges
 2. `DesktopTextKey` - 128 edges
-3. `DesktopAPI` - 109 edges
+3. `DesktopAPI` - 111 edges
 4. `CodingKeys` - 106 edges
 5. `GitWorkspaceService` - 79 edges
 6. `DesktopStoreTests` - 69 edges
 7. `language` - 58 edges
 8. `DesktopStateStore` - 48 edges
 9. `ModelsTests` - 35 edges
-10. `Data` - 34 edges
+10. `Data` - 35 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `language` --calls--> `userFacingIssueKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `userFacingDecisionTitle()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `localizedSourceKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
+- `userFacingIssueKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `userFacingDecisionTitle()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `localizedSourceKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
 - `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
   macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
 - `agent()` --calls--> `CompanyAgentDefinitionRecord`  [INFERRED]
@@ -351,23 +350,23 @@ Nodes (52): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChat
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (158): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+150 more)
+Nodes (163): App, ButtonStyle, Commands, Scanner, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView (+155 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (19): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+11 more)
+Nodes (20): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+12 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (38): ActionStore, RetryingFileChannel, DirectChatMessage, VideoBaseCommand, AppLogger, CompanySidebarDisclosureState, APIError, http (+30 more)
+Nodes (36): ActionStore, RetryingFileChannel, DirectChatMessage, AppLogger, APIError, http, ConfigureGitHubOriginPayload, Data (+28 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.03
-Nodes (135): Codable, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, Array, IssueRecord, MeetingRoomAgentResolver (+127 more)
+Nodes (136): Codable, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, Array, IssueRecord, MeetingRoomAgentResolver (+128 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
-Nodes (158): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+150 more)
+Nodes (154): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+146 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.01
@@ -379,7 +378,7 @@ Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgent
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, label, relation, source (+116 more)
+Nodes (126): CodingKey, EmbeddedBackendHealthPayload, CodingKeys, community, confidenceScore, fileType, label, relation (+118 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
@@ -391,7 +390,7 @@ Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, Agen
 
 ### Community 11 - "Community 11"
 Cohesion: 0.04
-Nodes (19): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+11 more)
+Nodes (17): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendLauncher, isBackendRuntimeJar() (+9 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
@@ -406,20 +405,20 @@ Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (21): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView, WebView (+13 more)
+Cohesion: 0.08
+Nodes (7): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DashboardPayload, DesktopSettingsPayload, DesktopStoreTests
 
 ### Community 16 - "Community 16"
 Cohesion: 0.04
-Nodes (4): CachedState, DesktopStateStore, SqliteCachedState, StateCollection
+Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.04
-Nodes (52): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+44 more)
+Nodes (54): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+46 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.1
-Nodes (5): A2aArtifactStore, settings(), AgentSkillCardRecord, AgentCapabilitySettingRecord, DesktopStoreTests
+Cohesion: 0.04
+Nodes (4): CachedState, DesktopStateStore, SqliteCachedState, StateCollection
 
 ### Community 19 - "Community 19"
 Cohesion: 0.04
@@ -635,51 +634,51 @@ Nodes (1): BoardServiceTest
 
 ### Community 72 - "Community 72"
 Cohesion: 0.18
-Nodes (1): DirectChatService
+Nodes (2): DesktopAppServiceRuntimeCleanupTest, StartupRecordingBrowserSkillRunner
 
 ### Community 73 - "Community 73"
 Cohesion: 0.18
-Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+Nodes (1): DirectChatService
 
 ### Community 74 - "Community 74"
 Cohesion: 0.18
-Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
+Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
 ### Community 75 - "Community 75"
 Cohesion: 0.18
-Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
+Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
 ### Community 76 - "Community 76"
 Cohesion: 0.18
-Nodes (1): VerificationBundleService
+Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
 ### Community 77 - "Community 77"
 Cohesion: 0.18
-Nodes (1): ProvenanceService
+Nodes (1): VerificationBundleService
 
 ### Community 78 - "Community 78"
 Cohesion: 0.18
-Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
+Nodes (1): ProvenanceService
 
 ### Community 79 - "Community 79"
 Cohesion: 0.18
-Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
+Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
 ### Community 80 - "Community 80"
 Cohesion: 0.18
-Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
+Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
-Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
+Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
 ### Community 82 - "Community 82"
 Cohesion: 0.18
-Nodes (2): ErrorMessages, UserFriendlyError
+Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (3): CoroutineEventBus, EventBus, EventSubscription
+Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
@@ -779,806 +778,802 @@ Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallC
 
 ### Community 108 - "Community 108"
 Cohesion: 0.25
-Nodes (1): DesktopAppServiceRuntimeCleanupTest
+Nodes (1): BoardController
 
 ### Community 109 - "Community 109"
 Cohesion: 0.25
-Nodes (1): BoardController
+Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
 ### Community 110 - "Community 110"
 Cohesion: 0.25
-Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 111 - "Community 111"
 Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+Nodes (1): CompanyIssueReadiness
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (1): ChatSession
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (1): OpenCodeDefaults
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (2): JsonParser, YamlParser
 
 ### Community 116 - "Community 116"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (1): DiagramGenerator
 
 ### Community 117 - "Community 117"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
+Nodes (2): Linter, LintResult
 
 ### Community 118 - "Community 118"
 Cohesion: 0.25
-Nodes (2): Linter, LintResult
-
-### Community 119 - "Community 119"
-Cohesion: 0.25
 Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.29
 Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.29
 Nodes (1): LocalModelPluginTest
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.29
 Nodes (1): DefaultResultAnalyzer
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.29
 Nodes (2): A2aDedupeStore, StoredAck
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.29
 Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (2): A2aSessionPersistenceStore, Snapshot
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (1): DurableResumeCoordinator
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (1): FileReaderPlugin
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.29
 Nodes (1): OpenAIPlugin
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.29
 Nodes (1): InteractiveCommandCompleter
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.29
 Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (1): DesktopStateStoreTest
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.33
 Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.33
 Nodes (1): CompanyRuntimeBindingServiceTest
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.33
 Nodes (1): ProductionReliabilityBaselineTest
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.33
 Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.33
 Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.33
 Nodes (1): GitHubControlPlaneService
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.33
 Nodes (1): QaVerificationPlugin
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.33
 Nodes (1): CommandPlugin
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.33
 Nodes (2): DefaultResultAggregator, ResultAggregator
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.33
 Nodes (1): CodexDashboardCommand
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (2): PluginCommand, PluginInitCommand
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (1): PolicyEngine
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.4
 Nodes (1): OpenCodePluginTest
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.4
 Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.4
 Nodes (1): CliGoldenSnapshotTest
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.4
 Nodes (1): DesktopEndpointPolicy
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.4
 Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.4
 Nodes (1): EvidencePathPolicy
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.4
 Nodes (1): CompanyRuntimeMachine
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.4
 Nodes (1): WorkQueue
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.4
 Nodes (1): NetworkEndpointPolicy
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.4
 Nodes (1): CheckpointGraphStore
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.4
 Nodes (1): SideEffectJournalStore
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.4
 Nodes (1): ProvenanceStore
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.4
 Nodes (1): CodexDefaults
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.4
 Nodes (1): CotorHttpClients
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.4
 Nodes (2): StuckDetector, StuckSignal
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.4
 Nodes (1): AppServerCommand
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.4
 Nodes (2): SyntaxValidationResult, SyntaxValidator
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.5
 Nodes (1): BoardServiceApplicationTests
 
-### Community 164 - "Community 164"
-Cohesion: 0.67
-Nodes (2): BoardServiceApplication, main()
-
-### Community 165 - "Community 165"
+### Community 163 - "Community 163"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostDetailResponse
 
-### Community 166 - "Community 166"
+### Community 164 - "Community 164"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostSummaryResponse
 
-### Community 167 - "Community 167"
+### Community 165 - "Community 165"
 Cohesion: 0.5
 Nodes (1): PostRepository
 
-### Community 168 - "Community 168"
+### Community 166 - "Community 166"
 Cohesion: 0.5
 Nodes (1): Post
 
-### Community 169 - "Community 169"
+### Community 167 - "Community 167"
 Cohesion: 0.5
 Nodes (1): findPrimes()
 
-### Community 170 - "Community 170"
+### Community 168 - "Community 168"
+Cohesion: 0.67
+Nodes (2): BoardServiceApplication, main()
+
+### Community 169 - "Community 169"
 Cohesion: 0.5
 Nodes (1): AgentCapabilityGuardTest
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceOwnershipTest
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
-### Community 174 - "Community 174"
+### Community 173 - "Community 173"
 Cohesion: 0.5
 Nodes (2): CommandPluginTest, RecordingProcessManager
 
-### Community 175 - "Community 175"
+### Community 174 - "Community 174"
 Cohesion: 0.5
 Nodes (2): FileReaderPluginTest, NoopProcessManager
 
-### Community 176 - "Community 176"
+### Community 175 - "Community 175"
 Cohesion: 0.5
 Nodes (1): PipelineOrchestratorPropertyTest
 
-### Community 178 - "Community 178"
+### Community 177 - "Community 177"
 Cohesion: 0.5
 Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.5
 Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (1): StateRepository
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (3): ChatMessage, ChatMode, ChatRole
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (1): DurableRuntimeFlags
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (2): TimelineCollector, TimelineResult
 
-### Community 187 - "Community 187"
+### Community 186 - "Community 186"
 Cohesion: 0.5
 Nodes (1): StageConflictDetector
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.5
 Nodes (1): SimpleCLI
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.5
 Nodes (2): OutputValidator, StageValidationOutcome
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.67
 Nodes (1): PostCreateRequest
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.67
 Nodes (1): PostUpdateRequest
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.67
 Nodes (1): VersionConflictException
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.67
 Nodes (1): PostNotFoundException
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.67
 Nodes (1): PermissionDeniedException
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.67
 Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.67
 Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIntegrationHarness
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.67
 Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceExecutionMemoryTest
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.67
 Nodes (1): CheckpointFixtureProcess
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.67
 Nodes (1): CheckpointResumeIntegrationTest
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.67
 Nodes (1): RuntimeConstructorConsistencyTest
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (1): PipelineOrchestratorMapTest
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (1): TemplateCommandTest
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (1): InitCommandTest
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.67
 Nodes (1): ValidateCommandTest
 
-### Community 208 - "Community 208"
+### Community 207 - "Community 207"
 Cohesion: 0.67
 Nodes (1): DesktopLifecycleCommandTest
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (1): ResultAnalyzer
 
-### Community 210 - "Community 210"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 211 - "Community 211"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (2): VideoPlanRequest, VideoPlanResult
 
-### Community 213 - "Community 213"
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (1): DurableRuntimeContext
 
-### Community 214 - "Community 214"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (1): HelloCommand
 
-### Community 215 - "Community 215"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (1): WebCommand
 
-### Community 216 - "Community 216"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (1): LintCommand
 
-### Community 217 - "Community 217"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (1): ExplainCommand
 
-### Community 218 - "Community 218"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (1): CheckpointGCCommand
 
-### Community 219 - "Community 219"
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (2): StageTimelineEntry, StageTimelineState
 
-### Community 220 - "Community 220"
+### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (1): PipelineTemplateValidator
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (1): DefaultOutputValidator
 
-### Community 222 - "Community 222"
+### Community 221 - "Community 221"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 224 - "Community 224"
+### Community 223 - "Community 223"
 Cohesion: 1.0
 Nodes (1): KotestProjectConfig
 
-### Community 225 - "Community 225"
+### Community 224 - "Community 224"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 226 - "Community 226"
+### Community 225 - "Community 225"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 227 - "Community 227"
+### Community 226 - "Community 226"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 230 - "Community 230"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 234 - "Community 234"
+### Community 233 - "Community 233"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 235 - "Community 235"
+### Community 234 - "Community 234"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 236 - "Community 236"
+### Community 235 - "Community 235"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 241 - "Community 241"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 242 - "Community 242"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceMergeConfirmationTest
 
-### Community 244 - "Community 244"
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
-### Community 245 - "Community 245"
+### Community 244 - "Community 244"
 Cohesion: 1.0
 Nodes (1): AutonomousDiscoveryServiceTest
 
-### Community 246 - "Community 246"
+### Community 245 - "Community 245"
 Cohesion: 1.0
 Nodes (1): SkillModelsTest
 
-### Community 247 - "Community 247"
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (1): CompanyRuntimeMachineTest
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 1.0
 Nodes (1): WorkQueueTest
 
-### Community 249 - "Community 249"
+### Community 248 - "Community 248"
 Cohesion: 1.0
 Nodes (1): ChatTranscriptWriterTest
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 1.0
 Nodes (1): ChatSessionTest
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 1.0
 Nodes (1): NetworkEndpointPolicyTest
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 1.0
 Nodes (1): SecurityValidatorTest
 
-### Community 253 - "Community 253"
+### Community 252 - "Community 252"
 Cohesion: 1.0
 Nodes (1): A2aArtifactStoreTest
 
-### Community 254 - "Community 254"
+### Community 253 - "Community 253"
 Cohesion: 1.0
 Nodes (1): A2aApiTest
 
-### Community 255 - "Community 255"
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (1): A2aSessionStoreTest
 
-### Community 256 - "Community 256"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (1): A2aDedupeStoreTest
 
-### Community 257 - "Community 257"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (1): RecoveryExecutorTest
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 1.0
 Nodes (1): GitHubControlPlaneServiceTest
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 1.0
 Nodes (1): StoreConcurrencyTest
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 1.0
 Nodes (1): DurableRuntimeServiceTest
 
-### Community 261 - "Community 261"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (1): DurableResumeCoordinatorTest
 
-### Community 262 - "Community 262"
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (1): ActionExecutionServiceTest
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (1): LinearClientEndpointPolicyTest
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 1.0
 Nodes (1): VerificationBundleServiceTest
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 1.0
 Nodes (1): KnowledgeServiceTest
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 1.0
 Nodes (1): LocalModelDefaultsTest
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 1.0
 Nodes (1): ObservabilityServiceTest
 
-### Community 268 - "Community 268"
+### Community 267 - "Community 267"
 Cohesion: 1.0
 Nodes (1): FileConfigRepositoryTest
 
-### Community 269 - "Community 269"
+### Community 268 - "Community 268"
 Cohesion: 1.0
 Nodes (1): QaTestGenerationFixtureTest
 
-### Community 270 - "Community 270"
+### Community 269 - "Community 269"
 Cohesion: 1.0
 Nodes (1): ConfigRepositoryImportTest
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (1): ExampleConfigSmokeTest
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 1.0
 Nodes (1): YamlParserTest
 
-### Community 273 - "Community 273"
+### Community 272 - "Community 272"
 Cohesion: 1.0
 Nodes (1): CodexPluginTest
 
-### Community 274 - "Community 274"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (1): CotorHttpClientsTest
 
-### Community 275 - "Community 275"
+### Community 274 - "Community 274"
 Cohesion: 1.0
 Nodes (1): ProcessManagerTest
 
-### Community 276 - "Community 276"
+### Community 275 - "Community 275"
 Cohesion: 1.0
 Nodes (1): ErrorHelperTest
 
-### Community 277 - "Community 277"
+### Community 276 - "Community 276"
 Cohesion: 1.0
 Nodes (1): ResultAggregatorTest
 
-### Community 278 - "Community 278"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (1): ConditionEvaluatorTest
 
-### Community 279 - "Community 279"
+### Community 278 - "Community 278"
 Cohesion: 1.0
 Nodes (1): AgentExecutorTest
 
-### Community 280 - "Community 280"
+### Community 279 - "Community 279"
 Cohesion: 1.0
 Nodes (1): StuckDetectorTest
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 1.0
 Nodes (1): PipelineGuardServiceTest
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorDagValidationTest
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (1): StageConflictDetectorTest
 
-### Community 284 - "Community 284"
+### Community 283 - "Community 283"
 Cohesion: 1.0
 Nodes (1): PipelineOrchestratorTemplatingTest
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 1.0
 Nodes (1): CoroutineEventBusTest
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 1.0
 Nodes (1): WebServerTest
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 1.0
 Nodes (1): CompletionCommandTest
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 1.0
 Nodes (1): HelpCommandTest
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 1.0
 Nodes (1): AppServerCommandTest
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 1.0
 Nodes (1): StarterAgentResolverTest
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandCompleterTest
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 1.0
 Nodes (1): AgentCommandTest
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 1.0
 Nodes (1): PluginCommandTest
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 1.0
 Nodes (1): AuthCommandTest
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 1.0
 Nodes (1): HelloCommandTest
 
-### Community 296 - "Community 296"
+### Community 295 - "Community 295"
 Cohesion: 1.0
 Nodes (1): LintCommandTest
 
-### Community 297 - "Community 297"
+### Community 296 - "Community 296"
 Cohesion: 1.0
 Nodes (1): CompanyCommandTest
 
-### Community 298 - "Community 298"
+### Community 297 - "Community 297"
 Cohesion: 1.0
 Nodes (1): InteractiveCommandTest
 
-### Community 299 - "Community 299"
+### Community 298 - "Community 298"
 Cohesion: 1.0
 Nodes (1): StatsCommandTest
 
-### Community 300 - "Community 300"
+### Community 299 - "Community 299"
 Cohesion: 1.0
 Nodes (1): CodexDashboardCommandTest
 
-### Community 301 - "Community 301"
+### Community 300 - "Community 300"
 Cohesion: 1.0
 Nodes (1): StatsManagerTest
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorTest
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 1.0
 Nodes (1): PipelineValidatorExtTest
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 1.0
 Nodes (1): LinterTest
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 1.0
 Nodes (1): DefaultOutputValidatorTest
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 1.0
 Nodes (1): PolicyEngineTest
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
-### Community 309 - "Community 309"
+### Community 308 - "Community 308"
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 311 - "Community 311"
+### Community 310 - "Community 310"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **992 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+987 more)
+- **994 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+989 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 25`** (29 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1616,15 +1611,17 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 71`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (11 nodes): `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
+- **Thin community `Community 72`** (11 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `StartupRecordingBrowserSkillRunner`, `.execute()`, `.prewarm()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 73`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 73`** (11 nodes): `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 76`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 74`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 77`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 78`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 83`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 85`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1646,403 +1643,401 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 104`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 108`** (8 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
+- **Thin community `Community 108`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 109`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 111`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 112`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 113`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 114`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 115`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 116`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 117`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 120`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 121`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (7 nodes): `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 122`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (7 nodes): `DefaultResultAnalyzer`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 123`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 124`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 125`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 126`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 128`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 129`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 130`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 132`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 133`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 134`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 135`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 136`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 137`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 138`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 139`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 140`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 141`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 142`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 143`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 144`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 145`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 146`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 147`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 148`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 149`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 150`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 151`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 152`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 153`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 154`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 155`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 156`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 157`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 158`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (5 nodes): `CotorHttpClients`, `.client()`, `.newBuilder()`, `.newClient()`, `CotorHttpClients.kt`
+- **Thin community `Community 159`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 160`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 161`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (5 nodes): `SyntaxValidationResult`, `SyntaxValidator`, `.runCommand()`, `.validate()`, `SyntaxValidator.kt`
+- **Thin community `Community 162`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 163`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 164`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 165`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 166`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 167`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 168`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 169`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 170`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 171`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 172`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 173`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 174`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 175`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 177`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 178`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 180`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 182`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 185`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 186`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 187`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 188`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 189`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 190`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 191`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 192`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 193`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 194`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 195`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 196`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 197`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 198`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 199`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 200`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 201`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 202`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 203`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 204`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 205`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 206`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 207`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 208`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 209`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 210`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 212`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 213`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 214`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 215`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 216`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 217`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 218`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 219`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 220`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 221`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 223`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 224`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 225`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 226`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 227`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 228`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 229`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 230`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 231`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 232`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 233`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 234`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 235`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 236`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 237`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `DesktopTuiSessionServiceTest`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 238`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 239`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 240`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 241`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 242`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 243`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 244`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 245`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 246`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 247`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
+- **Thin community `Community 248`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 249`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 250`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 251`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 252`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 253`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 254`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 255`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 256`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 257`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 258`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 259`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 260`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 261`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `ActionExecutionServiceTest`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 262`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 263`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 264`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 265`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 267`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 268`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 269`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 270`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 271`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 272`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 273`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `CotorHttpClientsTest`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 274`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 275`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 276`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 277`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 278`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 279`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 280`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 281`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 282`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 283`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 284`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 285`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 286`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 287`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 288`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 289`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 290`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 291`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 292`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 293`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 294`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 295`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 296`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 297`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 298`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 299`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 300`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 301`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 302`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 303`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 304`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 305`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 306`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 308`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 310`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 311`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 15`, `Community 18`?**
-  _High betweenness centrality (0.102) - this node is a cross-community bridge._
+- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 11`, `Community 15`, `Community 16`?**
+  _High betweenness centrality (0.091) - this node is a cross-community bridge._
 - **Why does `DesktopTextKey` connect `Community 6` to `Community 2`?**
-  _High betweenness centrality (0.037) - this node is a cross-community bridge._
+  _High betweenness centrality (0.036) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 2` to `Community 1`, `Community 4`, `Community 5`, `Community 6`, `Community 21`?**
+  _High betweenness centrality (0.034) - this node is a cross-community bridge._
 - **Are the 38 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
   _`DesktopStore` has 38 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 12 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
   _`DesktopAPI` has 12 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
-  _992 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _994 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -154,6 +154,16 @@ struct DesktopAPI {
         try await get(path: "api/app/dashboard")
     }
 
+    /// Ask the backend to warm desktop-owned infrastructure without starting company work.
+    func prepareDesktopStartup() async throws -> DesktopLifecycleStartupPayload {
+        try await post(pathSegments: ["api", "app", "lifecycle", "startup"], body: EmptyPayload())
+    }
+
+    /// Ask the backend to stop desktop-owned work before the app-server process exits.
+    func prepareDesktopShutdown() async throws -> DesktopLifecycleShutdownPayload {
+        try await post(pathSegments: ["api", "app", "lifecycle", "shutdown"], body: EmptyPayload())
+    }
+
     /// Fetch the focused company snapshot used for live company-mode updates.
     func companyDashboard(companyId: String) async throws -> CompanyDashboardPayload {
         try await get(pathSegments: ["api", "app", "companies", companyId, "dashboard"])

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -473,6 +473,7 @@ final class DesktopStore: ObservableObject {
     private var companyEventStreamGeneration = 0
     private var polledTuiSessionID: String?
     private var didInitializeShellMode = false
+    private var didRequestDesktopLifecycleStartup = false
 
     init(api: DesktopAPI = DesktopAPI()) {
         self.api = api
@@ -1092,6 +1093,7 @@ final class DesktopStore: ObservableObject {
         startCompanyStatePolling()
         startEmbeddedBackendWatchdog()
         await EmbeddedBackendLauncher.shared.ensureRunning()
+        await prepareDesktopLifecycleStartupIfNeeded()
         // Installed app bundles launch the backend lazily, so the first request can
         // arrive before `cotor app-server` has finished binding its localhost port.
         let maxAttempts = 4
@@ -1104,6 +1106,22 @@ final class DesktopStore: ObservableObject {
             objectWillChange.send()
             await EmbeddedBackendLauncher.shared.ensureRunning()
             try? await Task.sleep(for: .seconds(1))
+        }
+    }
+
+    private func prepareDesktopLifecycleStartupIfNeeded() async {
+        guard !didRequestDesktopLifecycleStartup else { return }
+        didRequestDesktopLifecycleStartup = true
+        do {
+            let result = try await runWithEmbeddedBackendRecovery {
+                try await api.prepareDesktopStartup()
+            }
+            if result.runtimeStarted {
+                AppLogger.warning("Desktop lifecycle startup unexpectedly reported runtimeStarted=true.")
+            }
+        } catch {
+            didRequestDesktopLifecycleStartup = false
+            AppLogger.warning("Desktop lifecycle startup warmup failed: \(error.localizedDescription)")
         }
     }
 

--- a/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
+++ b/macos/Sources/CotorDesktopApp/EmbeddedBackendLauncher.swift
@@ -110,6 +110,10 @@ actor EmbeddedBackendLauncher {
         }
         shutdownRequested = true
         AppLogger.info("Embedded backend stop started.")
+        let lifecycleShutdownPrepared = await requestDesktopLifecycleShutdown()
+        if lifecycleShutdownPrepared {
+            AppLogger.info("Prepared desktop lifecycle shutdown over HTTP.")
+        }
         let gracefulShutdownRequested = await requestGracefulShutdown()
         if gracefulShutdownRequested {
             AppLogger.info("Requested graceful embedded backend shutdown over HTTP.")
@@ -271,6 +275,26 @@ actor EmbeddedBackendLauncher {
             let (_, response) = try await URLSession.shared.data(for: request)
             if let http = response as? HTTPURLResponse {
                 return http.statusCode == 202 || (200 ..< 300).contains(http.statusCode)
+            }
+        } catch {
+            return false
+        }
+        return false
+    }
+
+    private func requestDesktopLifecycleShutdown() async -> Bool {
+        guard let url = URL(string: "http://127.0.0.1:\(port)/api/app/lifecycle/shutdown") else {
+            return false
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 3.0
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(DesktopAPI.ensureAppToken())", forHTTPHeaderField: "Authorization")
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                return (200 ..< 300).contains(http.statusCode)
             }
         } catch {
             return false

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -1558,6 +1558,26 @@ struct DashboardPayload: Codable {
     let agentPerformance: [AgentPerformanceSnapshotRecord]
 }
 
+struct DesktopLifecycleStartupPayload: Codable, Equatable {
+    let stateWarmed: Bool
+    let companyCount: Int
+    let workspaceCount: Int
+    let skillCatalogSize: Int
+    let staleRuntimeCount: Int
+    let runningRuntimeCount: Int
+    let browserSkillPrewarmQueued: Bool
+    let runtimeStarted: Bool
+}
+
+struct DesktopLifecycleShutdownPayload: Codable, Equatable {
+    let activeTaskCount: Int
+    let cancelledJobCount: Int
+    let stoppedRuntimeCount: Int
+    let terminatedRunProcessCount: Int
+    let codexBackendsStopped: Bool
+    let tuiSessionsShutdown: Bool
+}
+
 extension DashboardPayload {
     static let empty = DashboardPayload(
         repositories: [],

--- a/src/main/kotlin/com/cotor/app/AppApiModels.kt
+++ b/src/main/kotlin/com/cotor/app/AppApiModels.kt
@@ -530,6 +530,28 @@ data class HealthResponse(
     val build: String = "unknown"
 )
 
+@Serializable
+data class DesktopLifecycleStartupResponse(
+    val stateWarmed: Boolean,
+    val companyCount: Int,
+    val workspaceCount: Int,
+    val skillCatalogSize: Int,
+    val staleRuntimeCount: Int,
+    val runningRuntimeCount: Int,
+    val browserSkillPrewarmQueued: Boolean,
+    val runtimeStarted: Boolean = false
+)
+
+@Serializable
+data class DesktopLifecycleShutdownResponse(
+    val activeTaskCount: Int,
+    val cancelledJobCount: Int,
+    val stoppedRuntimeCount: Int,
+    val terminatedRunProcessCount: Int,
+    val codexBackendsStopped: Boolean,
+    val tuiSessionsShutdown: Boolean = false
+)
+
 // ── Pipeline API Models ─────────────────────────────────────────────
 
 @Serializable

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -432,6 +432,24 @@ internal fun Application.cotorAppModule(
                 shutdownHandler?.invoke()
             }
 
+            route("/lifecycle") {
+                post("/startup") {
+                    if (!requireToken(token)) return@post
+                    respondDesktopRequest {
+                        desktopService.prepareDesktopAppStartup()
+                    }
+                }
+
+                post("/shutdown") {
+                    if (!requireToken(token)) return@post
+                    respondDesktopRequest {
+                        val result = desktopService.prepareDesktopAppShutdown()
+                        tuiSessionService.shutdown()
+                        result.copy(tuiSessionsShutdown = true)
+                    }
+                }
+            }
+
             get("/dashboard") {
                 if (!requireToken(token)) return@get
                 call.respond(desktopService.dashboard().redactedForApi())

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -359,6 +359,7 @@ class DesktopAppService(
     private val automationRefreshJobs: MutableMap<String, Job> = ConcurrentHashMap()
     private val automationRefreshQueuedAt = ConcurrentHashMap<String, Long>()
     private val activeTaskJobs: MutableMap<String, Job> = ConcurrentHashMap()
+    private var browserSkillPrewarmJob: Job? = null
     private val intentionallyInterruptedTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val recentCompanyAutomationTraceKeys = ConcurrentHashMap<String, Long>()
     private val recentSupersededPullRequestCleanupAt = ConcurrentHashMap<String, Long>()
@@ -407,51 +408,95 @@ class DesktopAppService(
     }
 
     fun shutdown() {
-        runBlocking {
-            serviceScope.cancel("DesktopAppService shutdown")
-            val jobsToJoin = synchronized(runtimeLifecycleLock) {
-                buildList {
-                    addAll(activeTaskJobs.values.filterNotNull())
-                    addAll(companyRuntimeJobs.values.filterNotNull())
-                    addAll(automationRefreshJobs.values.filterNotNull())
-                }.distinct()
-            }.distinct()
-            jobsToJoin.forEach { it.cancel() }
-            withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
-                jobsToJoin.forEach { it.cancelAndJoin() }
-            }
-            withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
-                interruptActiveTasksForShutdown()
-            }
-        }
-        synchronized(runtimeLifecycleLock) {
-            activeTaskJobs.clear()
-            companyRuntimeJobs.clear()
-            companyRuntimeTickMutexes.clear()
-            companyRuntimeWakeSignals.clear()
-            automationRefreshJobs.clear()
-        }
+        prepareForDesktopAppShutdown()
         intentionallyInterruptedTaskIds.clear()
         recentCompanyAutomationTraceKeys.clear()
         recentSupersededPullRequestCleanupAt.clear()
         recentNoOpPullRequestRefreshAt.clear()
         recentPullRequestMetadataRefreshes.clear()
         recentAgentModelDiscoveries.clear()
-        codexAppServerManager.stopAll()
-        runBlocking {
-            withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
-                interruptActiveTasksForShutdown()
-            }
-            withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
-                markRuntimesStoppedForServiceShutdown()
-            }
-        }
         serviceScope.cancel()
         liveServicesForTesting -= this
     }
 
-    private suspend fun markRuntimesStoppedForServiceShutdown() {
-        stateMutex.withLock {
+    fun prepareForDesktopAppShutdown(): DesktopLifecycleShutdownResponse = runBlocking {
+        shutdownOwnedDesktopWorkloads()
+    }
+
+    suspend fun prepareDesktopAppShutdown(): DesktopLifecycleShutdownResponse =
+        shutdownOwnedDesktopWorkloads()
+
+    suspend fun prepareDesktopAppStartup(): DesktopLifecycleStartupResponse {
+        pruneRuntimeCaches()
+        val staleRuntimeCount = markStalePersistedCompanyRuntimesStopped()
+        val state = stateStore.load().withDerivedMetrics()
+        val skillCount = skillCatalog().size
+        val prewarmQueued = queueBrowserSkillPrewarm()
+        return DesktopLifecycleStartupResponse(
+            stateWarmed = true,
+            companyCount = state.companies.size,
+            workspaceCount = state.workspaces.size,
+            skillCatalogSize = skillCount,
+            staleRuntimeCount = staleRuntimeCount,
+            runningRuntimeCount = state.companyRuntimes.count { it.status == CompanyRuntimeStatus.RUNNING },
+            browserSkillPrewarmQueued = prewarmQueued,
+            runtimeStarted = false
+        )
+    }
+
+    private suspend fun shutdownOwnedDesktopWorkloads(): DesktopLifecycleShutdownResponse {
+        val jobsToJoin = synchronized(runtimeLifecycleLock) {
+            buildList {
+                addAll(activeTaskJobs.values.filterNotNull())
+                addAll(companyRuntimeJobs.values.filterNotNull())
+                addAll(automationRefreshJobs.values.filterNotNull())
+                browserSkillPrewarmJob?.let(::add)
+            }.distinct()
+        }
+        jobsToJoin.forEach { it.cancel() }
+        withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
+            jobsToJoin.forEach { it.cancelAndJoin() }
+        }
+        val interrupted = withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
+            interruptActiveTasksForShutdown()
+        } ?: RuntimeStopInterruption(taskCount = 0, taskIds = emptySet(), processIds = emptyList())
+        val terminatedRunProcesses = terminateProcessIds(interrupted.processIds)
+        codexAppServerManager.stopAll()
+        val stoppedRuntimes = withTimeoutOrNull(SHUTDOWN_JOIN_TIMEOUT_MS) {
+            markRuntimesStoppedForServiceShutdown()
+        } ?: 0
+        synchronized(runtimeLifecycleLock) {
+            activeTaskJobs.clear()
+            companyRuntimeJobs.clear()
+            companyRuntimeTickMutexes.clear()
+            companyRuntimeWakeSignals.clear()
+            automationRefreshJobs.clear()
+            automationRefreshQueuedAt.clear()
+            browserSkillPrewarmJob = null
+        }
+        return DesktopLifecycleShutdownResponse(
+            activeTaskCount = interrupted.taskCount,
+            cancelledJobCount = jobsToJoin.size,
+            stoppedRuntimeCount = stoppedRuntimes,
+            terminatedRunProcessCount = terminatedRunProcesses,
+            codexBackendsStopped = true
+        )
+    }
+
+    private fun queueBrowserSkillPrewarm(): Boolean {
+        synchronized(runtimeLifecycleLock) {
+            if (browserSkillPrewarmJob?.isActive == true) {
+                return false
+            }
+            browserSkillPrewarmJob = serviceScope.launch {
+                runCatching { browserSkillRunner.prewarm() }
+            }
+            return true
+        }
+    }
+
+    private suspend fun markRuntimesStoppedForServiceShutdown(): Int {
+        return stateMutex.withLock {
             val state = stateStore.load()
             val runningRuntimes = state.companyRuntimes.filter { runtime ->
                 runtime.status == CompanyRuntimeStatus.RUNNING ||
@@ -460,7 +505,7 @@ class DesktopAppService(
                     runtime.backendPort != null
             }
             if (runningRuntimes.isEmpty()) {
-                return@withLock
+                return@withLock 0
             }
             val now = System.currentTimeMillis()
             val nextState = state.copy(
@@ -483,6 +528,7 @@ class DesktopAppService(
                 }
             ).withDerivedMetrics()
             stateStore.save(nextState)
+            return@withLock runningRuntimes.size
         }
     }
 
@@ -507,7 +553,8 @@ class DesktopAppService(
         "traceKeys" to recentCompanyAutomationTraceKeys.size,
         "supersededPrTimestamps" to recentSupersededPullRequestCleanupAt.size,
         "pullRequestMetadataRefreshes" to recentPullRequestMetadataRefreshes.size,
-        "agentModelDiscoveries" to recentAgentModelDiscoveries.size
+        "agentModelDiscoveries" to recentAgentModelDiscoveries.size,
+        "browserSkillPrewarmJob" to if (browserSkillPrewarmJob?.isActive == true) 1 else 0
     )
 
     private fun pruneRuntimeCaches(now: Long = System.currentTimeMillis()) {
@@ -1510,8 +1557,8 @@ class DesktopAppService(
         traceEvents.forEach(::appendCompanyAutomationTrace)
     }
 
-    private suspend fun markStalePersistedCompanyRuntimesStopped(companyId: String? = null) {
-        stateMutex.withLock {
+    private suspend fun markStalePersistedCompanyRuntimesStopped(companyId: String? = null): Int {
+        return stateMutex.withLock {
             val state = stateStore.load()
             val now = System.currentTimeMillis()
             val staleRuntimeIds = state.companyRuntimes
@@ -1525,7 +1572,7 @@ class DesktopAppService(
                 .mapNotNull { it.companyId }
                 .toSet()
             if (staleRuntimeIds.isEmpty()) {
-                return@withLock
+                return@withLock 0
             }
             stateStore.save(
                 state.copy(
@@ -1548,6 +1595,7 @@ class DesktopAppService(
                     }
                 ).withDerivedMetrics()
             )
+            return@withLock staleRuntimeIds.size
         }
     }
 
@@ -1672,9 +1720,9 @@ class DesktopAppService(
 
     private fun runsByTask(runs: List<AgentRun>): Map<String, List<AgentRun>> = runs.groupBy { it.taskId }
 
-    private suspend fun interruptActiveTasksForShutdown() {
+    private suspend fun interruptActiveTasksForShutdown(): RuntimeStopInterruption {
         val traceEvents = mutableListOf<CompanyAutomationTraceEvent>()
-        stateMutex.withLock {
+        val result = stateMutex.withLock {
             val state = stateStore.load()
             val now = System.currentTimeMillis()
             val issuesById = state.issues.associateBy { it.id }
@@ -1683,11 +1731,18 @@ class DesktopAppService(
                 it.status == DesktopTaskStatus.RUNNING || it.status == DesktopTaskStatus.QUEUED
             }
             if (activeTasks.isEmpty()) {
-                return@withLock
+                return@withLock RuntimeStopInterruption(taskCount = 0, taskIds = emptySet(), processIds = emptyList())
             }
 
             val interruptedTaskIds = activeTasks.mapTo(linkedSetOf()) { it.id }
             intentionallyInterruptedTaskIds.addAll(interruptedTaskIds)
+            val activeProcessIds = state.runs
+                .filter { run ->
+                    run.taskId in interruptedTaskIds &&
+                        (run.status == AgentRunStatus.RUNNING || run.status == AgentRunStatus.QUEUED)
+                }
+                .mapNotNull { it.processId }
+                .distinct()
 
             val updatedRuns = state.runs.map { run ->
                 if (run.taskId in interruptedTaskIds &&
@@ -1794,8 +1849,14 @@ class DesktopAppService(
                 severity = "warning"
             ).withDerivedMetrics()
             stateStore.save(nextState)
+            RuntimeStopInterruption(
+                taskCount = activeTasks.size,
+                taskIds = interruptedTaskIds,
+                processIds = activeProcessIds
+            )
         }
         traceEvents.forEach(::appendCompanyAutomationTrace)
+        return result
     }
 
     private suspend fun reopenInterruptedBlockedIssues(companyId: String): Int {

--- a/src/test/kotlin/com/cotor/app/AppServerTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerTest.kt
@@ -618,6 +618,52 @@ class AppServerTest : FunSpec({
         }
     }
 
+    test("desktop lifecycle routes warm startup and prepare shutdown") {
+        coEvery { desktopService.prepareDesktopAppStartup() } returns DesktopLifecycleStartupResponse(
+            stateWarmed = true,
+            companyCount = 2,
+            workspaceCount = 3,
+            skillCatalogSize = 8,
+            staleRuntimeCount = 1,
+            runningRuntimeCount = 0,
+            browserSkillPrewarmQueued = true
+        )
+        coEvery { desktopService.prepareDesktopAppShutdown() } returns DesktopLifecycleShutdownResponse(
+            activeTaskCount = 1,
+            cancelledJobCount = 2,
+            stoppedRuntimeCount = 1,
+            terminatedRunProcessCount = 1,
+            codexBackendsStopped = true
+        )
+
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService
+                )
+            }
+
+            val startup = client.post("/api/app/lifecycle/startup") {
+                header("Authorization", "Bearer secret-token")
+            }
+            val shutdown = client.post("/api/app/lifecycle/shutdown") {
+                header("Authorization", "Bearer secret-token")
+            }
+
+            startup.status shouldBe HttpStatusCode.OK
+            startup.bodyAsText() shouldContain "\"stateWarmed\":true"
+            startup.bodyAsText() shouldContain "\"runtimeStarted\":false"
+            shutdown.status shouldBe HttpStatusCode.OK
+            shutdown.bodyAsText() shouldContain "\"terminatedRunProcessCount\":1"
+            shutdown.bodyAsText() shouldContain "\"tuiSessionsShutdown\":true"
+            coVerify(exactly = 1) { desktopService.prepareDesktopAppStartup() }
+            coVerify(exactly = 1) { desktopService.prepareDesktopAppShutdown() }
+            io.mockk.verify(exactly = 1) { tuiSessionService.shutdown() }
+        }
+    }
+
     test("browser smoke route delegates to guarded backend planner") {
         coEvery {
             desktopService.planBrowserSmoke(

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeCleanupTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeCleanupTest.kt
@@ -5,9 +5,12 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.FileTime
+import java.util.concurrent.atomic.AtomicInteger
 
 class DesktopAppServiceRuntimeCleanupTest : FunSpec({
     test("shutdown clears retained runtime cache state") {
@@ -25,6 +28,91 @@ class DesktopAppServiceRuntimeCleanupTest : FunSpec({
         service.shutdown()
 
         service.runtimeCacheSizesForTesting().values.forEach { it shouldBe 0 }
+    }
+
+    test("startup lifecycle warms infrastructure without starting company runtime") {
+        val appHome = Files.createTempDirectory("desktop-app-service-startup-lifecycle")
+        val stateStore = DesktopStateStore { appHome }
+        val browserSkillRunner = StartupRecordingBrowserSkillRunner()
+        val companyId = "company-startup"
+        val repo = Files.createTempDirectory("cotor-startup-lifecycle-repo")
+        stateStore.save(
+            baseState(companyId, repo).copy(
+                goals = baseState(companyId, repo).goals.map { it.copy(autonomyEnabled = true) },
+                companyRuntimes = listOf(
+                    CompanyRuntimeSnapshot(
+                        companyId = companyId,
+                        status = CompanyRuntimeStatus.STOPPED,
+                        manuallyStoppedAt = System.currentTimeMillis()
+                    )
+                )
+            )
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            browserSkillRunner = browserSkillRunner,
+            autoStartAutomationRefresh = false
+        )
+
+        val response = service.prepareDesktopAppStartup()
+
+        response.stateWarmed shouldBe true
+        response.companyCount shouldBe 1
+        response.browserSkillPrewarmQueued shouldBe true
+        response.runtimeStarted shouldBe false
+        withTimeout(2_000) {
+            while (browserSkillRunner.prewarmCount.get() == 0) {
+                delay(10)
+            }
+        }
+        service.runtimeStatus(companyId).status shouldBe CompanyRuntimeStatus.STOPPED
+        service.runtimeCacheSizesForTesting()["runtimeJobs"] shouldBe 0
+    }
+
+    test("desktop shutdown lifecycle terminates active run process and marks runtime stopped") {
+        val appHome = Files.createTempDirectory("desktop-app-service-shutdown-lifecycle")
+        val stateStore = DesktopStateStore { appHome }
+        val service = testService(stateStore)
+        val companyId = "company-shutdown"
+        val repo = Files.createTempDirectory("cotor-shutdown-lifecycle-repo")
+        val worktreePath = worktree(repo, "task-running", "builder", System.currentTimeMillis())
+        val process = ProcessBuilder("/bin/sleep", "30").start()
+        try {
+            stateStore.save(
+                baseState(companyId, repo).copy(
+                    tasks = listOf(task("task-running", "issue-running").copy(status = DesktopTaskStatus.RUNNING)),
+                    issues = listOf(issue("issue-running", companyId, IssueStatus.IN_PROGRESS, worktreePath)),
+                    runs = listOf(
+                        run(
+                            runId = "run-running",
+                            taskId = "task-running",
+                            worktreePath = worktreePath,
+                            status = AgentRunStatus.RUNNING,
+                            updatedAt = System.currentTimeMillis()
+                        ).copy(processId = process.pid())
+                    ),
+                    companyRuntimes = listOf(
+                        CompanyRuntimeSnapshot(companyId = companyId, status = CompanyRuntimeStatus.RUNNING)
+                    )
+                )
+            )
+
+            val result = service.prepareForDesktopAppShutdown()
+            val state = stateStore.load()
+
+            result.activeTaskCount shouldBe 1
+            result.stoppedRuntimeCount shouldBe 1
+            result.terminatedRunProcessCount shouldBe 1
+            process.isAlive shouldBe false
+            state.tasks.single().status shouldBe DesktopTaskStatus.FAILED
+            state.runs.single().status shouldBe AgentRunStatus.FAILED
+            state.companyRuntimes.single().status shouldBe CompanyRuntimeStatus.STOPPED
+        } finally {
+            process.takeIf { it.isAlive }?.destroyForcibly()
+        }
     }
 
     test("runtime cleanup protects active issue and review worktrees while pruning stale terminal worktrees") {
@@ -251,3 +339,15 @@ private fun run(
         createdAt = updatedAt,
         updatedAt = updatedAt
     )
+
+private class StartupRecordingBrowserSkillRunner : BrowserSkillRunner {
+    val prewarmCount = AtomicInteger(0)
+
+    override suspend fun execute(command: BrowserSkillCommand): BrowserSkillResult {
+        error("not used")
+    }
+
+    override suspend fun prewarm() {
+        prewarmCount.incrementAndGet()
+    }
+}


### PR DESCRIPTION
## Summary
- Add desktop lifecycle startup/shutdown endpoints so the macOS shell can warm required state once on launch and clean runtime resources on exit.
- Wire the macOS app to call startup warmup during bootstrap and lifecycle shutdown before stopping the bundled backend.
- Ensure shutdown cancels runtime jobs, interrupts active tasks, terminates tracked run processes, stops Codex app-server backends, marks runtimes stopped, and clears runtime caches.

## Bugs Fixed
- App launch previously loaded dashboard state without an explicit one-shot warmup boundary.
- App quit could leave runtime jobs, task jobs, run process IDs, or bundled backend processes alive after the Swift shell exited.
- Lifecycle behavior had no direct HTTP contract or regression coverage.

## Validation
- `./gradlew --no-daemon test --tests com.cotor.app.DesktopAppServiceRuntimeCleanupTest --tests com.cotor.app.AppServerTest -x jacocoTestCoverageVerification`
- `swift test --package-path macos`
- `./gradlew --no-daemon test`
- `graphify update .`
- `./script/build_and_run.sh --verify`
- Jar HTTP smoke: `/health`, `POST /api/app/lifecycle/startup`, `POST /api/app/lifecycle/shutdown`, `/api/app/shutdown` on a temp app home.
- Manual macOS GUI smoke on branch bundle: launched `/Users/Projects/bssm-oss/cotor-organization/cotor-lifecycle-supervisor-20260527/dist/cotor-desktop-run/Cotor Desktop.app`, confirmed connected dashboard, clicked refresh, meeting room, operator chat new-chat sheet/cancel, goals, team, issues, issue details drawer, reports, performance, EN/KO, light/dark, search/clear, new-company form expansion.
- Manual shutdown verification: clicked the branch app close button and confirmed no matching `CotorDesktop`, launcher, or `cotor-backend-runtime` Java processes remained.

## Notes
- No app-server payload contract was changed beyond additive lifecycle endpoints.
- Existing `dist/` build output remains untracked and is not part of this PR.
