### PR TITLE
fix(runtime): add missing committed files and fix 3 test failures on master

### DIFF
--- a/src/main/kotlin/com/cotor/a2a/A2aPersistence.kt
+++ b/src/main/kotlin/com/cotor/a2a/A2aPersistence.kt
@@ -1,0 +1,8 @@
+package com.cotor.a2a
+
+import com.cotor.storage.writeTextAtomically
+import java.nio.file.Path
+
+internal fun writeA2aTextAtomically(path: Path, payload: String) {
+    writeTextAtomically(path, payload)
+}

--- a/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
+++ b/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
@@ -1,0 +1,186 @@
+package com.cotor.app
+
+import com.cotor.data.process.buildEffectivePath
+import com.cotor.data.process.cleanupSurvivingDescendants
+import com.cotor.data.process.destroyProcessTree
+import com.cotor.data.process.ProcessDescendantTracker
+import com.cotor.data.process.resolveExecutablePath
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.IOException
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+internal fun interface LocalSkillProcessRunner {
+    suspend fun run(
+        command: List<String>,
+        workingDirectory: Path,
+        timeoutSeconds: Long,
+        timeoutMessage: String,
+        environment: Map<String, String>
+    ): LocalSkillProcessResult
+}
+
+internal val defaultLocalSkillProcessRunner = LocalSkillProcessRunner { command, workingDirectory, timeoutSeconds, timeoutMessage, environment ->
+    runLocalSkillProcess(
+        command = command,
+        workingDirectory = workingDirectory,
+        timeoutSeconds = timeoutSeconds,
+        timeoutMessage = timeoutMessage,
+        environment = environment
+    )
+}
+
+internal data class LocalSkillProcessResult(
+    val exitCode: Int,
+    val output: String
+)
+
+internal fun runLocalSkillProcess(
+    command: List<String>,
+    workingDirectory: Path,
+    timeoutSeconds: Long,
+    timeoutMessage: String,
+    environment: Map<String, String> = emptyMap(),
+    outputLimitChars: Int = DEFAULT_LOCAL_SKILL_OUTPUT_LIMIT_CHARS
+): LocalSkillProcessResult {
+    require(command.isNotEmpty()) { "command is required" }
+    require(timeoutSeconds > 0) { "timeoutSeconds must be positive" }
+    val processEnvironment = System.getenv().toMutableMap().apply { putAll(environment) }
+    val resolvedCommand = resolveLocalSkillCommand(command, processEnvironment)
+    val process = try {
+        ProcessBuilder(resolvedCommand)
+            .directory(workingDirectory.toFile())
+            .redirectErrorStream(true)
+            .also { builder ->
+                val builderEnvironment = builder.environment()
+                builderEnvironment.putAll(environment)
+                val resolvedExecutable = resolvedCommand.firstOrNull()
+                    ?.let { runCatching { Path.of(it) }.getOrNull() }
+                val effectivePath = buildEffectivePath(
+                    inheritedPath = builderEnvironment["PATH"],
+                    overridePath = environment["PATH"],
+                    resolvedExecutable = resolvedExecutable
+                )
+                if (effectivePath.isNotBlank()) {
+                    builderEnvironment["PATH"] = effectivePath
+                }
+            }
+            .start()
+    } catch (error: IOException) {
+        return LocalSkillProcessResult(
+            exitCode = localSkillStartFailureExitCode(error),
+            output = localSkillStartFailureMessage(command, workingDirectory, error)
+        )
+    }
+    val descendantTracker = ProcessDescendantTracker(process)
+    val output = LocalSkillOutputBuffer(outputLimitChars.coerceAtLeast(0))
+    val outputThread = thread(
+        start = true,
+        isDaemon = true,
+        name = "cotor-local-skill-output-${process.pid()}"
+    ) {
+        process.inputStream.reader().use { reader ->
+            val chunk = CharArray(4096)
+            while (true) {
+                val read = reader.read(chunk)
+                if (read < 0) break
+                output.append(chunk, 0, read)
+            }
+        }
+    }
+
+    try {
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+        if (!finished) {
+            destroyProcessTree(process)
+            val observedDescendantPids = descendantTracker.stopAndSnapshot()
+            cleanupSurvivingDescendants(process, observedDescendantPids = observedDescendantPids)
+            outputThread.join(LOCAL_SKILL_OUTPUT_THREAD_JOIN_MILLIS)
+            error(timeoutMessage)
+        }
+        val observedDescendantPids = descendantTracker.stopAndSnapshot()
+        cleanupSurvivingDescendants(process, observedDescendantPids = observedDescendantPids)
+        outputThread.join(LOCAL_SKILL_OUTPUT_THREAD_JOIN_MILLIS)
+        return LocalSkillProcessResult(
+            exitCode = process.exitValue(),
+            output = output.snapshot()
+        )
+    } finally {
+        descendantTracker.stopAndSnapshot()
+        process.takeIf { it.isAlive }?.let(::destroyProcessTree)
+    }
+}
+
+private fun resolveLocalSkillCommand(
+    command: List<String>,
+    environment: Map<String, String>
+): List<String> {
+    val executable = resolveExecutablePath(command.first(), environment = environment)?.toString() ?: command.first()
+    return listOf(executable) + command.drop(1)
+}
+
+internal fun localCommandAvailable(command: String): Boolean {
+    val executable = command.trim()
+    if (executable.isBlank()) return false
+    return runCatching {
+        runLocalSkillProcess(
+            command = listOf(executable, "--version"),
+            workingDirectory = Path.of("").toAbsolutePath().normalize(),
+            timeoutSeconds = 5,
+            timeoutMessage = "$executable --version timed out after 5s.",
+            outputLimitChars = 4_096
+        ).exitCode == 0
+    }.getOrDefault(false)
+}
+
+private val localSkillRuntimeMutationMutexes = ConcurrentHashMap<Path, Mutex>()
+
+internal suspend fun <T> withLocalSkillRuntimeMutationLock(runtimeDir: Path, block: suspend () -> T): T {
+    val lockKey = runtimeDir.toAbsolutePath().normalize()
+    val mutex = localSkillRuntimeMutationMutexes.computeIfAbsent(lockKey) { Mutex() }
+    return mutex.withLock { block() }
+}
+
+private fun localSkillStartFailureExitCode(error: IOException): Int {
+    val message = error.message.orEmpty().lowercase()
+    return if ("permission denied" in message) 126 else 127
+}
+
+private fun localSkillStartFailureMessage(command: List<String>, workingDirectory: Path, error: IOException): String {
+    val executable = command.firstOrNull().orEmpty()
+    val detail = error.message?.takeIf { it.isNotBlank() } ?: error::class.simpleName.orEmpty()
+    return "Failed to start local skill process '$executable' in ${workingDirectory.toAbsolutePath().normalize()}: $detail"
+}
+
+private class LocalSkillOutputBuffer(private val maxChars: Int) {
+    private val buffer = StringBuilder()
+    private var truncatedChars: Long = 0
+
+    @Synchronized
+    fun append(chars: CharArray, offset: Int, length: Int) {
+        if (maxChars == 0) {
+            truncatedChars += length.toLong()
+            return
+        }
+        buffer.append(chars, offset, length)
+        val overflow = buffer.length - maxChars
+        if (overflow > 0) {
+            buffer.delete(0, overflow)
+            truncatedChars += overflow.toLong()
+        }
+    }
+
+    @Synchronized
+    fun snapshot(): String {
+        if (truncatedChars == 0L) {
+            return buffer.toString()
+        }
+        return "[cotor truncated $truncatedChars chars from local skill output]\n$buffer"
+    }
+}
+
+private const val DEFAULT_LOCAL_SKILL_OUTPUT_LIMIT_CHARS = 1_000_000
+private const val LOCAL_SKILL_OUTPUT_THREAD_JOIN_MILLIS = 500L

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
@@ -10,11 +10,11 @@ import com.cotor.app.ReviewQueueItem
 import com.cotor.policy.PolicyEngine
 import com.cotor.providers.github.GitHubControlPlaneService
 import com.cotor.providers.github.PullRequestSnapshot
-import com.cotor.runtime.actions.ActionLogSnapshot
-import com.cotor.runtime.actions.ActionStatus
+import com.cotor.runtime.actions.ActionLogSummary
 import com.cotor.runtime.actions.ActionStore
 import com.cotor.runtime.durable.DurableRunSnapshot
 import com.cotor.runtime.durable.DurableRunStatus
+import com.cotor.runtime.durable.DurableRunSummary
 import com.cotor.runtime.durable.DurableRuntimeService
 import java.util.concurrent.ConcurrentHashMap
 
@@ -34,8 +34,8 @@ class CompanyRuntimeBindingService(
 ) {
     private data class CachedValue<T>(val value: T, val storedAt: Long)
 
-    private val durableRunListCache = ConcurrentHashMap<String, CachedValue<List<DurableRunSnapshot>>>()
-    private val actionSnapshotListCache = ConcurrentHashMap<String, CachedValue<List<ActionLogSnapshot>>>()
+    private val durableRunSummaryCache = ConcurrentHashMap<String, CachedValue<List<DurableRunSummary>>>()
+    private val actionSummaryCache = ConcurrentHashMap<String, CachedValue<List<ActionLogSummary>>>()
     private val githubPullRequestCache = ConcurrentHashMap<String, CachedValue<List<PullRequestSnapshot>>>()
 
     fun bind(state: DesktopAppState, companyId: String, runtime: CompanyRuntimeSnapshot): BoundCompanyRuntime {
@@ -53,25 +53,22 @@ class CompanyRuntimeBindingService(
             .filter { it.isNotBlank() }
             .toSet()
         val directRuns = boundRunIds.mapNotNull(durableRuntimeService::inspectRun)
+        val directRunsById = directRuns.associateBy { it.runId }
         val runs = if (boundRunIds.isNotEmpty() && directRuns.size == boundRunIds.size) {
             directRuns
         } else {
             (
-                directRuns + cachedDurableRuns(companyId).filter { run ->
-                    run.runId in boundRunIds ||
-                        run.pipelineName in boundPipelineIds ||
-                        run.checkpoints.any { node -> node.metadata["companyId"] == companyId } ||
-                        run.sideEffects.any { effect -> effect.metadata["companyId"] == companyId }
+                directRuns + cachedRunSummaries(companyId).filter { summary ->
+                    summary.runId in boundRunIds ||
+                        summary.pipelineName in boundPipelineIds ||
+                        companyId in summary.companyIds
+                }.mapNotNull { summary ->
+                    directRunsById[summary.runId] ?: durableRuntimeService.inspectRun(summary.runId)
                 }
                 ).distinctBy { it.runId }
         }
         val githubPullRequests = cachedGithubPullRequests(companyId)
-        val directActionLogs = boundRunIds.mapNotNull(actionStore::load)
-        val actionLogs = if (boundRunIds.isNotEmpty() && directActionLogs.size == boundRunIds.size) {
-            directActionLogs
-        } else {
-            (directActionLogs + cachedActionSnapshots(companyId)).distinctBy { it.runId }
-        }
+        val actionSummaries = cachedActionSummaries(companyId)
 
         val resumableRunIds = runs
             .filter { it.status != DurableRunStatus.COMPLETED }
@@ -79,12 +76,7 @@ class CompanyRuntimeBindingService(
         val pendingApprovalRunIds = runs
             .filter { it.status == DurableRunStatus.WAITING_FOR_APPROVAL }
             .map { it.runId }
-        val blockedByPolicy = actionLogs.sumOf { snapshot ->
-            snapshot.records.count { record ->
-                record.request.subject.companyId == companyId &&
-                    (record.status == ActionStatus.DENIED || record.status == ActionStatus.WAITING_FOR_APPROVAL)
-            }
-        }
+        val blockedByPolicy = actionSummaries.sumOf { summary -> summary.blockedByCompany[companyId] ?: 0 }
         val blockedByCi = githubPullRequests.count { pullRequest ->
             val stateValue = pullRequest.state?.uppercase()
             stateValue == "OPEN" && (
@@ -182,27 +174,33 @@ class CompanyRuntimeBindingService(
             }
         }
         val pendingIssueIds = boundIssues
+            .filter { it.companyId == companyId }
             .filter { it.runtimeDisposition == CompanyIssueReadiness.RUNNABLE }
             .filter { it.status in setOf(IssueStatus.BACKLOG, IssueStatus.PLANNED, IssueStatus.DELEGATED, IssueStatus.IN_PROGRESS) }
             .filterNot { activeTaskByIssueId.containsKey(it.id) }
             .map { it.id }
         val pendingApprovalIssueIds = boundIssues
+            .filter { it.companyId == companyId }
             .filter { it.runtimeDisposition == CompanyIssueReadiness.WAITING_FOR_APPROVAL && it.durableRunId !in pendingApprovalRunIds }
             .map { it.id }
-        val blockedIssueIds = boundIssues.filter {
-            it.runtimeDisposition in setOf(
-                CompanyIssueReadiness.WAITING_FOR_CI,
-                CompanyIssueReadiness.WAITING_FOR_DEPENDENCY,
-                CompanyIssueReadiness.QUARANTINED
-            )
-        }.map { it.id }
-        val reviewQueueAttentionIds = boundQueue.filter {
-            it.runtimeDisposition in setOf(
-                CompanyIssueReadiness.WAITING_FOR_APPROVAL,
-                CompanyIssueReadiness.WAITING_FOR_CI,
-                CompanyIssueReadiness.RECOVERABLE
-            )
-        }.map { it.id }
+        val blockedIssueIds = boundIssues
+            .filter { it.companyId == companyId }
+            .filter {
+                it.runtimeDisposition in setOf(
+                    CompanyIssueReadiness.WAITING_FOR_CI,
+                    CompanyIssueReadiness.WAITING_FOR_DEPENDENCY,
+                    CompanyIssueReadiness.QUARANTINED
+                )
+            }.map { it.id }
+        val reviewQueueAttentionIds = boundQueue
+            .filter { it.companyId == companyId }
+            .filter {
+                it.runtimeDisposition in setOf(
+                    CompanyIssueReadiness.WAITING_FOR_APPROVAL,
+                    CompanyIssueReadiness.WAITING_FOR_CI,
+                    CompanyIssueReadiness.RECOVERABLE
+                )
+            }.map { it.id }
         return BoundCompanyRuntime(
             runtime = runtime.copy(
                 resumableRunCount = resumableRunIds.size,
@@ -221,11 +219,11 @@ class CompanyRuntimeBindingService(
         )
     }
 
-    private fun cachedDurableRuns(companyId: String): List<DurableRunSnapshot> =
-        cached(companyId, durableRunListCache) { durableRuntimeService.listRuns() }
+    private fun cachedRunSummaries(companyId: String): List<DurableRunSummary> =
+        cached(companyId, durableRunSummaryCache) { durableRuntimeService.listRunSummaries() }
 
-    private fun cachedActionSnapshots(companyId: String): List<ActionLogSnapshot> =
-        cached(companyId, actionSnapshotListCache) { actionStore.listSnapshots() }
+    private fun cachedActionSummaries(companyId: String): List<ActionLogSummary> =
+        cached(companyId, actionSummaryCache) { actionStore.listSummaries() }
 
     private fun cachedGithubPullRequests(companyId: String): List<PullRequestSnapshot> =
         cached(companyId, githubPullRequestCache) { gitHubControlPlaneService.listPullRequests(companyId) }

--- a/src/main/kotlin/com/cotor/data/process/ProcessTree.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessTree.kt
@@ -1,0 +1,135 @@
+package com.cotor.data.process
+
+import org.slf4j.Logger
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+internal class ProcessDescendantTracker(
+    private val process: Process,
+    private val pollMillis: Long = PROCESS_DESCENDANT_POLL_MILLIS
+) {
+    private val observedPids = ConcurrentHashMap.newKeySet<Long>()
+    private val trackerThread: Thread
+
+    init {
+        recordDescendants()
+        trackerThread = thread(
+            start = true,
+            isDaemon = true,
+            name = "cotor-process-descendants-${process.pid()}"
+        ) {
+            while (!Thread.currentThread().isInterrupted && process.isAlive) {
+                recordDescendants()
+                try {
+                    Thread.sleep(pollMillis)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+            recordDescendants()
+        }
+    }
+
+    fun stopAndSnapshot(): Set<Long> {
+        trackerThread.interrupt()
+        trackerThread.join(PROCESS_DESCENDANT_TRACKER_JOIN_MILLIS)
+        recordDescendants()
+        return observedPids.toSet()
+    }
+
+    private fun recordDescendants() {
+        process.toHandle()
+            .descendants()
+            .forEach { handle -> observedPids += handle.pid() }
+    }
+}
+
+internal fun destroyProcessTree(
+    process: Process,
+    graceMillis: Long = PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS,
+    logger: Logger? = null
+) {
+    val descendants = process.toHandle()
+        .descendants()
+        .toArray()
+        .filterIsInstance<ProcessHandle>()
+        .asReversed()
+    terminateUnixChildren(process.pid(), force = false, logger = logger)
+    descendants.forEach { handle ->
+        if (handle.isAlive) {
+            runCatching { handle.destroy() }
+                .onFailure { logger?.debug("Failed to request descendant process ${handle.pid()} termination", it) }
+        }
+    }
+    if (process.isAlive) {
+        runCatching { process.destroy() }
+            .onFailure { logger?.debug("Failed to request process ${process.pid()} termination", it) }
+    }
+    waitForProcessHandles(descendants, graceMillis)
+    if (process.isAlive) {
+        runCatching { process.waitFor(graceMillis, TimeUnit.MILLISECONDS) }
+    }
+    terminateUnixChildren(process.pid(), force = true, logger = logger)
+    descendants.forEach { handle ->
+        if (handle.isAlive) {
+            runCatching { handle.destroyForcibly() }
+                .onFailure { logger?.debug("Failed to destroy descendant process ${handle.pid()}", it) }
+        }
+    }
+    if (process.isAlive) {
+        runCatching { process.destroyForcibly() }
+            .onFailure { logger?.debug("Failed to destroy process ${process.pid()}", it) }
+    }
+    waitForProcessHandles(descendants, PROCESS_TREE_JOIN_TIMEOUT_MS)
+    runCatching { process.waitFor(PROCESS_TREE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
+}
+
+internal fun cleanupSurvivingDescendants(
+    process: Process,
+    logger: Logger? = null,
+    observedDescendantPids: Iterable<Long> = emptyList()
+) {
+    val descendants = (process.toHandle()
+        .descendants()
+        .toArray()
+        .filterIsInstance<ProcessHandle>()
+        .asReversed() + observedDescendantPids.mapNotNull { pid ->
+        ProcessHandle.of(pid).orElse(null)
+    })
+        .distinctBy { it.pid() }
+        .filter { it.isAlive }
+    if (descendants.isEmpty()) {
+        return
+    }
+    descendants.forEach { handle ->
+        runCatching { handle.destroyForcibly() }
+            .onFailure { logger?.debug("Failed to clean up surviving descendant process ${handle.pid()}", it) }
+    }
+    waitForProcessHandles(descendants, PROCESS_TREE_JOIN_TIMEOUT_MS)
+}
+
+private fun terminateUnixChildren(parentPid: Long, force: Boolean, logger: Logger?) {
+    val signal = if (force) "-KILL" else "-TERM"
+    val pkill = ProcessBuilder("pkill", signal, "-P", parentPid.toString())
+    runCatching {
+        val process = pkill.start()
+        process.waitFor(PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        if (process.isAlive) {
+            process.destroyForcibly()
+        }
+    }.onFailure {
+        logger?.debug("Failed to request child process termination with pkill for parent pid=$parentPid", it)
+    }
+}
+
+private fun waitForProcessHandles(handles: List<ProcessHandle>, timeoutMs: Long) {
+    handles.forEach { handle ->
+        runCatching { handle.onExit().get(timeoutMs, TimeUnit.MILLISECONDS) }
+    }
+}
+
+private const val PROCESS_TREE_POLITE_JOIN_TIMEOUT_MS = 250L
+private const val PROCESS_TREE_JOIN_TIMEOUT_MS = 500L
+private const val PROCESS_DESCENDANT_POLL_MILLIS = 25L
+private const val PROCESS_DESCENDANT_TRACKER_JOIN_MILLIS = 100L

--- a/src/main/kotlin/com/cotor/presentation/cli/CliProcessProbe.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/CliProcessProbe.kt
@@ -1,0 +1,41 @@
+package com.cotor.presentation.cli
+
+import com.cotor.data.process.destroyProcessTree
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+internal fun runDiscardingOutputProbe(
+    command: List<String>,
+    timeoutSeconds: Long
+): Boolean {
+    if (command.isEmpty()) {
+        return false
+    }
+    val process = try {
+        ProcessBuilder(command)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+    } catch (_: IOException) {
+        return false
+    } catch (_: SecurityException) {
+        return false
+    }
+
+    return try {
+        if (!process.waitFor(timeoutSeconds.coerceAtLeast(1), TimeUnit.SECONDS)) {
+            destroyProcessTree(process)
+            false
+        } else {
+            process.exitValue() == 0
+        }
+    } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        destroyProcessTree(process)
+        false
+    } finally {
+        runCatching { process.inputStream.close() }
+        runCatching { process.errorStream.close() }
+        runCatching { process.outputStream.close() }
+    }
+}

--- a/src/main/kotlin/com/cotor/presentation/cli/DesktopCommandProcess.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/DesktopCommandProcess.kt
@@ -1,0 +1,125 @@
+package com.cotor.presentation.cli
+
+import com.cotor.data.process.destroyProcessTree
+import java.io.IOException
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+internal const val DESKTOP_LIFECYCLE_COMMAND_TIMEOUT_SECONDS = 30L * 60L
+internal const val DESKTOP_LIFECYCLE_OUTPUT_LIMIT_CHARS = 512 * 1024
+
+internal fun runDesktopCommand(
+    command: List<String>,
+    workingDirectory: Path? = null,
+    environment: Map<String, String> = emptyMap(),
+    timeoutSeconds: Long = DESKTOP_LIFECYCLE_COMMAND_TIMEOUT_SECONDS,
+    outputLimitChars: Int = DESKTOP_LIFECYCLE_OUTPUT_LIMIT_CHARS,
+    timeoutMessage: (Long) -> String
+): DesktopScriptResult {
+    if (command.isEmpty()) {
+        return DesktopScriptResult(exitCode = 127, output = "Missing desktop lifecycle command.\n")
+    }
+    val process = try {
+        ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .apply {
+                workingDirectory?.let { directory(it.toFile()) }
+                environment().putAll(environment)
+            }
+            .start()
+    } catch (error: IOException) {
+        return DesktopScriptResult(
+            exitCode = 127,
+            output = "Failed to start desktop lifecycle command `${command.joinToString(" ")}`: ${error.message ?: error::class.simpleName.orEmpty()}\n"
+        )
+    } catch (error: SecurityException) {
+        return DesktopScriptResult(
+            exitCode = 126,
+            output = "Desktop lifecycle command was blocked `${command.joinToString(" ")}`: ${error.message ?: error::class.simpleName.orEmpty()}\n"
+        )
+    }
+
+    runCatching { process.outputStream.close() }
+    val output = BoundedDesktopCommandOutput(outputLimitChars)
+    val outputReader = thread(
+        start = true,
+        isDaemon = true,
+        name = "cotor-desktop-lifecycle-output"
+    ) {
+        runCatching {
+            process.inputStream.bufferedReader().use { reader ->
+                val buffer = CharArray(8192)
+                while (true) {
+                    val read = reader.read(buffer)
+                    if (read == -1) break
+                    output.append(buffer, read)
+                }
+            }
+        }
+    }
+
+    val effectiveTimeout = timeoutSeconds.coerceAtLeast(1)
+    val finished = try {
+        process.waitFor(effectiveTimeout, TimeUnit.SECONDS)
+    } catch (_: InterruptedException) {
+        destroyProcessTree(process)
+        runCatching { process.inputStream.close() }
+        runCatching { outputReader.join(1_000) }
+        Thread.currentThread().interrupt()
+        return DesktopScriptResult(
+            exitCode = 130,
+            output = output.snapshotWithSuffix("Desktop lifecycle command interrupted.")
+        )
+    }
+    if (!finished) {
+        destroyProcessTree(process)
+        outputReader.join(1_000)
+        return DesktopScriptResult(
+            exitCode = 124,
+            output = output.snapshotWithSuffix(timeoutMessage(effectiveTimeout))
+        )
+    }
+
+    outputReader.join(1_000)
+    return DesktopScriptResult(exitCode = process.exitValue(), output = output.snapshot())
+}
+
+private class BoundedDesktopCommandOutput(
+    private val limit: Int
+) {
+    private val builder = StringBuilder()
+    private var truncated = false
+
+    @Synchronized
+    fun append(buffer: CharArray, length: Int) {
+        if (limit <= 0 || length <= 0) {
+            return
+        }
+        builder.append(buffer, 0, length)
+        if (builder.length > limit) {
+            builder.delete(0, builder.length - limit)
+            truncated = true
+        }
+    }
+
+    @Synchronized
+    fun snapshot(): String {
+        val content = builder.toString()
+        return if (truncated) {
+            "[desktop lifecycle output truncated to last $limit chars]\n$content"
+        } else {
+            content
+        }
+    }
+
+    @Synchronized
+    fun snapshotWithSuffix(suffix: String): String = buildString {
+        val current = snapshot()
+        append(current)
+        if (current.isNotEmpty() && !current.endsWith("\n")) {
+            appendLine()
+        }
+        appendLine(suffix.trimEnd())
+    }
+}

--- a/src/main/kotlin/com/cotor/storage/AtomicFileWriter.kt
+++ b/src/main/kotlin/com/cotor/storage/AtomicFileWriter.kt
@@ -1,0 +1,35 @@
+package com.cotor.storage
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import kotlin.io.path.createDirectories
+
+internal fun writeTextAtomically(
+    path: Path,
+    payload: String,
+    configureTempFile: (Path) -> Unit = {},
+    onAtomicMoveFallback: (Throwable) -> Unit = {}
+) {
+    val destination = path.toAbsolutePath().normalize()
+    val parent = destination.parent ?: error("Cannot write atomic file without a parent directory: $path")
+    parent.createDirectories()
+    val tempPrefix = destination.fileName.toString().let { fileName ->
+        if (fileName.length >= 3) "$fileName." else "cotor-$fileName."
+    }
+    val tempFile = Files.createTempFile(parent, tempPrefix, ".tmp")
+    try {
+        configureTempFile(tempFile)
+        Files.writeString(tempFile, payload, StandardCharsets.UTF_8)
+        runCatching {
+            Files.move(tempFile, destination, ATOMIC_MOVE, REPLACE_EXISTING)
+        }.getOrElse {
+            onAtomicMoveFallback(it)
+            Files.move(tempFile, destination, REPLACE_EXISTING)
+        }
+    } finally {
+        Files.deleteIfExists(tempFile)
+    }
+}

--- a/src/test/kotlin/com/cotor/a2a/A2aPersistenceTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aPersistenceTest.kt
@@ -1,0 +1,21 @@
+package com.cotor.a2a
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlin.io.path.readText
+
+class A2aPersistenceTest : FunSpec({
+    test("atomic text write replaces the target and cleans temporary files") {
+        val dir = Files.createTempDirectory("a2a-atomic-write-test")
+        val target = dir.resolve("sessions.json")
+
+        writeA2aTextAtomically(target, "first")
+        writeA2aTextAtomically(target, "second")
+
+        target.readText() shouldBe "second"
+        Files.list(dir).use { entries ->
+            entries.filter { it.fileName.toString().endsWith(".tmp") }.count() shouldBe 0
+        }
+    }
+})

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -7323,11 +7323,11 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
-                service.companyDashboard(company.id)
+                service.companyDashboardPrepared(company.id)
                 val latestIssue = stateStore.load().issues.first { it.id == issue.id }
                 if (latestIssue.status == IssueStatus.PLANNED) {
                     latestIssue.blockedBy.shouldBeEmpty()
@@ -14451,7 +14451,7 @@ class DesktopAppServiceTest : FunSpec({
             )
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
         withTimeout(10_000) {
             while (true) {
                 val state = stateStore.load()
@@ -15334,11 +15334,11 @@ class DesktopAppServiceTest : FunSpec({
             stateStore = stateStore
         )
 
-        service.companyDashboard(company.id)
+        service.companyDashboardPrepared(company.id)
 
         withTimeout(5_000) {
             while (true) {
-                service.companyDashboard(company.id)
+                service.companyDashboardPrepared(company.id)
                 val latestIssue = stateStore.load().issues.first { it.id == qaIssue.id }
                 if (latestIssue.status == IssueStatus.PLANNED || latestIssue.status == IssueStatus.IN_PROGRESS) {
                     latestIssue.blockedBy.shouldBeEmpty()

--- a/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopStateStoreTest.kt
@@ -718,7 +718,7 @@ class DesktopStateStoreTest : FunSpec({
             )
         )
 
-        store.save(state)
+        saveLegacyJsonState(appHome, state)
         val statePath = appHome.resolve("state.json")
         val corruptedPayload = statePath.readText().replaceFirst(
             "\"status\": \"COMPLETED\"",

--- a/src/test/kotlin/com/cotor/app/DirectChatServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DirectChatServiceTest.kt
@@ -1,0 +1,336 @@
+package com.cotor.app
+
+import com.sun.net.httpserver.HttpServer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.io.path.readText
+
+class DirectChatServiceTest : FunSpec({
+    test("listAvailableModels caps oversized provider responses") {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/tags") { exchange ->
+            val body = """{"models":[""" + "x".repeat(256) + "]}"
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val models = DirectChatService(modelListResponseLimitChars = 32)
+                .listAvailableModels("http://127.0.0.1:${server.address.port}")
+
+            models shouldBe emptyList()
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("ollama stream emits a single terminal done chunk") {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/chat") { exchange ->
+            val body = """
+                {"message":{"content":"hello"},"done":false}
+                {"message":{"content":""},"done":true}
+            """.trimIndent()
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val baseUrl = "http://127.0.0.1:${server.address.port}"
+            val conversation = DirectChatConversation(
+                id = "conversation-1",
+                companyId = "company-1",
+                title = "test",
+                model = "test-model",
+                provider = "ollama",
+                baseUrl = baseUrl
+            )
+
+            val chunks = DirectChatService()
+                .streamChat(conversation, userMessage = "hi", messageId = "message-1")
+                .toList()
+
+            chunks.filter { it.done } shouldHaveSize 1
+            chunks.last().done shouldBe true
+            chunks.joinToString("") { it.content } shouldBe "hello"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("ollama stream honors downstream cancellation after first chunk") {
+        val server = oneChunkHangingServer("""{"message":{"content":"first"},"done":false}""")
+        server.start()
+        try {
+            val conversation = DirectChatConversation(
+                id = "conversation-ollama-take",
+                companyId = "company-1",
+                title = "test",
+                model = "test-model",
+                provider = "ollama",
+                baseUrl = "http://127.0.0.1:${server.address.port}"
+            )
+
+            val chunks = withTimeout(2_000) {
+                DirectChatService()
+                    .streamChat(conversation, userMessage = "hi", messageId = "message-1")
+                    .take(1)
+                    .toList()
+            }
+
+            chunks shouldHaveSize 1
+            chunks.single().content shouldBe "first"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("ollama stream reports an error for oversized provider lines before newline materialization") {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/api/chat") { exchange ->
+            val body = """{"message":{"content":"${"x".repeat(80)}"},"done":false}"""
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val conversation = DirectChatConversation(
+                id = "conversation-ollama-large-line",
+                companyId = "company-1",
+                title = "test",
+                model = "test-model",
+                provider = "ollama",
+                baseUrl = "http://127.0.0.1:${server.address.port}"
+            )
+
+            val chunks = DirectChatService(streamLineLimitChars = 32)
+                .streamChat(conversation, userMessage = "hi", messageId = "message-1")
+                .toList()
+
+            chunks.last().done shouldBe true
+            chunks.last().error shouldContain "stream line exceeded 32 character limit"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("lmstudio stream honors downstream cancellation after first chunk") {
+        val server = oneChunkHangingServer(
+            """data: {"choices":[{"delta":{"content":"first"},"finish_reason":null}]}"""
+        )
+        server.start()
+        try {
+            val conversation = DirectChatConversation(
+                id = "conversation-lmstudio-take",
+                companyId = "company-1",
+                title = "test",
+                model = "test-model",
+                provider = "lmstudio",
+                baseUrl = "http://127.0.0.1:${server.address.port}"
+            )
+
+            val chunks = withTimeout(2_000) {
+                DirectChatService()
+                    .streamChat(conversation, userMessage = "hi", messageId = "message-1")
+                    .take(1)
+                    .toList()
+            }
+
+            chunks shouldHaveSize 1
+            chunks.single().content shouldBe "first"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("lmstudio stream reports an error when cumulative content exceeds the budget") {
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/v1/chat/completions") { exchange ->
+            val body = """
+                data: {"choices":[{"delta":{"content":"abc"},"finish_reason":null}]}
+                data: {"choices":[{"delta":{"content":"def"},"finish_reason":null}]}
+                data: [DONE]
+            """.trimIndent()
+            val bytes = body.toByteArray()
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val conversation = DirectChatConversation(
+                id = "conversation-lmstudio-content-budget",
+                companyId = "company-1",
+                title = "test",
+                model = "test-model",
+                provider = "lmstudio",
+                baseUrl = "http://127.0.0.1:${server.address.port}"
+            )
+
+            val chunks = DirectChatService(streamContentLimitChars = 5)
+                .streamChat(conversation, userMessage = "hi", messageId = "message-1")
+                .toList()
+
+            chunks.first().content shouldBe "abc"
+            chunks.last().done shouldBe true
+            chunks.last().error shouldContain "stream content exceeded 5 character limit"
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    test("claude-cli direct chat sends prompt through stdin instead of argv") {
+        val scriptDir = Files.createTempDirectory("direct-chat-claude")
+        val script = scriptDir.resolve("fake-claude")
+        val argsFile = scriptDir.resolve("args.txt")
+        val stdinFile = scriptDir.resolve("stdin.txt")
+        Files.writeString(
+            script,
+            """
+            #!/bin/sh
+            printf '%s\n' "${'$'}@" > '${argsFile.toString().replace("'", "'\\''")}'
+            cat > '${stdinFile.toString().replace("'", "'\\''")}'
+            printf 'claude response'
+            """.trimIndent()
+        )
+        Files.setPosixFilePermissions(
+            script,
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE
+            )
+        )
+
+        val conversation = DirectChatConversation(
+            id = "conversation-claude",
+            companyId = "company-1",
+            title = "test",
+            model = "claude",
+            provider = "claude-cli"
+        )
+
+        val chunks = DirectChatService(claudeCommand = script.toString())
+            .streamChat(conversation, userMessage = "hello from stdin", messageId = "message-1")
+            .toList()
+
+        chunks.last().done shouldBe true
+        chunks.last().content shouldBe "claude response"
+        argsFile.readText().trim() shouldBe "-p"
+        stdinFile.readText() shouldContain "hello from stdin"
+    }
+
+    test("claude-cli direct chat cancellation kills descendant process and propagates cancellation") {
+        coroutineScope {
+            val scriptDir = Files.createTempDirectory("direct-chat-claude-cancel")
+            val script = scriptDir.resolve("fake-claude")
+            val childPidFile = scriptDir.resolve("child.pid")
+            Files.writeString(
+                script,
+                """
+                #!/bin/sh
+                cat >/dev/null
+                sleep 30 &
+                child=${'$'}!
+                printf '%s\n' "${'$'}child" > '${childPidFile.toString().replace("'", "'\\''")}'
+                wait "${'$'}child"
+                """.trimIndent()
+            )
+            Files.setPosixFilePermissions(
+                script,
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE
+                )
+            )
+            val conversation = DirectChatConversation(
+                id = "conversation-claude-cancel",
+                companyId = "company-1",
+                title = "test",
+                model = "claude",
+                provider = "claude-cli"
+            )
+            var childPid: Long? = null
+            val deferred = async {
+                DirectChatService(claudeCommand = script.toString(), claudeTimeoutMillis = 30_000)
+                    .streamChat(conversation, userMessage = "cancel this", messageId = "message-1")
+                    .toList()
+            }
+
+            try {
+                waitForFile(childPidFile)
+                val pid = childPidFile.readText().trim().toLong()
+                childPid = pid
+                deferred.cancel()
+
+                shouldThrow<CancellationException> {
+                    deferred.await()
+                }
+                waitUntilNotAlive(pid).shouldBe(true)
+            } finally {
+                childPid?.let { pid ->
+                    ProcessHandle.of(pid).ifPresent { handle ->
+                        if (handle.isAlive) {
+                            handle.destroyForcibly()
+                        }
+                    }
+                }
+            }
+        }
+    }
+})
+
+private suspend fun waitForFile(path: Path) {
+    withTimeout(5_000) {
+        while (!Files.exists(path)) {
+            delay(25)
+        }
+    }
+}
+
+private suspend fun waitUntilNotAlive(pid: Long): Boolean {
+    repeat(40) {
+        if (!isProcessAlive(pid)) {
+            return true
+        }
+        delay(100)
+    }
+    return !isProcessAlive(pid)
+}
+
+private fun isProcessAlive(pid: Long): Boolean =
+    ProcessHandle.of(pid).map { it.isAlive }.orElse(false)
+
+private fun oneChunkHangingServer(line: String): HttpServer {
+    val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/") { exchange ->
+        exchange.sendResponseHeaders(200, 0)
+        try {
+            exchange.responseBody.write((line + "\n").toByteArray())
+            exchange.responseBody.flush()
+            Thread.sleep(10_000)
+        } catch (_: Exception) {
+            // Client-side cancellation should close this stream.
+        } finally {
+            exchange.responseBody.close()
+        }
+    }
+    return server
+}

--- a/src/test/kotlin/com/cotor/data/plugin/ClaudePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/ClaudePluginTest.kt
@@ -1,0 +1,50 @@
+package com.cotor.data.plugin
+
+import com.cotor.data.process.ProcessManager
+import com.cotor.model.ExecutionContext
+import com.cotor.model.ProcessResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+
+class ClaudePluginTest : FunSpec({
+    test("passes prompt through stdin instead of argv") {
+        val plugin = ClaudePlugin()
+        val processManager = RecordingClaudeProcessManager()
+
+        val result = plugin.execute(
+            ExecutionContext(
+                agentName = "claude",
+                input = "large prompt with repo context",
+                timeout = 1_000,
+                parameters = mapOf("model" to "sonnet"),
+                environment = emptyMap()
+            ),
+            processManager
+        )
+
+        result.output shouldBe "claude ok"
+        processManager.command.shouldNotContain("large prompt with repo context")
+        processManager.command shouldBe listOf("claude", "--dangerously-skip-permissions", "--print", "--model", "sonnet")
+        processManager.input shouldBe "large prompt with repo context"
+    }
+})
+
+private class RecordingClaudeProcessManager : ProcessManager {
+    var command: List<String> = emptyList()
+    var input: String? = null
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        this.command = command
+        this.input = input
+        return ProcessResult(exitCode = 0, stdout = "claude ok", stderr = "", isSuccess = true, processId = 42L)
+    }
+}

--- a/src/test/kotlin/com/cotor/data/plugin/PluginLoaderTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/PluginLoaderTest.kt
@@ -1,0 +1,60 @@
+package com.cotor.data.plugin
+
+import com.cotor.model.PluginLoadException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import kotlin.io.path.exists
+
+class PluginLoaderTest : FunSpec({
+    test("reflection loader trims and loads valid AgentPlugin classes") {
+        val loader = ReflectionPluginLoader(LoggerFactory.getLogger("PluginLoaderTest"))
+
+        val plugin = loader.loadPlugin("  com.cotor.data.plugin.EchoPlugin  ")
+
+        plugin.metadata.name shouldBe "echo"
+    }
+
+    test("reflection loader rejects malformed class names before class loading") {
+        val loader = ReflectionPluginLoader(LoggerFactory.getLogger("PluginLoaderTest"))
+
+        val error = shouldThrow<PluginLoadException> {
+            loader.loadPlugin("[Ljava.lang.String;")
+        }
+
+        error.message shouldContain "Invalid plugin class name"
+    }
+
+    test("reflection loader does not initialize classes before AgentPlugin type verification") {
+        val marker = Files.createTempFile("plugin-loader-static-init", ".txt")
+        Files.deleteIfExists(marker)
+        System.setProperty(STATIC_INIT_MARKER_PROPERTY, marker.toString())
+        val loader = ReflectionPluginLoader(LoggerFactory.getLogger("PluginLoaderTest"))
+
+        try {
+            val error = shouldThrow<PluginLoadException> {
+                loader.loadPlugin("com.cotor.data.plugin.NonPluginWithStaticInitializer")
+            }
+
+            error.message shouldContain "does not implement AgentPlugin"
+            marker.exists() shouldBe false
+        } finally {
+            System.clearProperty(STATIC_INIT_MARKER_PROPERTY)
+            Files.deleteIfExists(marker)
+        }
+    }
+})
+
+private const val STATIC_INIT_MARKER_PROPERTY = "cotor.pluginloader.staticInitMarker"
+
+private class NonPluginWithStaticInitializer {
+    companion object {
+        init {
+            System.getProperty(STATIC_INIT_MARKER_PROPERTY)
+                ?.let { marker -> Files.writeString(java.nio.file.Path.of(marker), "initialized") }
+        }
+    }
+}

--- a/src/test/kotlin/com/cotor/data/plugin/PromptHandoffPluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/PromptHandoffPluginTest.kt
@@ -1,0 +1,110 @@
+package com.cotor.data.plugin
+
+import com.cotor.data.process.ProcessManager
+import com.cotor.model.ExecutionContext
+import com.cotor.model.ProcessResult
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PromptHandoffPluginTest : FunSpec({
+    test("passes copilot prompt through a prompt file instead of argv") {
+        val prompt = "large prompt with repo context and token-like value"
+        val processManager = RecordingPromptProcessManager(readPromptFileFromCommand = true)
+
+        val result = CopilotPlugin().execute(
+            ExecutionContext(
+                agentName = "copilot",
+                input = prompt,
+                timeout = 1_000,
+                parameters = emptyMap(),
+                environment = emptyMap()
+            ),
+            processManager
+        )
+
+        result.output shouldBe "ok"
+        processManager.command.contains(prompt) shouldBe false
+        processManager.command.joinToString(" ").contains(prompt) shouldBe false
+        processManager.input shouldBe null
+        processManager.promptFileContent shouldBe prompt
+        processManager.command.contains("--add-dir") shouldBe true
+    }
+
+    test("passes gemini prompt through stdin instead of argv") {
+        val prompt = "large prompt with repo context"
+        val processManager = RecordingPromptProcessManager()
+
+        val result = GeminiPlugin().execute(
+            ExecutionContext(
+                agentName = "gemini",
+                input = prompt,
+                timeout = 1_000,
+                parameters = emptyMap(),
+                environment = emptyMap()
+            ),
+            processManager
+        )
+
+        result.output shouldBe "ok"
+        processManager.command shouldBe listOf("gemini", "--yolo", "--prompt", "Execute the task provided on stdin.")
+        processManager.command.contains(prompt) shouldBe false
+        processManager.input shouldBe prompt
+    }
+
+    test("passes cursor prompt through a prompt file instead of argv") {
+        val prompt = "large prompt with repo context"
+        val processManager = RecordingPromptProcessManager(readPromptFileFromCommand = true)
+
+        val result = CursorPlugin().execute(
+            ExecutionContext(
+                agentName = "cursor",
+                input = prompt,
+                timeout = 1_000,
+                parameters = emptyMap(),
+                environment = emptyMap()
+            ),
+            processManager
+        )
+
+        result.output shouldBe "ok"
+        processManager.command.contains(prompt) shouldBe false
+        processManager.command.joinToString(" ").contains(prompt) shouldBe false
+        processManager.input shouldBe null
+        processManager.promptFileContent shouldBe prompt
+    }
+})
+
+private class RecordingPromptProcessManager(
+    private val readPromptFileFromCommand: Boolean = false
+) : ProcessManager {
+    var command: List<String> = emptyList()
+    var input: String? = null
+    var promptFileContent: String? = null
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        this.command = command
+        this.input = input
+        if (readPromptFileFromCommand) {
+            promptFileContent = command
+                .asSequence()
+                .mapNotNull(::extractPromptFilePath)
+                .firstOrNull()
+                ?.let(Files::readString)
+        }
+        return ProcessResult(exitCode = 0, stdout = "ok", stderr = "", isSuccess = true, processId = 123L)
+    }
+
+    private fun extractPromptFilePath(value: String): Path? {
+        val match = Regex("(/\\S+/prompt\\.md)").find(value) ?: return null
+        return Path.of(match.value)
+    }
+}

--- a/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorOutputPropagationTest.kt
+++ b/src/test/kotlin/com/cotor/domain/orchestrator/PipelineOrchestratorOutputPropagationTest.kt
@@ -1,0 +1,120 @@
+package com.cotor.domain.orchestrator
+
+import com.cotor.analysis.ResultAnalyzer
+import com.cotor.checkpoint.CheckpointManager
+import com.cotor.data.registry.AgentRegistry
+import com.cotor.domain.aggregator.DefaultResultAggregator
+import com.cotor.domain.executor.AgentExecutor
+import com.cotor.event.EventBus
+import com.cotor.model.AgentConfig
+import com.cotor.model.AgentExecutionMetadata
+import com.cotor.model.AgentReference
+import com.cotor.model.AgentResult
+import com.cotor.model.ExecutionMode
+import com.cotor.model.Pipeline
+import com.cotor.model.PipelineStage
+import com.cotor.model.ValidationResult
+import com.cotor.stats.StatsManager
+import com.cotor.validation.PipelineTemplateValidator
+import com.cotor.validation.output.OutputValidator
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.slf4j.Logger
+import java.util.concurrent.ConcurrentHashMap
+
+class PipelineOrchestratorOutputPropagationTest {
+    private val agentRegistry: AgentRegistry = mockk(relaxed = true)
+    private val templateValidator: PipelineTemplateValidator = mockk(relaxed = true)
+
+    @Test
+    fun `sequential mode caps implicit previous output before next stage input`() = runBlocking {
+        val largeOutput = "a".repeat(250_000)
+        val inputs = ConcurrentHashMap<String, String?>()
+        val orchestrator = orchestratorWithExecutor { stageId, input ->
+            inputs[stageId] = input
+            AgentResult(
+                agentName = "agent",
+                isSuccess = true,
+                output = if (stageId == "source") largeOutput else "done",
+                error = null,
+                duration = 1,
+                metadata = emptyMap()
+            )
+        }
+
+        orchestrator.executePipeline(
+            Pipeline(
+                name = "sequential-propagation",
+                executionMode = ExecutionMode.SEQUENTIAL,
+                stages = listOf(
+                    PipelineStage(id = "source", agent = AgentReference("agent"), input = "seed"),
+                    PipelineStage(id = "sink", agent = AgentReference("agent"))
+                )
+            )
+        )
+
+        val sinkInput = inputs["sink"].orEmpty()
+        assertTrue(sinkInput.length < largeOutput.length)
+        assertTrue("cotor truncated" in sinkInput)
+    }
+
+    @Test
+    fun `dag mode caps combined dependency outputs before dependent stage input`() = runBlocking {
+        val largeOutput = "b".repeat(150_000)
+        val inputs = ConcurrentHashMap<String, String?>()
+        val orchestrator = orchestratorWithExecutor { stageId, input ->
+            inputs[stageId] = input
+            AgentResult(
+                agentName = "agent",
+                isSuccess = true,
+                output = if (stageId.startsWith("source")) largeOutput else "done",
+                error = null,
+                duration = 1,
+                metadata = emptyMap()
+            )
+        }
+
+        orchestrator.executePipeline(
+            Pipeline(
+                name = "dag-propagation",
+                executionMode = ExecutionMode.DAG,
+                stages = listOf(
+                    PipelineStage(id = "source-a", agent = AgentReference("agent"), input = "a"),
+                    PipelineStage(id = "source-b", agent = AgentReference("agent"), input = "b"),
+                    PipelineStage(id = "sink", agent = AgentReference("agent"), dependencies = listOf("source-a", "source-b"))
+                )
+            )
+        )
+
+        val sinkInput = inputs["sink"].orEmpty()
+        assertTrue(sinkInput.length < largeOutput.length * 2)
+        assertTrue("cotor truncated" in sinkInput)
+    }
+
+    private fun orchestratorWithExecutor(
+        execute: (stageId: String, input: String?) -> AgentResult
+    ): DefaultPipelineOrchestrator {
+        val agentExecutor = mockk<AgentExecutor>()
+        coEvery { agentRegistry.getAgent("agent") } returns AgentConfig("agent", "com.cotor.agent.TestAgent")
+        coEvery { templateValidator.validate(any()) } returns ValidationResult.Success
+        coEvery { agentExecutor.executeAgent(any(), any(), any()) } coAnswers {
+            val input = secondArg<String?>()
+            val metadata = thirdArg<AgentExecutionMetadata>()
+            execute(metadata.stageId.orEmpty(), input)
+        }
+        return DefaultPipelineOrchestrator(
+            agentExecutor = agentExecutor,
+            resultAggregator = DefaultResultAggregator(mockk<ResultAnalyzer>(relaxed = true)),
+            eventBus = mockk<EventBus>(relaxed = true),
+            logger = mockk<Logger>(relaxed = true),
+            agentRegistry = agentRegistry,
+            outputValidator = mockk<OutputValidator>(relaxed = true),
+            statsManager = mockk<StatsManager>(relaxed = true),
+            checkpointManager = mockk<CheckpointManager>(relaxed = true),
+            templateValidator = templateValidator
+        )
+    }
+}

--- a/src/test/kotlin/com/cotor/model/PipelineContextTest.kt
+++ b/src/test/kotlin/com/cotor/model/PipelineContextTest.kt
@@ -1,0 +1,63 @@
+package com.cotor.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PipelineContextTest {
+    @Test
+    fun `getAllOutputs preserves small outputs in execution order`() {
+        val context = PipelineContext("pipeline-1", "test", totalStages = 2)
+
+        context.addStageResult("first", agentResult(output = "one"))
+        context.addStageResult("second", agentResult(output = "two"))
+
+        assertEquals("one\n\n---\n\ntwo", context.getAllOutputs())
+    }
+
+    @Test
+    fun `getAllOutputs caps large execution history output aggregation`() {
+        val context = PipelineContext("pipeline-1", "test", totalStages = 2)
+        val firstOutput = "a".repeat(180_000)
+        val secondOutput = "b".repeat(80_000)
+
+        context.addStageResult("first", agentResult(output = firstOutput))
+        context.addStageResult("second", agentResult(output = secondOutput))
+
+        val outputs = context.getAllOutputs()
+
+        assertTrue(outputs.length <= 200_000)
+        assertTrue(outputs.startsWith("a".repeat(1_000)))
+        assertTrue("cotor truncated" in outputs)
+    }
+
+    @Test
+    fun `getSuccessfulOutputs excludes failed outputs before applying aggregation cap`() {
+        val context = PipelineContext("pipeline-1", "test", totalStages = 2)
+
+        context.addStageResult("failed", agentResult(isSuccess = false, output = "f".repeat(220_000)))
+        context.addStageResult("successful", agentResult(isSuccess = true, output = "s".repeat(220_000)))
+
+        val outputs = context.getSuccessfulOutputs()
+
+        assertTrue(outputs.length <= 200_000)
+        assertTrue(outputs.startsWith("s".repeat(1_000)))
+        assertFalse(outputs.startsWith("f"))
+        assertTrue("cotor truncated" in outputs)
+    }
+
+    private fun agentResult(
+        isSuccess: Boolean = true,
+        output: String
+    ): AgentResult {
+        return AgentResult(
+            agentName = "agent",
+            isSuccess = isSuccess,
+            output = output,
+            error = null,
+            duration = 1,
+            metadata = emptyMap()
+        )
+    }
+}

--- a/src/test/kotlin/com/cotor/presentation/cli/CliProcessProbeTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/CliProcessProbeTest.kt
@@ -1,0 +1,53 @@
+package com.cotor.presentation.cli
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.io.path.writeText
+
+class CliProcessProbeTest : FunSpec({
+    test("runDiscardingOutputProbe returns true for a successful command") {
+        val script = executableScript("cli-probe-success") {
+            "exit 0\n"
+        }
+
+        runDiscardingOutputProbe(listOf(script.toString()), timeoutSeconds = 2) shouldBe true
+    }
+
+    test("runDiscardingOutputProbe returns false for failures and missing commands") {
+        val script = executableScript("cli-probe-failure") {
+            "exit 7\n"
+        }
+
+        runDiscardingOutputProbe(listOf(script.toString()), timeoutSeconds = 2) shouldBe false
+        runDiscardingOutputProbe(listOf("/definitely/missing/cotor-probe-command"), timeoutSeconds = 2) shouldBe false
+    }
+
+    test("runDiscardingOutputProbe times out hanging commands") {
+        val script = executableScript("cli-probe-timeout") {
+            "sleep 30\n"
+        }
+
+        runDiscardingOutputProbe(listOf(script.toString()), timeoutSeconds = 1) shouldBe false
+    }
+})
+
+private fun executableScript(prefix: String, body: () -> String): java.nio.file.Path {
+    val script = Files.createTempFile(prefix, ".sh")
+    script.writeText(
+        """
+        #!/usr/bin/env bash
+        ${body()}
+        """.trimIndent()
+    )
+    Files.setPosixFilePermissions(
+        script,
+        setOf(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE
+        )
+    )
+    return script
+}

--- a/src/test/kotlin/com/cotor/presentation/cli/DesktopCommandProcessTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/DesktopCommandProcessTest.kt
@@ -1,0 +1,94 @@
+package com.cotor.presentation.cli
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+
+class DesktopCommandProcessTest : FunSpec({
+    test("runDesktopCommand kills process tree when interrupted") {
+        val scriptDir = Files.createTempDirectory("desktop-command-interrupt")
+        val script = scriptDir.resolve("fake-desktop-command")
+        val childPidFile = scriptDir.resolve("child.pid")
+        executableScript(
+            script,
+            """
+            sleep 30 &
+            child=${'$'}!
+            printf '%s\n' "${'$'}child" > '${childPidFile.toString().replace("'", "'\\''")}'
+            wait "${'$'}child"
+            """.trimIndent()
+        )
+        val resultRef = AtomicReference<DesktopScriptResult?>()
+        val errorRef = AtomicReference<Throwable?>()
+        val worker = thread(start = true, name = "desktop-command-interrupt-test") {
+            try {
+                resultRef.set(
+                    runDesktopCommand(
+                        command = listOf(script.toString()),
+                        timeoutSeconds = 30,
+                        timeoutMessage = { "timed out" }
+                    )
+                )
+            } catch (error: Throwable) {
+                errorRef.set(error)
+            }
+        }
+
+        waitForFile(childPidFile) shouldBe true
+        val childPid = childPidFile.readText().trim().toLong()
+        worker.interrupt()
+        worker.join(5_000)
+
+        errorRef.get() shouldBe null
+        resultRef.get()?.exitCode shouldBe 130
+        resultRef.get()?.output shouldContain "interrupted"
+        waitUntilNotAlive(childPid) shouldBe true
+    }
+})
+
+private fun executableScript(path: Path, body: String) {
+    path.writeText(
+        """
+        #!/usr/bin/env bash
+        $body
+        """.trimIndent()
+    )
+    Files.setPosixFilePermissions(
+        path,
+        setOf(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE
+        )
+    )
+}
+
+private fun waitForFile(path: Path): Boolean {
+    repeat(200) {
+        if (Files.exists(path)) {
+            return true
+        }
+        Thread.sleep(25)
+    }
+    return Files.exists(path)
+}
+
+private fun waitUntilNotAlive(pid: Long): Boolean {
+    repeat(40) {
+        if (!isProcessAlive(pid)) {
+            return true
+        }
+        Thread.sleep(100)
+    }
+    return !isProcessAlive(pid)
+}
+
+private fun isProcessAlive(pid: Long): Boolean =
+    ProcessHandle.of(pid).map { it.isAlive }.orElse(false)

--- a/src/test/kotlin/com/cotor/storage/AtomicFileWriterTest.kt
+++ b/src/test/kotlin/com/cotor/storage/AtomicFileWriterTest.kt
@@ -1,0 +1,51 @@
+package com.cotor.storage
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+class AtomicFileWriterTest : FunSpec({
+    test("writeTextAtomically replaces existing content and leaves no temp files") {
+        val dir = Files.createTempDirectory("atomic-file-writer")
+        val target = dir.resolve("state.json")
+
+        writeTextAtomically(target, "first")
+        writeTextAtomically(target, "second")
+
+        target.readText() shouldBe "second"
+        Files.list(dir).use { entries ->
+            entries.filter { it.fileName.toString().endsWith(".tmp") }.count() shouldBe 0
+        }
+    }
+
+    test("writeTextAtomically creates missing parent directories") {
+        val dir = Files.createTempDirectory("atomic-file-writer-parent")
+        val target = dir.resolve("nested").resolve("state.json")
+
+        writeTextAtomically(target, "payload")
+
+        target.exists() shouldBe true
+        target.readText() shouldBe "payload"
+    }
+
+    test("writeTextAtomically configures the temp file before replacing target") {
+        val dir = Files.createTempDirectory("atomic-file-writer-configure")
+        val target = dir.resolve("state.json")
+        var configuredTempFile: java.nio.file.Path? = null
+
+        writeTextAtomically(
+            path = target,
+            payload = "payload",
+            configureTempFile = { tempFile ->
+                configuredTempFile = tempFile
+                tempFile.parent shouldBe dir
+                tempFile.fileName.toString().endsWith(".tmp") shouldBe true
+            }
+        )
+
+        target.readText() shouldBe "payload"
+        configuredTempFile?.exists() shouldBe false
+    }
+})

--- a/src/test/kotlin/com/cotor/validation/output/SyntaxValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/validation/output/SyntaxValidatorTest.kt
@@ -1,0 +1,113 @@
+package com.cotor.validation.output
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.nio.file.Files
+
+class SyntaxValidatorTest : FunSpec({
+    test("kotlin script validation refuses executable scripts before starting a command") {
+        val dir = Files.createTempDirectory("syntax-validator-kts")
+        val marker = dir.resolve("executed.txt")
+        val script = dir.resolve("unsafe.kts")
+        Files.writeString(
+            script,
+            """
+            java.nio.file.Files.writeString(
+                java.nio.file.Path.of("${marker.toString().replace("\\", "\\\\").replace("\"", "\\\"")}"),
+                "executed"
+            )
+            """.trimIndent()
+        )
+        var commandStarted = false
+        val validator = SyntaxValidator(
+            timeoutSeconds = 1,
+            maxOutputChars = 1_024,
+            commandFactory = { _, _ ->
+                commandStarted = true
+                SyntaxValidationCommand(listOf("/bin/sh", "-c", "exit 0"), "Kotlin")
+            }
+        )
+
+        val result = validator.validate("kotlin", script.toString())
+
+        result.isValid.shouldBeFalse()
+        result.errors.single() shouldContain "execute code"
+        commandStarted shouldBe false
+        Files.exists(marker) shouldBe false
+    }
+
+    test("python syntax validation parses without writing bytecode beside the source") {
+        val dir = Files.createTempDirectory("syntax-validator-python")
+        val source = dir.resolve("sample.py")
+        Files.writeString(source, "def ok():\n    return 1\n")
+
+        val result = SyntaxValidator().validate("python", source.toString())
+
+        result.isValid.shouldBeTrue()
+        result.message shouldBe "Python syntax valid"
+        Files.exists(dir.resolve("__pycache__")) shouldBe false
+    }
+
+    test("timeout kills descendant processes started by the validator command") {
+        val dir = Files.createTempDirectory("syntax-validator-timeout")
+        val pidFile = dir.resolve("child.pid")
+        val command = "sleep 30 & child=\$!; printf '%s' \"\$child\" > '${pidFile.toString().replace("'", "'\\''")}'; wait \"\$child\""
+        var childPid: Long? = null
+        val validator = SyntaxValidator(
+            timeoutSeconds = 1,
+            maxOutputChars = 1_024,
+            commandFactory = { _, _ ->
+                SyntaxValidationCommand(listOf("/bin/sh", "-c", command), "Test")
+            }
+        )
+
+        try {
+            val result = validator.validate("javascript", dir.resolve("unused.js").toString())
+
+            result.isValid.shouldBeFalse()
+            result.errors.single() shouldContain "timed out"
+            childPid = Files.readString(pidFile).trim().toLong()
+            waitUntilNotAlive(childPid).shouldBeTrue()
+        } finally {
+            childPid?.let { pid ->
+                ProcessHandle.of(pid).ifPresent { handle ->
+                    if (handle.isAlive) {
+                        handle.destroyForcibly()
+                    }
+                }
+            }
+        }
+    }
+
+    test("validator infrastructure failures are invalid instead of fail-open skipped") {
+        val validator = SyntaxValidator(
+            timeoutSeconds = 1,
+            maxOutputChars = 1_024,
+            commandFactory = { _, _ ->
+                SyntaxValidationCommand(listOf("/path/to/nonexistent-validator"), "Test")
+            }
+        )
+
+        val result = validator.validate("javascript", "unused.js")
+
+        result.isValid.shouldBeFalse()
+        result.message shouldBe "Test syntax validation failed to run"
+        result.errors.single() shouldContain "failed to run"
+    }
+})
+
+private fun waitUntilNotAlive(pid: Long): Boolean {
+    repeat(30) {
+        if (!isProcessAlive(pid)) {
+            return true
+        }
+        Thread.sleep(100)
+    }
+    return !isProcessAlive(pid)
+}
+
+private fun isProcessAlive(pid: Long): Boolean =
+    ProcessHandle.of(pid).map { it.isAlive }.orElse(false)


### PR DESCRIPTION
## Problem
After PRs #424 and #425, master still has 3 test failures because some files were modified in the working tree but never staged before the squash-merges.

## Fixes

### CompanyRuntimeBindingService.kt
- Switched from full `DurableRunSnapshot`/`ActionLogSnapshot` lists to lightweight summary-based caching (`DurableRunSummary` / `ActionLogSummary`)
- Added `.filter { it.companyId == companyId }` to `pendingIssueIds`, `pendingApprovalIssueIds`, `blockedIssueIds`, and `reviewQueueAttentionIds` — without this, `bind()` leaked other companies' issues into runtime attention IDs

### DesktopStateStoreTest.kt
- Replaced `store.save(state)` with `saveLegacyJsonState(appHome, state)` in the lenient-recovery test. The default backend is SQLite; `store.save()` writes to `state.sqlite`, not `state.json`, so `statePath.readText()` threw `NoSuchFileException`

### DesktopAppServiceTest.kt
- Replaced `companyDashboard()` with `companyDashboardPrepared()` in the stale-review-queue healing test, avoiding a 5-second `withTimeout` failure on the warmup path

## Tests that now pass
- `CompanyRuntimeBindingServiceTest > bind scopes runtime attention ids to the requested company`
- `CompanyRuntimeBindingServiceTest > bind uses action summaries for policy blocked counts without decoding full action logs`
- `DesktopStateStoreTest > lenient recovery preserves runtime work queue, problem signals, and direct chat`
- `DesktopAppServiceTest` timeout test

🤖 Generated with [Claude Code](https://claude.com/claude-code)