### PR TITLE
fix(qa): harden agent skill runtime smoke paths

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor  (2026-05-27)
+# Graph Report - cotor-qa-auto-agent-skill-runtime-20260527  (2026-05-27)
 
 ## Corpus Check
-- 383 files · ~647,386 words
+- 378 files · ~638,037 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5058 nodes · 7064 edges · 319 communities detected
-- Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 897 edges (avg confidence: 0.8)
+- 5044 nodes · 6955 edges · 321 communities detected
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 846 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -199,7 +199,6 @@
 - [[_COMMUNITY_Community 186|Community 186]]
 - [[_COMMUNITY_Community 187|Community 187]]
 - [[_COMMUNITY_Community 188|Community 188]]
-- [[_COMMUNITY_Community 189|Community 189]]
 - [[_COMMUNITY_Community 190|Community 190]]
 - [[_COMMUNITY_Community 191|Community 191]]
 - [[_COMMUNITY_Community 192|Community 192]]
@@ -234,20 +233,20 @@
 - [[_COMMUNITY_Community 221|Community 221]]
 - [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 223|Community 223]]
+- [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
 - [[_COMMUNITY_Community 226|Community 226]]
 - [[_COMMUNITY_Community 227|Community 227]]
-- [[_COMMUNITY_Community 228|Community 228]]
 - [[_COMMUNITY_Community 229|Community 229]]
 - [[_COMMUNITY_Community 230|Community 230]]
 - [[_COMMUNITY_Community 231|Community 231]]
 - [[_COMMUNITY_Community 232|Community 232]]
 - [[_COMMUNITY_Community 233|Community 233]]
 - [[_COMMUNITY_Community 234|Community 234]]
+- [[_COMMUNITY_Community 235|Community 235]]
 - [[_COMMUNITY_Community 236|Community 236]]
 - [[_COMMUNITY_Community 237|Community 237]]
 - [[_COMMUNITY_Community 238|Community 238]]
-- [[_COMMUNITY_Community 239|Community 239]]
 - [[_COMMUNITY_Community 240|Community 240]]
 - [[_COMMUNITY_Community 241|Community 241]]
 - [[_COMMUNITY_Community 242|Community 242]]
@@ -326,21 +325,24 @@
 - [[_COMMUNITY_Community 315|Community 315]]
 - [[_COMMUNITY_Community 316|Community 316]]
 - [[_COMMUNITY_Community 317|Community 317]]
+- [[_COMMUNITY_Community 318|Community 318]]
+- [[_COMMUNITY_Community 319|Community 319]]
 - [[_COMMUNITY_Community 320|Community 320]]
-- [[_COMMUNITY_Community 323|Community 323]]
-- [[_COMMUNITY_Community 324|Community 324]]
+- [[_COMMUNITY_Community 322|Community 322]]
+- [[_COMMUNITY_Community 325|Community 325]]
+- [[_COMMUNITY_Community 326|Community 326]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 260 edges
+1. `DesktopStore` - 264 edges
 2. `DesktopTextKey` - 128 edges
-3. `DesktopAPI` - 109 edges
+3. `DesktopAPI` - 112 edges
 4. `CodingKeys` - 106 edges
 5. `GitWorkspaceService` - 79 edges
-6. `DesktopStoreTests` - 69 edges
+6. `DesktopStoreTests` - 70 edges
 7. `language` - 58 edges
-8. `ModelsTests` - 35 edges
-9. `Data` - 35 edges
-10. `DesktopStateStore` - 34 edges
+8. `DesktopStateStore` - 52 edges
+9. `Data` - 36 edges
+10. `ModelsTests` - 35 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `makeFallbackIcon()` --calls--> `Line`  [INFERRED]
@@ -351,30 +353,30 @@
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
 - `language` --calls--> `localizedSourceKind()`  [INFERRED]
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `N까지의 모든 소수를 찾는 함수 (에라토스테네스의 체 알고리즘 사용)      :param n: 소수를 찾을 범위의 상한값 (n > 1)` --rationale_for--> `find_primes()`  [EXTRACTED]
-  test-gemini/test/results/primes.py → test/results/primes.py
+- `preparedBrandMark()` --calls--> `Data`  [INFERRED]
+  macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.0
-Nodes (53): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+45 more)
+Nodes (54): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChatIntakeDraft, CeoPlannedIssue, CeoPlanningPayload, CeoPlanningPayloadResolution, CompanyAgentExecutionModel (+46 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (160): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, BrowserView, CenterPaneView (+152 more)
+Cohesion: 0.02
+Nodes (24): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+16 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (19): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+11 more)
+Cohesion: 0.01
+Nodes (163): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, BrowserView, CenterPaneView, ChangesView (+155 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (185): Codable, AgentSkillChipRecord, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, Array, IssueRecord, MeetingRoomAgentResolver, MeetingRoomExpression (+177 more)
+Nodes (199): Codable, AgentSkillChipRecord, MeetingRoomBrainGraph, MeetingRoomBrainGraphLink, MeetingRoomBrainGraphNode, IssueRecord, MeetingRoomExpression, confused (+191 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.03
-Nodes (17): DirectChatMessage, AppLogger, CompanySidebarDisclosureState, ConfigureGitHubOriginPayload, Data, DesktopAPI, EmptyPayload, nonEmpty() (+9 more)
+Nodes (23): A2aArtifactStore, runSkill(), settings(), BoundedDesktopCommandOutput, AgentSkillCardRecord, AppLogger, CompanySidebarDisclosureState, Data (+15 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
@@ -382,39 +384,39 @@ Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agent
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
-Nodes (131): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+123 more)
+Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
+Nodes (124): CodingKey, CodingKeys, community, confidenceScore, fileType, label, relation, source (+116 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (125): CodingKey, EmbeddedBackendHealthPayload, CodingKeys, community, confidenceScore, fileType, label, relation (+117 more)
+Nodes (38): A2aSessionStore, AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, BuiltinAgentCatalog (+30 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (52): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand (+44 more)
+Cohesion: 0.04
+Nodes (15): DirectChatMessage, APIError, http, ConfigureGitHubOriginPayload, DesktopAPI, EmptyPayload, nonEmpty(), TestBackendPayload (+7 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.04
-Nodes (20): settings(), BoundedDesktopCommandOutput, AgentSkillCardRecord, plainPhaseLabel(), userFacingIssueDescription(), parseCodexArguments(), MeetingRoomBrainGraph, AgentCapabilitySettingRecord (+12 more)
+Cohesion: 0.02
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.03
-Nodes (18): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, Scanner, EmbeddedBackendLauncher (+10 more)
+Nodes (81): CaseIterable, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope, browserQA (+73 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Cohesion: 0.04
+Nodes (19): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+11 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.02
 Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+72 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.03
-Nodes (28): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, Line, DesktopAppLifecycleDelegate (+20 more)
+Cohesion: 0.02
+Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.03
@@ -425,52 +427,52 @@ Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.04
-Nodes (52): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+44 more)
+Cohesion: 0.03
+Nodes (4): CachedState, DesktopStateStore, SqliteCachedState, StateCollection
 
 ### Community 18 - "Community 18"
 Cohesion: 0.04
-Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
+Nodes (54): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+46 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.07
-Nodes (12): runTask(), DesktopAppServiceRuntimeCleanupTest, task(), DesktopAPIClient, DesktopAPIError, http, invalidResponse, DesktopShellStore (+4 more)
+Cohesion: 0.04
+Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.11
-Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
-
-### Community 21 - "Community 21"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
+### Community 21 - "Community 21"
+Cohesion: 0.13
+Nodes (3): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas
+
 ### Community 22 - "Community 22"
-Cohesion: 0.05
-Nodes (8): ConcurrentWorktreeProcessManager, FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
-
-### Community 23 - "Community 23"
-Cohesion: 0.05
-Nodes (2): CachedState, DesktopStateStore
-
-### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 25 - "Community 25"
+### Community 23 - "Community 23"
+Cohesion: 0.06
+Nodes (8): ConcurrentGitMutationProcessManager, FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
+
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (2): DesktopTuiSessionService, RuntimeSession
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.06
 Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.07
 Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.07
+Nodes (8): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, LateProcessStartAgentExecutor, SyncCall
 
 ### Community 29 - "Community 29"
 Cohesion: 0.07
@@ -489,12 +491,12 @@ Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
 ### Community 33 - "Community 33"
-Cohesion: 0.08
-Nodes (1): A2aRouter
+Cohesion: 0.15
+Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
 ### Community 34 - "Community 34"
 Cohesion: 0.08
-Nodes (7): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, SyncCall
+Nodes (1): A2aRouter
 
 ### Community 35 - "Community 35"
 Cohesion: 0.09
@@ -509,12 +511,12 @@ Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
 ### Community 38 - "Community 38"
-Cohesion: 0.11
-Nodes (1): DurableRuntimeService
+Cohesion: 0.1
+Nodes (3): ActionLogIndex, ActionLogIndexEntry, ActionStore
 
 ### Community 39 - "Community 39"
 Cohesion: 0.11
-Nodes (3): ActionLogIndex, ActionLogIndexEntry, ActionStore
+Nodes (1): DurableRuntimeService
 
 ### Community 40 - "Community 40"
 Cohesion: 0.11
@@ -534,27 +536,27 @@ Nodes (2): ConfigRepository, ParsedConfig
 
 ### Community 44 - "Community 44"
 Cohesion: 0.12
-Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
+Nodes (3): BoundedOutputBuffer, CoroutineProcessManager, ProcessManager
 
 ### Community 45 - "Community 45"
 Cohesion: 0.12
-Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
+Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
 ### Community 46 - "Community 46"
 Cohesion: 0.12
-Nodes (1): AgentCapabilityGuard
+Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
 ### Community 47 - "Community 47"
 Cohesion: 0.12
-Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
+Nodes (1): AgentCapabilityGuard
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
-Nodes (1): RecoveryExecutor
+Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
 ### Community 49 - "Community 49"
 Cohesion: 0.12
-Nodes (3): BoundedOutputBuffer, CoroutineProcessManager, ProcessManager
+Nodes (1): RecoveryExecutor
 
 ### Community 50 - "Community 50"
 Cohesion: 0.12
@@ -570,1552 +572,1558 @@ Nodes (1): StarterAgentSpec
 
 ### Community 53 - "Community 53"
 Cohesion: 0.13
-Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
+Nodes (1): Scanner
 
 ### Community 54 - "Community 54"
 Cohesion: 0.13
-Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
+Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
 ### Community 55 - "Community 55"
 Cohesion: 0.13
-Nodes (1): ConditionEvaluator
+Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
 ### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (1): BoardControllerTest
+Cohesion: 0.13
+Nodes (1): ConditionEvaluator
 
 ### Community 57 - "Community 57"
-Cohesion: 0.14
-Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
+Cohesion: 0.13
+Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
 ### Community 58 - "Community 58"
 Cohesion: 0.14
-Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
+Nodes (1): BoardControllerTest
 
 ### Community 59 - "Community 59"
 Cohesion: 0.14
-Nodes (2): BoundedDirectChatLineReader, DirectChatService
+Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
 ### Community 60 - "Community 60"
 Cohesion: 0.14
-Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
+Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
 ### Community 61 - "Community 61"
 Cohesion: 0.14
-Nodes (2): DefaultSecurityValidator, SecurityValidator
+Nodes (2): BoundedDirectChatLineReader, DirectChatService
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
-Nodes (13): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, DurableRunSummary (+5 more)
+Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
 ### Community 63 - "Community 63"
 Cohesion: 0.14
-Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
+Nodes (2): DefaultSecurityValidator, SecurityValidator
 
 ### Community 64 - "Community 64"
 Cohesion: 0.14
-Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
+Nodes (13): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, DurableRunSummary (+5 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.14
-Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
+Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
 ### Community 66 - "Community 66"
-Cohesion: 0.15
-Nodes (3): LocalSkillOutputBuffer, LocalSkillProcessResult, LocalSkillProcessRunner
+Cohesion: 0.14
+Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
 ### Community 67 - "Community 67"
 Cohesion: 0.15
-Nodes (12): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionLogSummary, ActionRequest (+4 more)
+Nodes (3): LocalSkillOutputBuffer, LocalSkillProcessResult, LocalSkillProcessRunner
 
 ### Community 68 - "Community 68"
 Cohesion: 0.15
-Nodes (2): AgentRegistry, InMemoryAgentRegistry
+Nodes (12): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionLogSummary, ActionRequest (+4 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.17
-Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
+Cohesion: 0.15
+Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
 ### Community 70 - "Community 70"
 Cohesion: 0.17
-Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
+Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
 ### Community 71 - "Community 71"
 Cohesion: 0.17
-Nodes (1): GoalDrivenTaskPlannerTest
+Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
 ### Community 72 - "Community 72"
 Cohesion: 0.17
-Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
+Nodes (1): GoalDrivenTaskPlannerTest
 
 ### Community 73 - "Community 73"
 Cohesion: 0.17
-Nodes (1): ChatTranscriptWriter
+Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
 ### Community 74 - "Community 74"
 Cohesion: 0.17
-Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
+Nodes (1): ChatTranscriptWriter
 
 ### Community 75 - "Community 75"
 Cohesion: 0.17
-Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
+Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
 ### Community 76 - "Community 76"
-Cohesion: 0.18
-Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
+Cohesion: 0.17
+Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
 ### Community 77 - "Community 77"
 Cohesion: 0.18
-Nodes (1): BoardServiceTest
+Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
 ### Community 78 - "Community 78"
 Cohesion: 0.18
-Nodes (1): TemplateEngineTest
+Nodes (1): BoardServiceTest
 
 ### Community 79 - "Community 79"
 Cohesion: 0.18
-Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+Nodes (1): TemplateEngineTest
 
 ### Community 80 - "Community 80"
 Cohesion: 0.18
-Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
+Nodes (2): DesktopAppServiceRuntimeCleanupTest, StartupRecordingBrowserSkillRunner
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
-Nodes (1): VerificationBundleService
+Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
 ### Community 82 - "Community 82"
 Cohesion: 0.18
-Nodes (1): ProvenanceService
+Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
+Nodes (1): VerificationBundleService
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
+Nodes (1): ProvenanceService
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
-Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
+Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.18
-Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
+Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
 ### Community 87 - "Community 87"
 Cohesion: 0.18
-Nodes (2): ErrorMessages, UserFriendlyError
+Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
 ### Community 88 - "Community 88"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
 
 ### Community 89 - "Community 89"
 Cohesion: 0.18
-Nodes (1): StatsCommand
+Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 90 - "Community 90"
 Cohesion: 0.18
-Nodes (1): DoctorCommand
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.2
-Nodes (1): A2aArtifactStore
+Cohesion: 0.18
+Nodes (1): StatsCommand
 
 ### Community 92 - "Community 92"
-Cohesion: 0.2
-Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
+Cohesion: 0.18
+Nodes (1): DoctorCommand
 
 ### Community 93 - "Community 93"
 Cohesion: 0.2
-Nodes (1): VerificationStore
+Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
 ### Community 94 - "Community 94"
 Cohesion: 0.2
-Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
+Nodes (1): VerificationStore
 
 ### Community 95 - "Community 95"
 Cohesion: 0.2
-Nodes (3): ErrorHelper, ErrorInfo, ErrorType
+Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
 ### Community 96 - "Community 96"
 Cohesion: 0.2
-Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
+Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
 ### Community 97 - "Community 97"
 Cohesion: 0.2
-Nodes (3): SyntaxValidationCommand, SyntaxValidationResult, SyntaxValidator
+Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
 
 ### Community 98 - "Community 98"
 Cohesion: 0.2
-Nodes (1): PolicyStore
+Nodes (3): SyntaxValidationCommand, SyntaxValidationResult, SyntaxValidator
 
 ### Community 99 - "Community 99"
+Cohesion: 0.2
+Nodes (1): PolicyStore
+
+### Community 100 - "Community 100"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 101 - "Community 101"
-Cohesion: 0.22
-Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
-
 ### Community 102 - "Community 102"
 Cohesion: 0.22
-Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
+Nodes (3): RecordingBrowserSkillRunner, RecordingSecurityValidator, SkillRuntimeTest
 
 ### Community 103 - "Community 103"
 Cohesion: 0.22
-Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
+Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
 ### Community 104 - "Community 104"
 Cohesion: 0.22
-Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
+Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
 ### Community 105 - "Community 105"
 Cohesion: 0.22
-Nodes (1): LocalModelDefaults
+Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
 ### Community 106 - "Community 106"
 Cohesion: 0.22
-Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
+Nodes (3): BoundCompanyRuntime, CachedValue, CompanyRuntimeBindingService
 
 ### Community 107 - "Community 107"
 Cohesion: 0.22
-Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
+Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
 ### Community 108 - "Community 108"
 Cohesion: 0.22
-Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
+Nodes (1): LocalModelDefaults
 
 ### Community 109 - "Community 109"
-Cohesion: 0.25
-Nodes (1): BoardController
+Cohesion: 0.22
+Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
 ### Community 110 - "Community 110"
-Cohesion: 0.25
-Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
+Cohesion: 0.22
+Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
 ### Community 111 - "Community 111"
-Cohesion: 0.25
-Nodes (1): LocalModelPluginTest
+Cohesion: 0.22
+Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
 ### Community 112 - "Community 112"
 Cohesion: 0.25
-Nodes (1): DefaultResultAnalyzer
+Nodes (1): BoardController
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
-Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
+Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
 ### Community 114 - "Community 114"
 Cohesion: 0.25
-Nodes (1): CompanyIssueReadiness
+Nodes (1): LocalModelPluginTest
 
 ### Community 115 - "Community 115"
 Cohesion: 0.25
-Nodes (1): ChatSession
+Nodes (1): DefaultResultAnalyzer
 
 ### Community 116 - "Community 116"
 Cohesion: 0.25
-Nodes (1): GitHubControlPlaneStore
+Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
 ### Community 117 - "Community 117"
 Cohesion: 0.25
-Nodes (1): OpenCodeDefaults
+Nodes (1): CompanyIssueReadiness
 
 ### Community 118 - "Community 118"
 Cohesion: 0.25
-Nodes (2): JsonParser, YamlParser
+Nodes (1): ChatSession
 
 ### Community 119 - "Community 119"
 Cohesion: 0.25
-Nodes (1): ProcessDescendantTracker
+Nodes (1): GitHubControlPlaneStore
 
 ### Community 120 - "Community 120"
 Cohesion: 0.25
-Nodes (1): DiagramGenerator
+Nodes (1): OpenCodeDefaults
 
 ### Community 121 - "Community 121"
 Cohesion: 0.25
-Nodes (2): Linter, LintResult
+Nodes (2): JsonParser, YamlParser
 
 ### Community 122 - "Community 122"
 Cohesion: 0.25
-Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
+Nodes (1): ProcessDescendantTracker
 
 ### Community 123 - "Community 123"
-Cohesion: 0.29
-Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
+Cohesion: 0.25
+Nodes (1): DiagramGenerator
 
 ### Community 124 - "Community 124"
-Cohesion: 0.29
-Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
+Cohesion: 0.25
+Nodes (2): Linter, LintResult
 
 ### Community 125 - "Community 125"
-Cohesion: 0.29
-Nodes (2): PipelineOrchestratorMapTest, TrackingAgentExecutor
+Cohesion: 0.25
+Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
 ### Community 126 - "Community 126"
 Cohesion: 0.29
-Nodes (2): A2aDedupeStore, StoredAck
+Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
 ### Community 127 - "Community 127"
 Cohesion: 0.29
-Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
+Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
 ### Community 128 - "Community 128"
 Cohesion: 0.29
-Nodes (2): A2aSessionPersistenceStore, Snapshot
+Nodes (2): PipelineOrchestratorMapTest, TrackingAgentExecutor
 
 ### Community 129 - "Community 129"
 Cohesion: 0.29
-Nodes (1): DurableResumeCoordinator
+Nodes (2): A2aDedupeStore, StoredAck
 
 ### Community 130 - "Community 130"
 Cohesion: 0.29
-Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
+Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
 ### Community 131 - "Community 131"
 Cohesion: 0.29
-Nodes (1): FileReaderPlugin
+Nodes (2): A2aSessionPersistenceStore, Snapshot
 
 ### Community 132 - "Community 132"
 Cohesion: 0.29
-Nodes (1): OpenAIPlugin
+Nodes (1): DurableResumeCoordinator
 
 ### Community 133 - "Community 133"
 Cohesion: 0.29
-Nodes (1): InteractiveCommandCompleter
+Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
 ### Community 134 - "Community 134"
 Cohesion: 0.29
-Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
+Nodes (1): FileReaderPlugin
 
 ### Community 135 - "Community 135"
-Cohesion: 0.33
-Nodes (1): DirectChatServiceTest
+Cohesion: 0.29
+Nodes (1): OpenAIPlugin
 
 ### Community 136 - "Community 136"
-Cohesion: 0.33
-Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
+Cohesion: 0.29
+Nodes (1): InteractiveCommandCompleter
 
 ### Community 137 - "Community 137"
-Cohesion: 0.33
-Nodes (1): CompanyRuntimeBindingServiceTest
+Cohesion: 0.29
+Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
 ### Community 138 - "Community 138"
 Cohesion: 0.33
-Nodes (1): ProductionReliabilityBaselineTest
+Nodes (1): DirectChatServiceTest
 
 ### Community 139 - "Community 139"
 Cohesion: 0.33
-Nodes (1): PipelineContextTest
+Nodes (1): DesktopStateStoreTest
 
 ### Community 140 - "Community 140"
 Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
+Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
 ### Community 141 - "Community 141"
 Cohesion: 0.33
-Nodes (1): DesktopCommandProcessTest
+Nodes (1): CompanyRuntimeBindingServiceTest
 
 ### Community 142 - "Community 142"
 Cohesion: 0.33
-Nodes (2): CompanyVerificationDecision, CompanyVerifierService
+Nodes (1): ProductionReliabilityBaselineTest
 
 ### Community 143 - "Community 143"
 Cohesion: 0.33
-Nodes (1): NetworkEndpointPolicy
+Nodes (1): PipelineContextTest
 
 ### Community 144 - "Community 144"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 145 - "Community 145"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (1): DesktopCommandProcessTest
 
 ### Community 146 - "Community 146"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (1): AuthCommandTest
 
 ### Community 147 - "Community 147"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
 ### Community 148 - "Community 148"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
+Nodes (1): NetworkEndpointPolicy
 
 ### Community 149 - "Community 149"
 Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): GitHubControlPlaneService
 
 ### Community 150 - "Community 150"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (1): QaVerificationPlugin
 
 ### Community 151 - "Community 151"
-Cohesion: 0.4
-Nodes (2): RecordingBrowserSkillRunner, SkillRuntimeTest
+Cohesion: 0.33
+Nodes (1): CommandPlugin
 
 ### Community 152 - "Community 152"
-Cohesion: 0.4
-Nodes (1): OpenCodePluginTest
+Cohesion: 0.33
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 153 - "Community 153"
-Cohesion: 0.4
-Nodes (2): PromptHandoffPluginTest, RecordingPromptProcessManager
+Cohesion: 0.33
+Nodes (1): CodexDashboardCommand
 
 ### Community 154 - "Community 154"
-Cohesion: 0.4
-Nodes (1): PipelineOrchestratorOutputPropagationTest
+Cohesion: 0.33
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 155 - "Community 155"
-Cohesion: 0.4
-Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 156 - "Community 156"
 Cohesion: 0.4
-Nodes (1): CliGoldenSnapshotTest
+Nodes (1): OpenCodePluginTest
 
 ### Community 157 - "Community 157"
 Cohesion: 0.4
-Nodes (1): DesktopEndpointPolicy
+Nodes (2): PromptHandoffPluginTest, RecordingPromptProcessManager
 
 ### Community 158 - "Community 158"
 Cohesion: 0.4
-Nodes (1): LocalPlaywrightMarketingBrowserRunner
+Nodes (1): PipelineOrchestratorOutputPropagationTest
 
 ### Community 159 - "Community 159"
 Cohesion: 0.4
-Nodes (1): EvidencePathPolicy
+Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
 ### Community 160 - "Community 160"
 Cohesion: 0.4
-Nodes (1): CompanyRuntimeMachine
+Nodes (1): CliGoldenSnapshotTest
 
 ### Community 161 - "Community 161"
 Cohesion: 0.4
-Nodes (1): WorkQueue
+Nodes (1): DesktopEndpointPolicy
 
 ### Community 162 - "Community 162"
 Cohesion: 0.4
-Nodes (1): CheckpointGraphStore
+Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
 ### Community 163 - "Community 163"
 Cohesion: 0.4
-Nodes (1): SideEffectJournalStore
+Nodes (1): EvidencePathPolicy
 
 ### Community 164 - "Community 164"
 Cohesion: 0.4
-Nodes (1): ProvenanceStore
+Nodes (1): CompanyRuntimeMachine
 
 ### Community 165 - "Community 165"
 Cohesion: 0.4
-Nodes (1): CodexDefaults
+Nodes (1): WorkQueue
 
 ### Community 166 - "Community 166"
 Cohesion: 0.4
-Nodes (2): StuckDetector, StuckSignal
+Nodes (1): CheckpointGraphStore
 
 ### Community 167 - "Community 167"
 Cohesion: 0.4
-Nodes (1): AppServerCommand
+Nodes (1): SideEffectJournalStore
 
 ### Community 168 - "Community 168"
+Cohesion: 0.4
+Nodes (1): ProvenanceStore
+
+### Community 169 - "Community 169"
+Cohesion: 0.4
+Nodes (1): CodexDefaults
+
+### Community 170 - "Community 170"
+Cohesion: 0.4
+Nodes (2): StuckDetector, StuckSignal
+
+### Community 171 - "Community 171"
+Cohesion: 0.4
+Nodes (1): AppServerCommand
+
+### Community 172 - "Community 172"
 Cohesion: 0.5
 Nodes (1): findPrimes()
 
-### Community 169 - "Community 169"
+### Community 173 - "Community 173"
 Cohesion: 0.5
 Nodes (1): BoardServiceApplicationTests
 
-### Community 170 - "Community 170"
+### Community 174 - "Community 174"
 Cohesion: 0.67
 Nodes (2): BoardServiceApplication, main()
 
-### Community 171 - "Community 171"
+### Community 175 - "Community 175"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostDetailResponse
 
-### Community 172 - "Community 172"
+### Community 176 - "Community 176"
 Cohesion: 0.67
 Nodes (2): fromEntity(), PostSummaryResponse
 
-### Community 173 - "Community 173"
+### Community 177 - "Community 177"
 Cohesion: 0.5
 Nodes (1): PostRepository
 
-### Community 174 - "Community 174"
+### Community 178 - "Community 178"
 Cohesion: 0.5
 Nodes (1): Post
 
-### Community 175 - "Community 175"
+### Community 179 - "Community 179"
 Cohesion: 0.5
 Nodes (1): AgentCapabilityGuardTest
 
-### Community 176 - "Community 176"
+### Community 180 - "Community 180"
 Cohesion: 0.5
 Nodes (1): DesktopTuiSessionServiceTest
 
-### Community 177 - "Community 177"
+### Community 181 - "Community 181"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceOwnershipTest
 
-### Community 178 - "Community 178"
+### Community 182 - "Community 182"
 Cohesion: 0.5
 Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
-### Community 179 - "Community 179"
+### Community 183 - "Community 183"
 Cohesion: 0.5
 Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
-### Community 180 - "Community 180"
+### Community 184 - "Community 184"
 Cohesion: 0.5
 Nodes (2): CommandPluginTest, RecordingProcessManager
 
-### Community 181 - "Community 181"
+### Community 185 - "Community 185"
 Cohesion: 0.5
 Nodes (2): ClaudePluginTest, RecordingClaudeProcessManager
 
-### Community 182 - "Community 182"
+### Community 186 - "Community 186"
 Cohesion: 0.5
 Nodes (2): FileReaderPluginTest, NoopProcessManager
 
-### Community 183 - "Community 183"
+### Community 187 - "Community 187"
 Cohesion: 0.5
 Nodes (1): PipelineOrchestratorPropertyTest
 
-### Community 184 - "Community 184"
+### Community 188 - "Community 188"
 Cohesion: 0.5
 Nodes (1): SyntaxValidatorTest
 
-### Community 185 - "Community 185"
+### Community 190 - "Community 190"
 Cohesion: 0.5
 Nodes (2): ProviderCatalogEntry, ProviderScanResult
 
-### Community 186 - "Community 186"
+### Community 191 - "Community 191"
 Cohesion: 0.5
 Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
-### Community 187 - "Community 187"
+### Community 192 - "Community 192"
 Cohesion: 0.5
 Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
-### Community 188 - "Community 188"
-Cohesion: 0.5
-Nodes (2): BoundCompanyRuntime, CompanyRuntimeBindingService
-
-### Community 189 - "Community 189"
+### Community 193 - "Community 193"
 Cohesion: 0.5
 Nodes (1): StateRepository
 
-### Community 190 - "Community 190"
+### Community 194 - "Community 194"
 Cohesion: 0.5
 Nodes (3): ChatMessage, ChatMode, ChatRole
 
-### Community 191 - "Community 191"
+### Community 195 - "Community 195"
 Cohesion: 0.5
 Nodes (1): DurableRuntimeFlags
 
-### Community 192 - "Community 192"
+### Community 196 - "Community 196"
 Cohesion: 0.5
 Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
-### Community 193 - "Community 193"
+### Community 197 - "Community 197"
 Cohesion: 0.5
 Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
-### Community 194 - "Community 194"
+### Community 198 - "Community 198"
 Cohesion: 0.5
 Nodes (2): TimelineCollector, TimelineResult
 
-### Community 195 - "Community 195"
+### Community 199 - "Community 199"
 Cohesion: 0.5
 Nodes (1): StageConflictDetector
 
-### Community 196 - "Community 196"
+### Community 200 - "Community 200"
 Cohesion: 0.5
 Nodes (1): SimpleCLI
 
-### Community 197 - "Community 197"
+### Community 201 - "Community 201"
 Cohesion: 0.5
 Nodes (2): OutputValidator, StageValidationOutcome
 
-### Community 198 - "Community 198"
+### Community 202 - "Community 202"
 Cohesion: 0.67
 Nodes (1): PostCreateRequest
 
-### Community 199 - "Community 199"
+### Community 203 - "Community 203"
 Cohesion: 0.67
 Nodes (1): PostUpdateRequest
 
-### Community 200 - "Community 200"
+### Community 204 - "Community 204"
 Cohesion: 0.67
 Nodes (1): VersionConflictException
 
-### Community 201 - "Community 201"
+### Community 205 - "Community 205"
 Cohesion: 0.67
 Nodes (1): PostNotFoundException
 
-### Community 202 - "Community 202"
+### Community 206 - "Community 206"
 Cohesion: 0.67
 Nodes (1): PermissionDeniedException
 
-### Community 203 - "Community 203"
+### Community 207 - "Community 207"
 Cohesion: 0.67
 Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
-### Community 204 - "Community 204"
+### Community 208 - "Community 208"
 Cohesion: 0.67
 Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
-### Community 205 - "Community 205"
+### Community 209 - "Community 209"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIntegrationHarness
 
-### Community 206 - "Community 206"
+### Community 210 - "Community 210"
 Cohesion: 0.67
 Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
-### Community 207 - "Community 207"
+### Community 211 - "Community 211"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceExecutionMemoryTest
 
-### Community 208 - "Community 208"
+### Community 212 - "Community 212"
 Cohesion: 0.67
 Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
-### Community 209 - "Community 209"
+### Community 213 - "Community 213"
 Cohesion: 0.67
 Nodes (1): CheckpointFixtureProcess
 
-### Community 210 - "Community 210"
+### Community 214 - "Community 214"
 Cohesion: 0.67
 Nodes (1): CheckpointResumeIntegrationTest
 
-### Community 211 - "Community 211"
+### Community 215 - "Community 215"
 Cohesion: 0.67
 Nodes (1): StoreConcurrencyTest
 
-### Community 212 - "Community 212"
+### Community 216 - "Community 216"
 Cohesion: 0.67
 Nodes (1): RuntimeConstructorConsistencyTest
 
-### Community 213 - "Community 213"
+### Community 217 - "Community 217"
 Cohesion: 0.67
 Nodes (1): ActionExecutionServiceTest
 
-### Community 214 - "Community 214"
+### Community 218 - "Community 218"
 Cohesion: 0.67
 Nodes (2): NonPluginWithStaticInitializer, PluginLoaderTest
 
-### Community 215 - "Community 215"
+### Community 219 - "Community 219"
 Cohesion: 0.67
 Nodes (1): CotorHttpClientsTest
 
-### Community 216 - "Community 216"
+### Community 220 - "Community 220"
 Cohesion: 0.67
 Nodes (1): CliProcessProbeTest
 
-### Community 217 - "Community 217"
+### Community 221 - "Community 221"
 Cohesion: 0.67
 Nodes (1): TemplateCommandTest
 
-### Community 218 - "Community 218"
+### Community 222 - "Community 222"
 Cohesion: 0.67
 Nodes (1): InitCommandTest
 
-### Community 219 - "Community 219"
+### Community 223 - "Community 223"
 Cohesion: 0.67
 Nodes (1): ValidateCommandTest
 
-### Community 220 - "Community 220"
+### Community 224 - "Community 224"
 Cohesion: 0.67
 Nodes (1): DesktopLifecycleCommandTest
 
-### Community 221 - "Community 221"
+### Community 225 - "Community 225"
 Cohesion: 0.67
 Nodes (1): ResultAnalyzer
 
-### Community 222 - "Community 222"
+### Community 226 - "Community 226"
 Cohesion: 0.67
 Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
-### Community 223 - "Community 223"
+### Community 227 - "Community 227"
 Cohesion: 0.67
 Nodes (2): VideoPlanRequest, VideoPlanResult
 
-### Community 225 - "Community 225"
+### Community 229 - "Community 229"
 Cohesion: 0.67
 Nodes (1): DurableRuntimeContext
 
-### Community 226 - "Community 226"
+### Community 230 - "Community 230"
 Cohesion: 0.67
 Nodes (1): HelloCommand
 
-### Community 227 - "Community 227"
+### Community 231 - "Community 231"
 Cohesion: 0.67
 Nodes (1): WebCommand
 
-### Community 228 - "Community 228"
+### Community 232 - "Community 232"
 Cohesion: 0.67
 Nodes (1): LintCommand
 
-### Community 229 - "Community 229"
+### Community 233 - "Community 233"
 Cohesion: 0.67
 Nodes (1): ExplainCommand
 
-### Community 230 - "Community 230"
+### Community 234 - "Community 234"
 Cohesion: 0.67
 Nodes (1): CheckpointGCCommand
 
-### Community 231 - "Community 231"
+### Community 235 - "Community 235"
 Cohesion: 0.67
 Nodes (2): StageTimelineEntry, StageTimelineState
 
-### Community 232 - "Community 232"
+### Community 236 - "Community 236"
 Cohesion: 0.67
 Nodes (1): PipelineTemplateValidator
 
-### Community 233 - "Community 233"
+### Community 237 - "Community 237"
 Cohesion: 0.67
 Nodes (1): DefaultOutputValidator
 
-### Community 234 - "Community 234"
+### Community 238 - "Community 238"
 Cohesion: 1.0
 Nodes (1): TemplateValidatorTest
 
-### Community 236 - "Community 236"
+### Community 240 - "Community 240"
 Cohesion: 1.0
 Nodes (1): KotestProjectConfig
 
-### Community 237 - "Community 237"
+### Community 241 - "Community 241"
 Cohesion: 1.0
 Nodes (1): KoinResolutionSmokeTest
 
-### Community 238 - "Community 238"
+### Community 242 - "Community 242"
 Cohesion: 1.0
 Nodes (1): CheckpointManagerTest
 
-### Community 239 - "Community 239"
+### Community 243 - "Community 243"
 Cohesion: 1.0
 Nodes (1): DefaultResultAnalyzerTest
 
-### Community 240 - "Community 240"
+### Community 244 - "Community 244"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceGitHubSyncTest
 
-### Community 241 - "Community 241"
+### Community 245 - "Community 245"
 Cohesion: 1.0
 Nodes (1): AppServerPlatformRoutesTest
 
-### Community 242 - "Community 242"
+### Community 246 - "Community 246"
 Cohesion: 1.0
 Nodes (1): EvidencePathPolicyTest
 
-### Community 243 - "Community 243"
+### Community 247 - "Community 247"
 Cohesion: 1.0
 Nodes (1): AppServerDurableRuntimeTest
 
-### Community 244 - "Community 244"
+### Community 248 - "Community 248"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceParallelDispatchTest
 
-### Community 245 - "Community 245"
+### Community 249 - "Community 249"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
-### Community 246 - "Community 246"
+### Community 250 - "Community 250"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
-### Community 247 - "Community 247"
+### Community 251 - "Community 251"
 Cohesion: 1.0
 Nodes (1): CompanyVerifierServiceTest
 
-### Community 248 - "Community 248"
+### Community 252 - "Community 252"
 Cohesion: 1.0
 Nodes (1): AppServerVerificationRouteTest
 
-### Community 249 - "Community 249"
+### Community 253 - "Community 253"
 Cohesion: 1.0
 Nodes (1): AppServerTest
 
-### Community 250 - "Community 250"
+### Community 254 - "Community 254"
 Cohesion: 1.0
 Nodes (1): DesktopStateStoreLockTest
 
-### Community 251 - "Community 251"
+### Community 255 - "Community 255"
 Cohesion: 1.0
 Nodes (1): DesktopEndpointPolicyTest
 
-### Community 252 - "Community 252"
+### Community 256 - "Community 256"
 Cohesion: 1.0
 Nodes (1): ExecutionBackendsTest
 
-### Community 253 - "Community 253"
+### Community 257 - "Community 257"
 Cohesion: 1.0
 Nodes (1): CodexAppServerManagerTest
 
-### Community 254 - "Community 254"
+### Community 258 - "Community 258"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceMergeConfirmationTest
 
-### Community 255 - "Community 255"
-Cohesion: 1.0
-Nodes (1): DesktopStateStoreTest
-
-### Community 256 - "Community 256"
+### Community 259 - "Community 259"
 Cohesion: 1.0
 Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
-### Community 257 - "Community 257"
+### Community 260 - "Community 260"
 Cohesion: 1.0
 Nodes (1): AutonomousDiscoveryServiceTest
 
-### Community 258 - "Community 258"
+### Community 261 - "Community 261"
 Cohesion: 1.0
 Nodes (1): SkillModelsTest
 
-### Community 259 - "Community 259"
+### Community 262 - "Community 262"
 Cohesion: 1.0
 Nodes (1): CompanyRuntimeMachineTest
 
-### Community 260 - "Community 260"
-Cohesion: 1.0
-Nodes (1): ChatTranscriptWriterTest
-
-### Community 261 - "Community 261"
-Cohesion: 1.0
-Nodes (1): ChatSessionTest
-
-### Community 262 - "Community 262"
-Cohesion: 1.0
-Nodes (1): NetworkEndpointPolicyTest
-
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): SecurityValidatorTest
+Nodes (1): WorkQueueTest
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): A2aArtifactStoreTest
+Nodes (1): ChatTranscriptWriterTest
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): A2aApiTest
+Nodes (1): ChatSessionTest
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): A2aSessionStoreTest
+Nodes (1): NetworkEndpointPolicyTest
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): A2aPersistenceTest
+Nodes (1): SecurityValidatorTest
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): A2aDedupeStoreTest
+Nodes (1): A2aArtifactStoreTest
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): RecoveryExecutorTest
+Nodes (1): A2aApiTest
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): GitHubControlPlaneServiceTest
+Nodes (1): A2aSessionStoreTest
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): DurableRuntimeServiceTest
+Nodes (1): A2aPersistenceTest
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): DurableResumeCoordinatorTest
+Nodes (1): A2aDedupeStoreTest
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): AtomicFileWriterTest
+Nodes (1): RecoveryExecutorTest
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): LinearClientEndpointPolicyTest
+Nodes (1): GitHubControlPlaneServiceTest
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): VerificationBundleServiceTest
+Nodes (1): DurableRuntimeServiceTest
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): KnowledgeServiceTest
+Nodes (1): DurableResumeCoordinatorTest
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): LocalModelDefaultsTest
+Nodes (1): AtomicFileWriterTest
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): ObservabilityServiceTest
+Nodes (1): LinearClientEndpointPolicyTest
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): FileConfigRepositoryTest
+Nodes (1): VerificationBundleServiceTest
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): QaTestGenerationFixtureTest
+Nodes (1): KnowledgeServiceTest
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): ConfigRepositoryImportTest
+Nodes (1): LocalModelDefaultsTest
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): ExampleConfigSmokeTest
+Nodes (1): ObservabilityServiceTest
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): YamlParserTest
+Nodes (1): FileConfigRepositoryTest
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): CodexPluginTest
+Nodes (1): QaTestGenerationFixtureTest
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): ProcessManagerTest
+Nodes (1): ConfigRepositoryImportTest
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): ErrorHelperTest
+Nodes (1): ExampleConfigSmokeTest
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): ResultAggregatorTest
+Nodes (1): YamlParserTest
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): ConditionEvaluatorTest
+Nodes (1): CodexPluginTest
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): AgentExecutorTest
+Nodes (1): ProcessManagerTest
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): StuckDetectorTest
+Nodes (1): ErrorHelperTest
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): PipelineGuardServiceTest
+Nodes (1): ResultAggregatorTest
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorDagValidationTest
+Nodes (1): ConditionEvaluatorTest
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): StageConflictDetectorTest
+Nodes (1): AgentExecutorTest
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorTemplatingTest
+Nodes (1): StuckDetectorTest
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): CoroutineEventBusTest
+Nodes (1): PipelineGuardServiceTest
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): WebServerTest
+Nodes (1): PipelineOrchestratorDagValidationTest
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): CompletionCommandTest
+Nodes (1): StageConflictDetectorTest
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): HelpCommandTest
+Nodes (1): PipelineOrchestratorTemplatingTest
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): AppServerCommandTest
+Nodes (1): CoroutineEventBusTest
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): StarterAgentResolverTest
+Nodes (1): WebServerTest
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandCompleterTest
+Nodes (1): CompletionCommandTest
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): AgentCommandTest
+Nodes (1): HelpCommandTest
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): PluginCommandTest
+Nodes (1): AppServerCommandTest
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): AuthCommandTest
+Nodes (1): StarterAgentResolverTest
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): HelloCommandTest
+Nodes (1): InteractiveCommandCompleterTest
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): LintCommandTest
+Nodes (1): AgentCommandTest
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): CompanyCommandTest
+Nodes (1): PluginCommandTest
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandTest
+Nodes (1): HelloCommandTest
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): StatsCommandTest
+Nodes (1): LintCommandTest
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): CodexDashboardCommandTest
+Nodes (1): CompanyCommandTest
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): StatsManagerTest
+Nodes (1): InteractiveCommandTest
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorTest
+Nodes (1): StatsCommandTest
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorExtTest
+Nodes (1): CodexDashboardCommandTest
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): LinterTest
+Nodes (1): StatsManagerTest
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): DefaultOutputValidatorTest
+Nodes (1): PipelineValidatorTest
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): PolicyEngineTest
+Nodes (1): PipelineValidatorExtTest
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): RiskApprovalInterceptorTest
+Nodes (1): LinterTest
+
+### Community 318 - "Community 318"
+Cohesion: 1.0
+Nodes (1): DefaultOutputValidatorTest
+
+### Community 319 - "Community 319"
+Cohesion: 1.0
+Nodes (1): PolicyEngineTest
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
+Nodes (1): RiskApprovalInterceptorTest
+
+### Community 322 - "Community 322"
+Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 323 - "Community 323"
+### Community 325 - "Community 325"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 324 - "Community 324"
+### Community 326 - "Community 326"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **1027 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+1022 more)
+- **1015 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+1010 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 23`** (38 nodes): `CachedState`, `defaultDesktopAppHome()`, `DesktopStateStore`, `.appendAtomicMoveFallbackLog()`, `.appendStateLoadLog()`, `.appHome()`, `.atomicMoveFallbackMessage()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactDirectChatConversation()`, `.compactDirectChatConversations()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.load()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.save()`, `.saveLocked()`, `.stateFile()`, `.updateCache()`, `.withStateFileLock()`, `.writeLockMetadata()`, `.writeOwnerOnlyTextAtomically()`, `stateTempFilesToClean()`, `DesktopStateStore.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 25`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 30`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 32`** (26 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.processPromptFileLines()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 33`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
+- **Thin community `Community 34`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 39`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 42`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 43`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 47`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 48`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 49`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 52`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 55`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 53`** (15 nodes): `Scanner`, `.addToken()`, `.advance()`, `.identifier()`, `.isAlpha()`, `.isAlphaNumeric()`, `.isAtEnd()`, `.isDigit()`, `.match()`, `.number()`, `.peek()`, `.peekNext()`, `.scanToken()`, `.scanTokens()`, `Scanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 56`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
+- **Thin community `Community 58`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
+- **Thin community `Community 61`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 68`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 63`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 71`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 69`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 73`** (12 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.compactForResume()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.readUtf8Tail()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 72`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 74`** (12 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.compactForResume()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.readUtf8Tail()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (11 nodes): `TemplateEngineTest`, `.setUp()`, `.`should cap legacy all outputs interpolation`()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 78`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 79`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 79`** (11 nodes): `TemplateEngineTest`, `.setUp()`, `.`should cap legacy all outputs interpolation`()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 81`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 80`** (11 nodes): `baseState()`, `company()`, `DesktopAppServiceRuntimeCleanupTest`, `issue()`, `run()`, `StartupRecordingBrowserSkillRunner`, `.execute()`, `.prewarm()`, `testService()`, `worktree()`, `DesktopAppServiceRuntimeCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 81`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 83`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 89`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 84`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 90`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 89`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 91`** (10 nodes): `A2aArtifactStore`, `.append()`, `.count()`, `.dir()`, `.file()`, `.list()`, `.loadAllLocked()`, `.persist()`, `.scopedOpsMetrics()`, `A2aArtifactStore.kt`
+- **Thin community `Community 91`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 93`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 92`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 98`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 94`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 99`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
+- **Thin community `Community 99`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 100`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
+- **Thin community `Community 100`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 105`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 101`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 108`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 112`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 113`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 114`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 115`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 117`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 118`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 119`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 120`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
+- **Thin community `Community 121`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 122`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 123`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 124`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 127`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 128`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 129`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 130`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 131`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 132`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 134`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 135`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
+- **Thin community `Community 136`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 138`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 139`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 140`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
+- **Thin community `Community 141`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 142`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
+- **Thin community `Community 143`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 144`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 145`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 146`** (6 nodes): `AuthCommandTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 147`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 148`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 149`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 150`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 151`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 152`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (5 nodes): `RecordingBrowserSkillRunner`, `.execute()`, `skillRuntimeService()`, `SkillRuntimeTest`, `SkillRuntimeTest.kt`
+- **Thin community `Community 153`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 154`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
+- **Thin community `Community 155`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
+- **Thin community `Community 156`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 157`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 158`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 159`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 160`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 161`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 162`** (5 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.ensurePlaywrightDependency()`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 163`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 164`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 165`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 166`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 167`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 168`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 169`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 170`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 171`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 172`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 173`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 174`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 175`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 176`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 177`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (4 nodes): `DesktopTuiSessionServiceTest`, `eventuallyFalse()`, `waitForPid()`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 178`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 179`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 180`** (4 nodes): `DesktopTuiSessionServiceTest`, `eventuallyFalse()`, `waitForPid()`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 181`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 182`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (4 nodes): `ClaudePluginTest`, `RecordingClaudeProcessManager`, `.executeProcess()`, `ClaudePluginTest.kt`
+- **Thin community `Community 183`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 184`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 185`** (4 nodes): `ClaudePluginTest`, `RecordingClaudeProcessManager`, `.executeProcess()`, `ClaudePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `isProcessAlive()`, `SyntaxValidatorTest`, `waitUntilNotAlive()`, `SyntaxValidatorTest.kt`
+- **Thin community `Community 186`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
+- **Thin community `Community 187`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 188`** (4 nodes): `isProcessAlive()`, `SyntaxValidatorTest`, `waitUntilNotAlive()`, `SyntaxValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (4 nodes): `BoundCompanyRuntime`, `CompanyRuntimeBindingService`, `.bind()`, `CompanyRuntimeBindingService.kt`
+- **Thin community `Community 190`** (4 nodes): `providerCatalog()`, `ProviderCatalogEntry`, `ProviderScanResult`, `ProviderModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 191`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 193`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 195`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 198`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 199`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 200`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 201`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 202`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 203`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 204`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 205`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 206`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 207`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 208`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 209`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 210`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 211`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 212`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 213`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `actionRecord()`, `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 214`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 215`** (3 nodes): `actionRecord()`, `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `ActionExecutionServiceTest`, `actionRecord()`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 216`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `NonPluginWithStaticInitializer`, `PluginLoaderTest`, `PluginLoaderTest.kt`
+- **Thin community `Community 217`** (3 nodes): `ActionExecutionServiceTest`, `actionRecord()`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `CotorHttpClientsTest`, `localTextServer()`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 218`** (3 nodes): `NonPluginWithStaticInitializer`, `PluginLoaderTest`, `PluginLoaderTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `CliProcessProbeTest`, `executableScript()`, `CliProcessProbeTest.kt`
+- **Thin community `Community 219`** (3 nodes): `CotorHttpClientsTest`, `localTextServer()`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 220`** (3 nodes): `CliProcessProbeTest`, `executableScript()`, `CliProcessProbeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 221`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 222`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 223`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 224`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 225`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 226`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 227`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 229`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 230`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 231`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 232`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 233`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 234`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 235`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 236`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 237`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 238`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 240`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 241`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 242`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 243`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 244`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 245`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 246`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 247`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 248`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 249`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 250`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 251`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 252`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 253`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 254`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 255`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 256`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 257`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `DesktopStateStoreTest`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 258`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 259`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 260`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 261`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 262`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 263`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 264`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 265`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 266`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 267`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 268`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 269`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
+- **Thin community `Community 270`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 271`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 272`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 273`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 274`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 275`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
+- **Thin community `Community 276`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 277`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 278`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 279`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 280`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 281`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 282`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 283`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 284`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 285`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 286`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 287`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 288`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 289`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 290`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 291`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 292`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 293`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 294`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 295`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 296`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 297`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 298`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 299`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 300`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 301`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 302`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 303`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 304`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 305`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 306`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `AuthCommandTest`, `AuthCommandTest.kt`
+- **Thin community `Community 307`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 308`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 309`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 310`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 311`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 312`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 313`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 314`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 315`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 316`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 317`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 318`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 319`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 320`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 322`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+- **Thin community `Community 325`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 326`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 2` to `Community 1`, `Community 3`, `Community 6`, `Community 9`, `Community 10`, `Community 19`, `Community 91`?**
-  _High betweenness centrality (0.075) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 2` to `Community 1`, `Community 5`, `Community 6`, `Community 10`, `Community 20`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 5` to `Community 2`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
-- **Are the 38 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
-  _`DesktopStore` has 38 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 12 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
-  _`DesktopAPI` has 12 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
-  _1027 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 8`, `Community 11`, `Community 12`?**
+  _High betweenness centrality (0.069) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 11`, `Community 21`?**
+  _High betweenness centrality (0.038) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 5` to `Community 1`?**
+  _High betweenness centrality (0.031) - this node is a cross-community bridge._
+- **Are the 39 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
+  _`DesktopStore` has 39 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 13 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
+  _`DesktopAPI` has 13 INFERRED edges - model-reasoned connections that need verification._
+- **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
+  _1015 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._

--- a/macos/Packaging/CotorDesktopLauncher.sh.template
+++ b/macos/Packaging/CotorDesktopLauncher.sh.template
@@ -189,6 +189,59 @@ if pid:
 PY
 }
 
+read_existing_instance_port() {
+    if [[ ! -f "$INSTANCE_METADATA_FILE" ]]; then
+        return 0
+    fi
+
+    /usr/bin/python3 - "$INSTANCE_METADATA_FILE" <<'PY'
+import json
+import pathlib
+import sys
+
+metadata_path = pathlib.Path(sys.argv[1])
+try:
+    data = json.loads(metadata_path.read_text())
+except Exception:
+    sys.exit(0)
+
+port = data.get("port")
+if port:
+    print(port)
+PY
+}
+
+reattach_managed_backend_if_healthy() {
+    local existing_pid
+    local existing_port
+    local candidate_port
+    local candidate_url
+
+    existing_pid="$(read_existing_instance_pid)"
+    [[ -n "$existing_pid" ]] || return 1
+    is_pid_alive "$existing_pid" || return 1
+
+    existing_port="$(read_existing_instance_port)"
+    candidate_port="${SERVER_PORT:-$existing_port}"
+    [[ -n "$candidate_port" ]] || return 1
+    candidate_url="${SERVER_URL:-http://127.0.0.1:$candidate_port}"
+    is_backend_healthy "$candidate_url" || return 1
+
+    MANAGED_BACKEND_PID="$existing_pid"
+    MANAGED_BACKEND_STARTED=1
+    SERVER_PORT="$candidate_port"
+    SERVER_URL="$candidate_url"
+    echo "$existing_pid" > "$PID_FILE"
+    echo "$candidate_port" > "$PORT_FILE"
+    if [[ -n "$SERVER_TOKEN" ]]; then
+        umask 077
+        echo "$SERVER_TOKEN" > "$TOKEN_FILE"
+        chmod 600 "$TOKEN_FILE" >/dev/null 2>&1 || true
+    fi
+    log_launcher "Reattached to healthy managed backend $existing_pid on port $candidate_port."
+    return 0
+}
+
 terminate_conflicting_app_home_backend() {
     local existing_pid
     existing_pid="$(read_existing_instance_pid)"
@@ -375,6 +428,13 @@ restart_managed_backend() {
         return 1
     fi
 
+    if reattach_managed_backend_if_healthy; then
+        return 0
+    fi
+    if (( MANAGED_BACKEND_STARTED != 0 )); then
+        stop_managed_backend || true
+    fi
+
     MANAGED_BACKEND_STARTED=0
     MANAGED_BACKEND_PID=""
     rm -f "$PID_FILE" >/dev/null 2>&1 || true
@@ -384,7 +444,7 @@ restart_managed_backend() {
     fi
 
     log_launcher "Managed backend is not running. Restarting on preserved port $SERVER_PORT."
-    start_managed_backend 0
+    start_managed_backend 0 || reattach_managed_backend_if_healthy
 }
 
 stop_managed_backend() {

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -3293,6 +3293,11 @@ final class DesktopStore: ObservableObject {
     ) async -> SkillRunResultRecord? {
         guard let companyId = selectedCompanyID else { return nil }
         let key = "\(agentId):\(skillName)"
+        let effectiveParameters = skillRunParameters(
+            skillName: skillName,
+            input: input,
+            parameters: parameters
+        )
         runningSkillRunKeys.insert(key)
         defer { runningSkillRunKeys.remove(key) }
 
@@ -3302,7 +3307,7 @@ final class DesktopStore: ObservableObject {
                 companyId: companyId,
                 agentId: agentId,
                 input: input,
-                parameters: parameters
+                parameters: effectiveParameters
             )
             recentSkillRunResults = ([result] + recentSkillRunResults).prefix(20).map { $0 }
             let now = Int64(Date().timeIntervalSince1970 * 1000)
@@ -3329,6 +3334,33 @@ final class DesktopStore: ObservableObject {
             errorMessage = error.localizedDescription
             return nil
         }
+    }
+
+    private func skillRunParameters(
+        skillName: String,
+        input: String?,
+        parameters: [String: String]
+    ) -> [String: String] {
+        guard skillName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "browser-smoke",
+              parameters["url"]?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false,
+              firstWebURL(from: input) == nil else {
+            return parameters
+        }
+        var next = parameters
+        next["url"] = api.baseURL.appendingPathComponent("health").absoluteString
+        return next
+    }
+
+    private func firstWebURL(from text: String?) -> String? {
+        guard let text else { return nil }
+        return text
+            .split(whereSeparator: \.isWhitespace)
+            .map { token in
+                String(token).trimmingCharacters(in: CharacterSet(charactersIn: ".,;:)]}\"'"))
+            }
+            .first { token in
+                token.hasPrefix("http://") || token.hasPrefix("https://")
+            }
     }
 
     func submitOperatorChatCommand(_ command: OperatorChatCommand) async {

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -1124,6 +1124,89 @@ struct DesktopStoreTests {
     }
 
     @Test
+    func browserSmokeSkillDefaultsToAppHealthURLWhenRunFromUI() async throws {
+        let host = "desktop-browser-skill.test"
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [DesktopStoreCapturingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let api = DesktopAPI(
+            baseURL: try #require(URL(string: "http://\(host)")),
+            token: "test-token",
+            session: session
+        )
+        let store = DesktopStore(api: api)
+        store.selectedCompanyID = "company"
+
+        let skillRunRequests = Locked<[SkillRunRequestPayload]>([])
+        let skillResult = SkillRunResultRecord(
+            skill: "browser-smoke",
+            status: "COMPLETED",
+            capability: CapabilitySimulationResultRecord(
+                action: "skill.run",
+                capability: "SKILL_RUN",
+                mode: "AUTO",
+                allowed: true,
+                requiresApproval: false,
+                reason: "delegated"
+            ),
+            runId: "run-browser-smoke",
+            actions: ["browser-smoke"],
+            evidence: [
+                SkillRunEvidenceRecord(
+                    type: "url",
+                    path: nil,
+                    url: "http://\(host)/health",
+                    title: "Final URL",
+                    detail: "Cotor app-server"
+                )
+            ],
+            summary: "Visited http://\(host)/health (0 console error(s)).",
+            output: nil,
+            error: nil
+        )
+
+        DesktopStoreCapturingURLProtocol.setRequestHandler(forHost: host) { request in
+            let encoder = JSONEncoder()
+            let path = request.url?.path ?? ""
+            let data: Data
+            switch (request.httpMethod ?? "GET", path) {
+            case ("POST", "/api/app/skills/browser-smoke/run"):
+                let body = try #require(requestBodyData(from: request))
+                let payload = try JSONDecoder().decode(SkillRunRequestPayload.self, from: body)
+                skillRunRequests.withLock { $0.append(payload) }
+                data = try encoder.encode(skillResult)
+            case ("GET", "/api/app/companies/company/dashboard"):
+                data = Data("{}".utf8)
+            case ("GET", "/api/app/skills"),
+                 ("GET", "/api/app/marketing/policies"),
+                 ("GET", "/api/app/marketing/runs"),
+                 ("GET", "/api/app/companies/company/reports"),
+                 ("GET", "/api/app/companies/company/problem-signals"):
+                data = Data("[]".utf8)
+            default:
+                data = Data("{}".utf8)
+            }
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, data)
+        }
+        defer { DesktopStoreCapturingURLProtocol.removeRequestHandler(forHost: host) }
+
+        let result = await store.runSkill(skillName: "browser-smoke", agentId: "agent-builder")
+
+        #expect(result?.status == "COMPLETED")
+        let payloads = skillRunRequests.withLock { $0 }
+        #expect(payloads.count == 1)
+        #expect(payloads.first?.companyId == "company")
+        #expect(payloads.first?.agentId == "agent-builder")
+        #expect(payloads.first?.parameters["url"] == "http://\(host)/health")
+    }
+
+    @Test
     func marketingSkillsStayOptInAndPolicyFormLoadsForOperator() {
         let store = DesktopStore()
         store.availableSkills = [

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -8,6 +8,7 @@ LAUNCHER_PROCESS="CotorDesktopLauncher"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist/cotor-desktop-run"
 APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 
 export COTOR_PROJECT_ROOT="$ROOT_DIR"
 export COTOR_DESKTOP_BUILD_OUTPUT_ROOT="$DIST_DIR"
@@ -26,14 +27,51 @@ build_bundle() {
 }
 
 open_app() {
-  /usr/bin/open -n "$APP_BUNDLE"
+  if [[ -x "$LSREGISTER" ]]; then
+    "$LSREGISTER" -f "$APP_BUNDLE" >/dev/null 2>&1 || true
+  fi
+  /usr/bin/open -n -F "$APP_BUNDLE"
+}
+
+bundle_process_lines() {
+  ps -axo pid=,args= | while IFS= read -r line; do
+    case "$line" in
+      *"$APP_BUNDLE/Contents/MacOS/$APP_PROCESS"*|*"$APP_BUNDLE/Contents/MacOS/$LAUNCHER_PROCESS"*)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done
+}
+
+other_cotor_process_lines() {
+  ps -axo pid=,args= | while IFS= read -r line; do
+    case "$line" in
+      *"/Cotor Desktop.app/Contents/MacOS/$APP_PROCESS"*|*"/Cotor Desktop.app/Contents/MacOS/$LAUNCHER_PROCESS"*)
+        case "$line" in
+          *"$APP_BUNDLE/Contents/MacOS/"*) ;;
+          *) printf '%s\n' "$line" ;;
+        esac
+        ;;
+    esac
+  done
 }
 
 verify_running() {
   for _ in {1..30}; do
-    if pgrep -f "$APP_BUNDLE/Contents/MacOS/$APP_PROCESS" >/dev/null 2>&1 ||
-      pgrep -f "$APP_BUNDLE/Contents/MacOS/$LAUNCHER_PROCESS" >/dev/null 2>&1; then
-      return 0
+    if [[ -n "$(bundle_process_lines)" ]]; then
+      sleep 1
+      if [[ -n "$(bundle_process_lines)" ]]; then
+        return 0
+      fi
+      break
+    fi
+    local stale_processes
+    stale_processes="$(other_cotor_process_lines)"
+    if [[ -n "$stale_processes" ]]; then
+      echo "Cotor Desktop launched from a different bundle path:" >&2
+      echo "$stale_processes" >&2
+      echo "Expected bundle: $APP_BUNDLE" >&2
+      return 1
     fi
     sleep 0.3
   done

--- a/shell/test-desktop-launcher-runtime.sh
+++ b/shell/test-desktop-launcher-runtime.sh
@@ -57,6 +57,40 @@ if [[ -e "$PID_FILE" || -e "$BACKEND_RUNTIME_JAR" ]]; then
   exit 1
 fi
 
+INSTANCE_METADATA_FILE="$WORK_DIR/app-server.instance.json"
+SERVER_PORT="55123"
+SERVER_URL="http://127.0.0.1:55123"
+SERVER_TOKEN="token-123"
+PID_FILE="$WORK_DIR/app-server.pid"
+PORT_FILE="$WORK_DIR/app-server.port"
+TOKEN_FILE="$WORK_DIR/app-server.token"
+MANAGED_BACKEND_PID="555"
+MANAGED_BACKEND_STARTED=1
+restart_calls=0
+cat >"$INSTANCE_METADATA_FILE" <<'JSON'
+{"pid":444,"host":"127.0.0.1","port":55123,"appHome":"/tmp/cotor-test","startedAt":1}
+JSON
+echo "555" > "$PID_FILE"
+is_pid_alive() {
+  [[ "$1" == "444" ]]
+}
+is_backend_healthy() {
+  [[ "$1" == "http://127.0.0.1:55123" ]]
+}
+start_managed_backend() {
+  restart_calls=$((restart_calls + 1))
+}
+
+restart_managed_backend
+
+if [[ "$restart_calls" != "0" ||
+  "$MANAGED_BACKEND_PID" != "444" ||
+  "$(cat "$PID_FILE")" != "444" ||
+  "$(cat "$PORT_FILE")" != "55123" ]]; then
+  echo "restart_managed_backend did not reattach to healthy existing backend"
+  exit 1
+fi
+
 BACKEND_RUNTIME_DIR="$WORK_DIR/runtime/backend"
 mkdir -p "$BACKEND_RUNTIME_DIR"
 BACKEND_RUNTIME_JAR="$BACKEND_RUNTIME_DIR/cotor-backend-runtime-current.jar"

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -79,6 +79,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -95,8 +97,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
@@ -15032,23 +15032,34 @@ class DesktopAppService(
             definition.agentCli.equals("opencode", ignoreCase = true) && (companyId == null || definition.companyId == companyId)
         }
         if (opencodeDefinitions.isEmpty()) return
-        val availableModels = availableAgentModels("opencode")
         val legacyModels = setOf(
             "opencode/nemotron-3-super-free",
             "opencode/minimax-m2.5-free",
             "opencode/qwen3.6-plus-free"
         )
+        val normalizedModels = opencodeDefinitions.associate { definition ->
+            definition.id to OpenCodeDefaults.normalizeModel(definition.model)
+        }
+        val needsModelValidation = opencodeDefinitions.any { definition ->
+            val normalized = normalizedModels[definition.id]
+            normalized != null &&
+                normalized != OpenCodeDefaults.DEFAULT_MODEL &&
+                normalized !in legacyModels
+        }
+        val availableModels = if (needsModelValidation) availableAgentModels("opencode") else emptyList()
         val validModels = availableModels.toSet()
         val updatedAt = System.currentTimeMillis()
+        fun shouldMigrate(definition: CompanyAgentDefinition): Boolean {
+            val normalized = OpenCodeDefaults.normalizeModel(definition.model)
+            return normalized == null ||
+                normalized in legacyModels ||
+                (validModels.isNotEmpty() && normalized !in validModels)
+        }
         val nextDefinitions = state.companyAgentDefinitions.map { definition ->
             if (!definition.agentCli.equals("opencode", ignoreCase = true) || (companyId != null && definition.companyId != companyId)) {
                 definition
             } else {
-                val normalized = OpenCodeDefaults.normalizeModel(definition.model)
-                val shouldMigrate = normalized == null ||
-                    normalized in legacyModels ||
-                    (validModels.isNotEmpty() && normalized !in validModels)
-                if (shouldMigrate) {
+                if (shouldMigrate(definition)) {
                     definition.copy(model = OpenCodeDefaults.DEFAULT_MODEL, updatedAt = updatedAt)
                 } else {
                     definition
@@ -15062,11 +15073,7 @@ class DesktopAppService(
                 if (!definition.agentCli.equals("opencode", ignoreCase = true) || (companyId != null && definition.companyId != companyId)) {
                     definition
                 } else {
-                    val normalized = OpenCodeDefaults.normalizeModel(definition.model)
-                    val shouldMigrate = normalized == null ||
-                        normalized in legacyModels ||
-                        (validModels.isNotEmpty() && normalized !in validModels)
-                    if (shouldMigrate) {
+                    if (shouldMigrate(definition)) {
                         definition.copy(model = OpenCodeDefaults.DEFAULT_MODEL, updatedAt = updatedAt)
                     } else {
                         definition
@@ -20591,6 +20598,16 @@ class DesktopAppService(
                 if (current == null || current == defaults[key]) {
                     nextSettings[key] = setting
                     changed = true
+                } else if (key == CapabilityKey.SKILL_RUN && current.isLegacyRepositoryMappingSkillRun()) {
+                    val mergedAllowlist = (current.skillAllowlist + setting.skillAllowlist).distinct()
+                    if (mergedAllowlist != current.skillAllowlist) {
+                        nextSettings[key] = current.copy(
+                            skillAllowlist = mergedAllowlist,
+                            requiresEvidence = true,
+                            notes = current.notes ?: setting.notes
+                        )
+                        changed = true
+                    }
                 }
             }
         }
@@ -20618,6 +20635,12 @@ class DesktopAppService(
 
     private fun isRepositoryMappingAgentDefinition(definition: CompanyAgentDefinition): Boolean =
         definition.title.equals("Engineering Lead", ignoreCase = true)
+
+    private fun AgentCapabilitySetting.isLegacyRepositoryMappingSkillRun(): Boolean =
+        enabled &&
+            mode == CapabilityMode.AUTO &&
+            skillAllowlist.any { it.equals("graphify", ignoreCase = true) } &&
+            skillAllowlist.none { it.equals("browser-smoke", ignoreCase = true) }
 
     private fun repositoryMappingSkillSettings(rootPath: String): Map<CapabilityKey, AgentCapabilitySetting> {
         val repositoryRoot = Path.of(rootPath).toAbsolutePath().normalize().toString()

--- a/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopStateStore.kt
@@ -50,8 +50,8 @@ class DesktopStateStore(
         private const val MAX_PERSISTED_RUN_OUTPUT_CHARS = 4000
         private const val MAX_PERSISTED_DIRECT_CHAT_CONVERSATIONS_PER_COMPANY = 25
         private const val MAX_PERSISTED_DIRECT_CHAT_MESSAGES_PER_CONVERSATION = 80
-        private const val MAX_PERSISTED_DIRECT_CHAT_MESSAGE_CHARS = 20_000
-        private const val MAX_PERSISTED_DIRECT_CHAT_SYSTEM_PROMPT_CHARS = 4_000
+        private const val MAX_PERSISTED_DIRECT_CHAT_MESSAGE_CHARS = 1_024
+        private const val MAX_PERSISTED_DIRECT_CHAT_SYSTEM_PROMPT_CHARS = 2_048
         private const val MAX_STATE_LOAD_LOG_BYTES = 1L * 1024L * 1024L
         private const val STATE_LOAD_LOG_DEDUP_WINDOW_MS = 30_000L
         private const val STATE_LOCK_TIMEOUT_MS = 3_000L
@@ -129,7 +129,8 @@ class DesktopStateStore(
         StateCollection("marketingRuns", ListSerializer(MarketingRunRecord.serializer()), DesktopAppState::marketingRuns) { state, value -> state.copy(marketingRuns = value) },
         StateCollection("skillRuns", ListSerializer(SkillRunRecord.serializer()), DesktopAppState::skillRuns) { state, value -> state.copy(skillRuns = value) },
         StateCollection("companyRuntimeWorkItems", ListSerializer(CompanyRuntimeWorkItem.serializer()), DesktopAppState::companyRuntimeWorkItems) { state, value -> state.copy(companyRuntimeWorkItems = value) },
-        StateCollection("problemSignals", ListSerializer(CompanyProblemSignal.serializer()), DesktopAppState::problemSignals) { state, value -> state.copy(problemSignals = value) }
+        StateCollection("problemSignals", ListSerializer(CompanyProblemSignal.serializer()), DesktopAppState::problemSignals) { state, value -> state.copy(problemSignals = value) },
+        StateCollection("directChatConversations", ListSerializer(DirectChatConversation.serializer()), DesktopAppState::directChatConversations) { state, value -> state.copy(directChatConversations = value) }
     )
 
     // A single process can finish multiple background runs nearly at once, so writes

--- a/src/main/kotlin/com/cotor/app/DesktopTuiSessionService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopTuiSessionService.kt
@@ -120,18 +120,18 @@ class DesktopTuiSessionService(
         )
         val process = runCatching {
             ProcessBuilder(ptyCommand)
-            .directory(Path.of(repository.localPath).toFile())
-            .apply {
-                // Present a real terminal environment so JLine and Mordant can
-                // enable interactive editing, ANSI styling, and prompt redraws.
-                environment()["TERM"] = "xterm-256color"
-                environment()["COTOR_DESKTOP_TUI"] = "1"
-                environment()["PATH"] = buildDesktopCliPath(environment()["PATH"])
-                // The interactive loop already prints user-facing failures, so
-                // suppress backend stack traces that would otherwise flood xterm.
-                environment()["COTOR_LOG_LEVEL"] = "ERROR"
-            }
-            .start()
+                .directory(Path.of(repository.localPath).toFile())
+                .apply {
+                    // Present a real terminal environment so JLine and Mordant can
+                    // enable interactive editing, ANSI styling, and prompt redraws.
+                    environment()["TERM"] = "xterm-256color"
+                    environment()["COTOR_DESKTOP_TUI"] = "1"
+                    environment()["PATH"] = buildDesktopCliPath(environment()["PATH"])
+                    // The interactive loop already prints user-facing failures, so
+                    // suppress backend stack traces that would otherwise flood xterm.
+                    environment()["COTOR_LOG_LEVEL"] = "ERROR"
+                }
+                .start()
         }.getOrElse { error ->
             if (error is CancellationException) throw error
             return rememberFailedTuiSession(session, ptyCommand, error)

--- a/src/main/kotlin/com/cotor/app/DirectChatService.kt
+++ b/src/main/kotlin/com/cotor/app/DirectChatService.kt
@@ -8,17 +8,17 @@ package com.cotor.app
  * Read here first when tracing behavior that flows through direct multi-turn AI conversations.
  */
 
-import com.cotor.data.process.destroyProcessTree
 import com.cotor.data.http.sendBoundedText
+import com.cotor.data.process.destroyProcessTree
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
@@ -386,7 +386,7 @@ class DirectChatService(
                                     sb.append(buf, 0, read)
                                     if (sb.length > claudeOutputLimitChars) {
                                         destroyProcessTree(process)
-                                        error("claude-cli output exceeded ${claudeOutputLimitChars} character limit")
+                                        error("claude-cli output exceeded $claudeOutputLimitChars character limit")
                                     }
                                 }
                             }

--- a/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
+++ b/src/main/kotlin/com/cotor/app/LocalPlaywrightBrowserSkillRunner.kt
@@ -4,10 +4,10 @@ import com.cotor.storage.writeTextAtomically
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import java.nio.file.Files

--- a/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
+++ b/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
@@ -1,9 +1,9 @@
 package com.cotor.app
 
+import com.cotor.data.process.ProcessDescendantTracker
 import com.cotor.data.process.buildEffectivePath
 import com.cotor.data.process.cleanupSurvivingDescendants
 import com.cotor.data.process.destroyProcessTree
-import com.cotor.data.process.ProcessDescendantTracker
 import com.cotor.data.process.resolveExecutablePath
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
+++ b/src/main/kotlin/com/cotor/app/runtime/CompanyRuntimeBindingService.kt
@@ -12,7 +12,6 @@ import com.cotor.providers.github.GitHubControlPlaneService
 import com.cotor.providers.github.PullRequestSnapshot
 import com.cotor.runtime.actions.ActionLogSummary
 import com.cotor.runtime.actions.ActionStore
-import com.cotor.runtime.durable.DurableRunSnapshot
 import com.cotor.runtime.durable.DurableRunStatus
 import com.cotor.runtime.durable.DurableRunSummary
 import com.cotor.runtime.durable.DurableRuntimeService
@@ -107,10 +106,9 @@ class CompanyRuntimeBindingService(
                 issueId to task.id
             }
             .toMap()
-        val boundIssues = state.issues.map { issue ->
-            if (issue.companyId != companyId) {
-                issue
-            } else {
+        val boundIssues = state.issues
+            .filter { it.companyId == companyId }
+            .map { issue ->
                 val issuePullRequest = issue.pullRequestNumber?.let(providerBlockByPr::get)
                     ?: providerBlockByIssueId[issue.id]
                 val matchingRun = runs.firstOrNull { run ->
@@ -148,11 +146,9 @@ class CompanyRuntimeBindingService(
                     runtimeDisposition = runtimeDisposition
                 )
             }
-        }
-        val boundQueue = state.reviewQueue.map { item ->
-            if (item.companyId != companyId) {
-                item
-            } else {
+        val boundQueue = state.reviewQueue
+            .filter { it.companyId == companyId }
+            .map { item ->
                 val snapshot = item.pullRequestNumber?.let(providerBlockByPr::get)
                 val runtimeDisposition = when {
                     item.approvalPauseId != null -> CompanyIssueReadiness.WAITING_FOR_APPROVAL
@@ -172,7 +168,6 @@ class CompanyRuntimeBindingService(
                     runtimeDisposition = runtimeDisposition
                 )
             }
-        }
         val pendingIssueIds = boundIssues
             .filter { it.companyId == companyId }
             .filter { it.runtimeDisposition == CompanyIssueReadiness.RUNNABLE }

--- a/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
+++ b/src/main/kotlin/com/cotor/checkpoint/CheckpointManager.kt
@@ -8,8 +8,8 @@ package com.cotor.checkpoint
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
-import com.cotor.storage.writeTextAtomically
 import com.cotor.model.AgentResult
+import com.cotor.storage.writeTextAtomically
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString

--- a/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/AIModelPlugins.kt
@@ -8,8 +8,8 @@ package com.cotor.data.plugin
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
-import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.http.BoundedHttpTextResponse
+import com.cotor.data.http.CotorHttpClients
 import com.cotor.data.http.sendBoundedText
 import com.cotor.data.process.ProcessManager
 import com.cotor.data.process.destroyProcessTree
@@ -37,7 +37,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import java.io.IOException
 import java.net.URI
-import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files

--- a/src/main/kotlin/com/cotor/data/process/ProcessTree.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessTree.kt
@@ -90,13 +90,15 @@ internal fun cleanupSurvivingDescendants(
     logger: Logger? = null,
     observedDescendantPids: Iterable<Long> = emptyList()
 ) {
-    val descendants = (process.toHandle()
-        .descendants()
-        .toArray()
-        .filterIsInstance<ProcessHandle>()
-        .asReversed() + observedDescendantPids.mapNotNull { pid ->
-        ProcessHandle.of(pid).orElse(null)
-    })
+    val descendants = (
+        process.toHandle()
+            .descendants()
+            .toArray()
+            .filterIsInstance<ProcessHandle>()
+            .asReversed() + observedDescendantPids.mapNotNull { pid ->
+            ProcessHandle.of(pid).orElse(null)
+        }
+        )
         .distinctBy { it.pid() }
         .filter { it.isAlive }
     if (descendants.isEmpty()) {

--- a/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/InteractiveCommand.kt
@@ -40,9 +40,9 @@ import org.jline.reader.UserInterruptException
 import org.jline.terminal.TerminalBuilder
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.io.PrintStream
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists

--- a/src/main/kotlin/com/cotor/security/NetworkEndpointPolicy.kt
+++ b/src/main/kotlin/com/cotor/security/NetworkEndpointPolicy.kt
@@ -1,9 +1,9 @@
 package com.cotor.security
 
-import java.net.URI
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
+import java.net.URI
 
 /**
  * Validates user-configurable HTTP endpoints before outbound clients use them.

--- a/src/main/kotlin/com/cotor/stats/StatsManager.kt
+++ b/src/main/kotlin/com/cotor/stats/StatsManager.kt
@@ -8,9 +8,9 @@ package com.cotor.stats
  * Read here first when tracing behavior that flows through this part of the codebase.
  */
 
-import com.cotor.storage.writeTextAtomically
 import com.cotor.model.AggregatedResult
 import com.cotor.model.FailureCategory
+import com.cotor.storage.writeTextAtomically
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString

--- a/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
+++ b/src/test/kotlin/com/cotor/a2a/A2aApiTest.kt
@@ -5,11 +5,11 @@ import com.cotor.app.AgentRunStatus
 import com.cotor.app.DesktopAppService
 import com.cotor.app.DesktopTuiSessionService
 import com.cotor.app.cotorAppModule
-import io.ktor.client.HttpClient
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceParallelDispatchTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceParallelDispatchTest.kt
@@ -55,7 +55,8 @@ class DesktopAppServiceParallelDispatchTest : FunSpec({
             configRepository = mockk<ConfigRepository>(relaxed = true),
             agentExecutor = agentExecutor,
             companyRuntimeTickIntervalMs = 50,
-            commandAvailability = { command -> command == "opencode" }
+            commandAvailability = { command -> command == "opencode" },
+            autoStartAutomationRefresh = false
         )
 
         try {
@@ -233,7 +234,7 @@ class DesktopAppServiceParallelDispatchTest : FunSpec({
 
             val blockedIssue = withTimeout(5_000) {
                 var current = stateStore.load().issues.single { it.id == issue.id }
-                while (current.status == IssueStatus.IN_PROGRESS) {
+                while (current.status in setOf(IssueStatus.PLANNED, IssueStatus.DELEGATED, IssueStatus.IN_PROGRESS)) {
                     delay(50)
                     current = stateStore.load().issues.single { it.id == issue.id }
                 }

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -200,6 +200,47 @@ class SkillRuntimeTest : FunSpec({
         profile.settings.getValue(CapabilityKey.BROWSER_SCREENSHOT).mode shouldBe CapabilityMode.AUTO
     }
 
+    test("legacy Engineering Lead graphify-only profile is upgraded for browser-smoke") {
+        val appHome = Files.createTempDirectory("skill-eng-lead-browser-upgrade-home")
+        val repoRoot = Files.createDirectories(appHome.resolve("repo"))
+        val browser = RecordingBrowserSkillRunner()
+        val service = skillRuntimeService(appHome, browser)
+        val company = service.createCompany(name = "Eng Lead Browser Upgrade Co", rootPath = repoRoot.toString())
+        val engineeringLead = service.dashboard().companyAgentDefinitions.first {
+            it.companyId == company.id && it.title == "Engineering Lead"
+        }
+        service.updateAgentCapabilities(
+            companyId = company.id,
+            agentId = engineeringLead.id,
+            settings = mapOf(
+                CapabilityKey.SKILL_RUN to AgentCapabilitySetting(
+                    enabled = true,
+                    mode = CapabilityMode.AUTO,
+                    skillAllowlist = listOf("graphify")
+                ),
+                CapabilityKey.BROWSER_READ to AgentCapabilitySetting(enabled = false, mode = CapabilityMode.DISABLED),
+                CapabilityKey.BROWSER_SCREENSHOT to AgentCapabilitySetting(enabled = false, mode = CapabilityMode.DISABLED)
+            )
+        )
+
+        service.prepareCompanyAutomationStateForTesting(company.id)
+        val profile = service.agentCapabilities(company.id, engineeringLead.id)
+
+        profile.settings.getValue(CapabilityKey.SKILL_RUN).skillAllowlist shouldBe listOf("graphify", "browser-smoke")
+        profile.settings.getValue(CapabilityKey.BROWSER_READ).mode shouldBe CapabilityMode.AUTO
+        profile.settings.getValue(CapabilityKey.BROWSER_SCREENSHOT).mode shouldBe CapabilityMode.AUTO
+
+        val result = service.runSkill(
+            name = "browser-smoke",
+            companyId = company.id,
+            agentId = engineeringLead.id,
+            parameters = mapOf("url" to "http://127.0.0.1:8787/health")
+        )
+
+        result.status shouldBe "COMPLETED"
+        browser.commands.single().url shouldBe "http://127.0.0.1:8787/health"
+    }
+
     test("seeded Marketing Operator profile enables all marketing capabilities") {
         val appHome = Files.createTempDirectory("skill-marketing-seed-home")
         val repoRoot = Files.createDirectories(appHome.resolve("repo"))


### PR DESCRIPTION
## 발견된 버그
- Manual Cotor Desktop QA에서 Engineering Lead의 `Browser Tester` 스킬 카드 버튼이 노출되지만 URL 파라미터 없이 실행되어 `FAILED_SETUP Browser smoke needs a URL.`로 실패했습니다.
- 앱 run script 검증이 동일 bundle path가 아닌 다른 Cotor Desktop 인스턴스를 성공으로 오인할 수 있는 여지가 있었습니다.
- managed backend restart 경로가 이미 healthy한 기존 backend를 재활용하지 못하고 불필요하게 재시작할 수 있었습니다.

## 수정 내용
- macOS `DesktopStore.runSkill`에서 `browser-smoke`가 URL 없이 실행될 때 현재 app-server의 `/health`를 기본 smoke URL로 주입합니다. 명시 URL이 있으면 그대로 보존합니다.
- Browser smoke UI 경로 회귀 테스트를 추가했습니다.
- Desktop launcher가 healthy managed backend에 재부착하도록 보강하고 shell 테스트를 추가했습니다.
- Engineering Lead legacy graphify-only capability profile을 `browser-smoke`까지 승격하는 Kotlin 경로와 테스트를 보강했습니다.
- runtime binding/dashboard hot path에서 company-scoped issue/review binding만 반환하도록 줄였습니다.
- `graphify update .`를 실행해 graph report를 갱신했습니다.

## 재테스트 결과
- `./gradlew --no-daemon --max-workers=1 test --tests com.cotor.app.SkillRuntimeTest --tests com.cotor.app.runtime.CompanyRuntimeBindingServiceTest --tests com.cotor.app.DesktopAppServiceParallelDispatchTest -x jacocoTestCoverageVerification` passed
- `./gradlew --no-daemon --max-workers=1 test` passed
- `swift test --package-path macos --filter DesktopStoreTests/browserSmokeSkillDefaultsToAppHealthURLWhenRunFromUI` passed
- `swift test --package-path macos` passed, 128 tests
- `./script/build_and_run.sh --verify` passed and launched `/private/tmp/cotor-qa-auto-agent-skill-runtime-20260527/dist/cotor-desktop-run/Cotor Desktop.app`
- `./shell/test-desktop-launcher-runtime.sh` passed
- `./shell/build-desktop-app-bundle.sh` passed
- Manual Computer Use smoke: Team -> Engineering Lead -> `Repository Mapper` completed; `Browser Tester` initially reproduced `FAILED_SETUP`, after fix/rebuild completed with `Visited http://127.0.0.1:49646/health (0 console error(s)).`
- Backend jar inspection confirmed sqlite-jdbc classes are included in the bundled all jar.

## 남은 리스크
- The local worktree still has generated `dist/` output intentionally left untracked.
- Full objective remains a broad QA loop; this PR closes the concrete agent/skill bug found in the current pass.