### PR TITLE
fix(qa): resolve provider alias readiness checks

### DIFF
--- a/docs/PROVIDERS.ko.md
+++ b/docs/PROVIDERS.ko.md
@@ -8,9 +8,11 @@ Cotor는 로그인, package install, remote catalog refresh, 유료 model call �
 cotor provider list
 cotor provider scan
 cotor provider test opencode
+cotor provider test codex-oauth
 ```
 
 scan은 각 provider command가 `PATH`에 있는지만 확인합니다. `login`, `install`, `pull`, `download`, `render`, `sync`, network refresh 같은 명령은 의도적으로 호출하지 않습니다.
+`provider test`는 canonical provider ID와 `codex`, `codex-exec`, `codex-oauth`, `claude`, `gemma4`, `lmstudio` 같은 agent-facing alias를 함께 받습니다.
 
 ## App-Server API
 
@@ -20,6 +22,6 @@ scan은 각 provider command가 `PATH`에 있는지만 확인합니다. `login`,
 
 ## 기본 Provider
 
-기본 catalog에는 AI CLI, local model server, Git/GitHub 도구, browser/video 도구, security scanner, language/package runtime이 포함됩니다: Codex, Claude Code, Goose, OpenCode, Ollama, LM Studio, `gh`, `git`, Playwright, FFmpeg, Remotion, Manim, OSV Scanner, Node.js, npm, pnpm, Bun, Python, uv, pip.
+기본 catalog에는 AI CLI, local model server, Git/GitHub 도구, browser/video 도구, security scanner, language/package runtime이 포함됩니다: Codex, Claude Code, Gemini, GitHub Copilot, Cursor, Goose, OpenCode, Graphify, Qwen, Ollama, LM Studio, `gh`, `git`, Playwright, FFmpeg, Remotion, Manim, OSV Scanner, Node.js, npm, pnpm, Bun, Python, uv, pip.
 
 OpenCode model discovery는 기존 agent model route와 desktop model picker에서 계속 사용합니다. provider scan은 로컬 provider availability만 보고합니다.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -8,9 +8,11 @@ Cotor can scan known local provider commands without logging in, installing pack
 cotor provider list
 cotor provider scan
 cotor provider test opencode
+cotor provider test codex-oauth
 ```
 
 The scan checks whether each provider command is available on `PATH`. It intentionally avoids commands such as `login`, `install`, `pull`, `download`, `render`, `sync`, and network refresh operations.
+`provider test` accepts canonical provider IDs and common agent-facing aliases such as `codex`, `codex-exec`, `codex-oauth`, `claude`, `gemma4`, and `lmstudio`.
 
 ## App-Server API
 
@@ -20,6 +22,6 @@ The scan checks whether each provider command is available on `PATH`. It intenti
 
 ## Known Providers
 
-The default catalog includes AI CLIs, local model servers, Git/GitHub tooling, browser/video tools, security scanners, and language/package runtimes: Codex, Claude Code, Goose, OpenCode, Ollama, LM Studio, `gh`, `git`, Playwright, FFmpeg, Remotion, Manim, OSV Scanner, Node.js, npm, pnpm, Bun, Python, uv, and pip.
+The default catalog includes AI CLIs, local model servers, Git/GitHub tooling, browser/video tools, security scanners, and language/package runtimes: Codex, Claude Code, Gemini, GitHub Copilot, Cursor, Goose, OpenCode, Graphify, Qwen, Ollama, LM Studio, `gh`, `git`, Playwright, FFmpeg, Remotion, Manim, OSV Scanner, Node.js, npm, pnpm, Bun, Python, uv, and pip.
 
 OpenCode model discovery remains available through the existing agent model route and desktop model picker; provider scan only reports local provider availability.

--- a/shell/cotor
+++ b/shell/cotor
@@ -48,9 +48,40 @@ APP_VERSION=$(/usr/bin/grep -E '^[[:space:]]*version[[:space:]]*=' "$PROJECT_ROO
 
 # Path to the shaded JAR file (built via shadowJar)
 JAR_PATH="$PROJECT_ROOT/build/libs/cotor-${APP_VERSION}-all.jar"
+JAR_TOOL="${JAVA_HOME:+$JAVA_HOME/bin/}jar"
+BUILD_LOCK_DIR="$PROJECT_ROOT/build/.cotor-cli-build.lock"
 
-# Build the CLI if the shaded JAR is missing
-if [ ! -f "$JAR_PATH" ]; then
+release_build_lock() {
+    if [ "${COTOR_CLI_BUILD_LOCK_HELD:-}" = "1" ]; then
+        /bin/rm -rf "$BUILD_LOCK_DIR" >/dev/null 2>&1 || true
+        COTOR_CLI_BUILD_LOCK_HELD=0
+    fi
+}
+
+acquire_build_lock() {
+    /bin/mkdir -p "$PROJECT_ROOT/build" || exit 1
+    local waited=0
+    while ! /bin/mkdir "$BUILD_LOCK_DIR" 2>/dev/null; do
+        if [ "$waited" -eq 0 ]; then
+            echo "Waiting for another cotor CLI build to finish..."
+        fi
+        if [ "$waited" -ge 300 ]; then
+            echo "Error: timed out waiting for cotor CLI build lock at $BUILD_LOCK_DIR"
+            exit 1
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    COTOR_CLI_BUILD_LOCK_HELD=1
+    echo "$$" > "$BUILD_LOCK_DIR/pid" 2>/dev/null || true
+    trap release_build_lock TERM INT HUP EXIT
+}
+
+jar_is_valid() {
+    [ -f "$1" ] && "$JAR_TOOL" tf "$1" >/dev/null 2>&1
+}
+
+build_cli_jar() {
     echo "Building cotor CLI (./gradlew shadowJar)..."
     if [ -x "$PROJECT_ROOT/gradlew" ]; then
         if [ -f "$GRADLE_JAVA_HELPER" ]; then
@@ -58,23 +89,49 @@ if [ ! -f "$JAR_PATH" ]; then
             source "$GRADLE_JAVA_HELPER"
             configure_gradle_java || exit 1
             JAVA_CMD="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+            JAR_TOOL="${JAVA_HOME:+$JAVA_HOME/bin/}jar"
         fi
         (cd "$PROJECT_ROOT" && ./gradlew shadowJar) || exit 1
     else
         echo "Error: gradlew not found in $PROJECT_ROOT"
         exit 1
     fi
-fi
+}
 
-if [ ! -f "$JAR_PATH" ]; then
-    LATEST_JAR=$(/bin/ls -1t "$PROJECT_ROOT"/build/libs/cotor-*-all.jar 2>/dev/null | /usr/bin/head -n 1)
+select_latest_valid_jar() {
+    LATEST_JAR=""
+    for candidate in $(/bin/ls -1t "$PROJECT_ROOT"/build/libs/cotor-*-all.jar 2>/dev/null); do
+        if jar_is_valid "$candidate"; then
+            LATEST_JAR="$candidate"
+            break
+        fi
+    done
     if [ -n "$LATEST_JAR" ] && [ -f "$LATEST_JAR" ]; then
         JAR_PATH="$LATEST_JAR"
-    else
-        echo "Error: unable to locate shaded CLI jar under $PROJECT_ROOT/build/libs"
+        return 0
+    fi
+    return 1
+}
+
+acquire_build_lock
+
+if ! jar_is_valid "$JAR_PATH"; then
+    if [ -f "$JAR_PATH" ]; then
+        echo "Existing cotor CLI jar is invalid; rebuilding..."
+        /bin/rm -f "$JAR_PATH" || exit 1
+    fi
+    build_cli_jar
+fi
+
+if ! jar_is_valid "$JAR_PATH"; then
+    if ! select_latest_valid_jar; then
+        echo "Error: unable to locate a valid shaded CLI jar under $PROJECT_ROOT/build/libs"
         exit 1
     fi
 fi
+
+release_build_lock
+trap - TERM INT HUP EXIT
 
 if [ "${1:-}" = "app-server" ]; then
     APP_HOME="${COTOR_APP_HOME:-${HOME}/Library/Application Support/CotorDesktop}"

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -4015,7 +4015,7 @@ class DesktopAppService(
     }
 
     fun testProvider(providerId: String): ProviderScanResult {
-        val provider = providerCatalog().firstOrNull { it.id.equals(providerId, ignoreCase = true) }
+        val provider = findProviderByIdOrAlias(providerId)
             ?: throw IllegalArgumentException("Provider not found: $providerId")
         val available = commandAvailability(provider.command)
         return ProviderScanResult(

--- a/src/main/kotlin/com/cotor/app/ProviderModels.kt
+++ b/src/main/kotlin/com/cotor/app/ProviderModels.kt
@@ -8,6 +8,7 @@ data class ProviderCatalogEntry(
     val displayName: String,
     val command: String,
     val capabilities: List<CapabilityKey> = emptyList(),
+    val aliases: List<String> = emptyList(),
     val noNetworkScan: Boolean = true
 )
 
@@ -19,12 +20,29 @@ data class ProviderScanResult(
 )
 
 fun providerCatalog(): List<ProviderCatalogEntry> = listOf(
-    ProviderCatalogEntry("codex-cli", "Codex CLI", "codex", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
-    ProviderCatalogEntry("claude-code", "Claude Code", "claude", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
+    ProviderCatalogEntry(
+        "codex-cli",
+        "Codex CLI",
+        "codex",
+        listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL),
+        aliases = listOf("codex", "codex-exec", "codex-oauth")
+    ),
+    ProviderCatalogEntry(
+        "claude-code",
+        "Claude Code",
+        "claude",
+        listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL),
+        aliases = listOf("claude")
+    ),
+    ProviderCatalogEntry("gemini", "Gemini CLI", "gemini", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
+    ProviderCatalogEntry("copilot", "GitHub Copilot CLI", "copilot", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
+    ProviderCatalogEntry("cursor", "Cursor CLI", "cursor", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
     ProviderCatalogEntry("goose", "Goose", "goose", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
     ProviderCatalogEntry("opencode", "OpenCode", "opencode", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
-    ProviderCatalogEntry("ollama", "Ollama", "ollama", listOf(CapabilityKey.EXTERNAL_API_CALL)),
-    ProviderCatalogEntry("lm-studio", "LM Studio CLI", "lms", listOf(CapabilityKey.EXTERNAL_API_CALL)),
+    ProviderCatalogEntry("graphify", "Graphify", "graphify", listOf(CapabilityKey.KNOWLEDGE_GRAPH_READ, CapabilityKey.KNOWLEDGE_GRAPH_WRITE)),
+    ProviderCatalogEntry("qwen", "Qwen CLI", "qwen", listOf(CapabilityKey.SHELL_EXEC, CapabilityKey.EXTERNAL_API_CALL)),
+    ProviderCatalogEntry("ollama", "Ollama", "ollama", listOf(CapabilityKey.EXTERNAL_API_CALL), aliases = listOf("gemma4")),
+    ProviderCatalogEntry("lm-studio", "LM Studio CLI", "lms", listOf(CapabilityKey.EXTERNAL_API_CALL), aliases = listOf("lmstudio")),
     ProviderCatalogEntry("gh", "GitHub CLI", "gh", listOf(CapabilityKey.GITHUB_READ, CapabilityKey.GITHUB_PR_CREATE, CapabilityKey.GITHUB_PR_UPDATE)),
     ProviderCatalogEntry("git", "Git", "git", listOf(CapabilityKey.GIT_READ, CapabilityKey.GIT_WRITE)),
     ProviderCatalogEntry(
@@ -51,3 +69,13 @@ fun providerCatalog(): List<ProviderCatalogEntry> = listOf(
     ProviderCatalogEntry("uv", "uv", "uv", listOf(CapabilityKey.PACKAGE_INSTALL, CapabilityKey.TEST_RUN)),
     ProviderCatalogEntry("pip", "pip", "pip", listOf(CapabilityKey.PACKAGE_INSTALL))
 )
+
+fun ProviderCatalogEntry.matchesIdOrAlias(providerId: String): Boolean {
+    val normalized = providerId.trim()
+    if (normalized.isBlank()) return false
+    return id.equals(normalized, ignoreCase = true) ||
+        aliases.any { it.equals(normalized, ignoreCase = true) }
+}
+
+fun findProviderByIdOrAlias(providerId: String): ProviderCatalogEntry? =
+    providerCatalog().firstOrNull { it.matchesIdOrAlias(providerId) }

--- a/src/test/kotlin/com/cotor/app/ProviderModelsTest.kt
+++ b/src/test/kotlin/com/cotor/app/ProviderModelsTest.kt
@@ -1,0 +1,37 @@
+package com.cotor.app
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+
+class ProviderModelsTest : FunSpec({
+    test("provider catalog exposes agent-facing aliases for readiness checks") {
+        val providers = providerCatalog()
+
+        providers.map { it.id }.distinct().size shouldBe providers.size
+        providers.first { it.id == "codex-cli" }.aliases shouldContainAll listOf("codex", "codex-exec", "codex-oauth")
+        providers.first { it.id == "claude-code" }.aliases shouldContainAll listOf("claude")
+        providers.first { it.id == "ollama" }.aliases shouldContainAll listOf("gemma4")
+        providers.first { it.id == "lm-studio" }.aliases shouldContainAll listOf("lmstudio")
+    }
+
+    test("provider id matching accepts canonical ids and aliases case-insensitively") {
+        val codex = providerCatalog().first { it.id == "codex-cli" }
+        val lmStudio = providerCatalog().first { it.id == "lm-studio" }
+
+        codex.matchesIdOrAlias("codex-cli") shouldBe true
+        codex.matchesIdOrAlias("CODEX-OAUTH") shouldBe true
+        lmStudio.matchesIdOrAlias("lmstudio") shouldBe true
+        codex.matchesIdOrAlias("missing") shouldBe false
+    }
+
+    test("provider lookup accepts agent-facing aliases") {
+        findProviderByIdOrAlias(" codex ")?.id shouldBe "codex-cli"
+        findProviderByIdOrAlias("codex-exec")?.id shouldBe "codex-cli"
+        findProviderByIdOrAlias("codex-oauth")?.id shouldBe "codex-cli"
+        findProviderByIdOrAlias("CLAUDE")?.id shouldBe "claude-code"
+        findProviderByIdOrAlias("gemma4")?.id shouldBe "ollama"
+        findProviderByIdOrAlias(" ") shouldBe null
+        findProviderByIdOrAlias("missing") shouldBe null
+    }
+})


### PR DESCRIPTION
## Found Bugs
- `provider test` only matched canonical provider IDs, so agent-facing names such as `codex`, `codex-exec`, `codex-oauth`, `gemma4`, and `lmstudio` returned `Provider not found` through the app-server/CLI readiness path.
- Parallel source CLI invocations could contend while building or selecting the shaded JAR, which matched the QA run's build-output contention risk when multiple agents were active.

## Fix
- Added provider aliases and case-insensitive alias lookup for readiness checks.
- Extended the provider catalog for current agent/tool providers including Gemini, Copilot, Cursor, Graphify, and Qwen.
- Added source CLI build locking plus shaded-JAR validity checks before launch.
- Updated English and Korean provider docs.
- Added focused provider catalog/alias tests.

## Retest Results
- PASS: `/tmp/cotor-qa-isolated-20260604`: `./gradlew --no-daemon test --rerun-tasks --stacktrace -x jacocoTestReport -x jacocoTestCoverageVerification`
- PASS: `/tmp/cotor-provider-alias-verify`: `./gradlew --no-daemon clean formatCheck test --rerun-tasks --stacktrace`
- PASS: focused provider/app tests in `/tmp/cotor-provider-alias-verify`
- PASS: `swift test`
- PASS: `swift build` in `macos/`
- PASS: `node --test .github/scripts/*.test.js`
- PASS: `./shell/test-desktop-launcher-runtime.sh`
- PASS: live source app-server `/health`, `/api/app/health`, `/api/app/skills`, provider scan, and provider alias tests
- PASS: CLI provider tests for `codex-oauth`, `codex-exec`, `gemma4`, `lmstudio`, and `graphify`
- PASS: direct desktop smoke on the running Cotor Desktop app with app-server health and UI click screenshots captured under local `qa-artifacts/`

## Notes
- `graphify update .` was attempted after code/doc changes but refused to overwrite because the newly extracted graph had fewer nodes than the existing graph (`5139` vs `5259`). The CLI exposes no safe `force` flag, so graph artifacts were left unchanged.
- Local generated artifacts under `dist/` and `qa-artifacts/` were intentionally not committed.
