### PR TITLE
test(qa): stabilize arbitrary cli agent dispatch test

### DIFF
--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -10805,7 +10805,7 @@ class DesktopAppServiceTest : FunSpec({
         seedWorkspace(stateStore, repoRoot)
         val gitWorkspaceService = mockk<GitWorkspaceService>()
         val agentExecutor = mockk<AgentExecutor>()
-        val capturedAgents = mutableListOf<AgentConfig>()
+        val builderAgentDispatched = CompletableDeferred<AgentConfig>()
         coEvery { gitWorkspaceService.resolveRepositoryRoot(any()) } answers { invocation.args[0] as Path }
         coEvery { gitWorkspaceService.detectDefaultBranch(any()) } returns "master"
         coEvery { gitWorkspaceService.detectRemoteUrl(any()) } returns "https://github.com/heodongun/cotor.git"
@@ -10819,8 +10819,10 @@ class DesktopAppServiceTest : FunSpec({
         coEvery { gitWorkspaceService.publishRun(any(), any(), any(), any(), any(), any(), any()) } returns PublishMetadata()
         coEvery { gitWorkspaceService.ensureGitHubPublishReady(any(), any()) } returns GitHubPublishReadiness(ready = true)
         coEvery { agentExecutor.executeAgent(any(), any(), any()) } answers {
-            capturedAgents += invocation.args[0] as AgentConfig
             val agent = invocation.args[0] as AgentConfig
+            if (agent.name == "/bin/echo" && !builderAgentDispatched.isCompleted) {
+                builderAgentDispatched.complete(agent)
+            }
             AgentResult(
                 agentName = agent.name,
                 isSuccess = true,
@@ -10867,14 +10869,9 @@ class DesktopAppServiceTest : FunSpec({
         service.updateIssueAssignee(issue.id, seededBuilder.id)
         service.runIssue(issue.id)
 
-        withTimeout(5_000) {
-            while (capturedAgents.none { it.name == "/bin/echo" }) {
-                delay(25)
-            }
-        }
+        val builderAgent = withTimeout(30_000) { builderAgentDispatched.await() }
 
         coVerify(atLeast = 1) { agentExecutor.executeAgent(any(), any(), any()) }
-        val builderAgent = capturedAgents.first { it.name == "/bin/echo" }
         builderAgent.pluginClass shouldBe "com.cotor.data.plugin.CommandPlugin"
         builderAgent.parameters["argvJson"] shouldBe """["/bin/echo","{input}"]"""
         service.stopCompanyRuntime(goal.companyId).status shouldBe CompanyRuntimeStatus.STOPPED


### PR DESCRIPTION
## Found Bug
- During the post-merge QA loop, the Kotlin suite exposed unstable behavior around agent execution tests while multiple local agent/tool runs were active.
- The arbitrary installed CLI agent test waited by polling a shared mutable capture list from another coroutine, which is weaker than waiting on the exact builder dispatch event.

## Fix
- Replaced list polling in the arbitrary CLI agent dispatch test with a CompletableDeferred that completes only when the /bin/echo builder agent is dispatched.
- Kept the assertion focused on the actual dispatched builder AgentConfig.

## Retest Results
- PASS: ./gradlew --no-daemon --no-build-cache -Dkotlin.compiler.execution.strategy=in-process clean test --stacktrace -x jacocoTestReport -x jacocoTestCoverageVerification
- PASS: ./gradlew --no-daemon formatCheck
- PASS: swift test
- PASS: node --test .github/scripts/*.test.js
- PASS: /bin/bash shell/build-desktop-app-bundle.sh
- PASS: /bin/bash shell/test-desktop-launcher-runtime.sh
- PASS: ./script/build_and_run.sh --verify

## Docs
- Docs were not changed; this is test-only stabilization.

## Notes
- graphify update . was run after the code change, but graphify refused to overwrite because the newly extracted graph had fewer nodes than the existing graph (5139 vs 5259). No graph artifacts were changed.
- Local generated artifacts under dist/ and qa-artifacts/ were intentionally left uncommitted.