### PR TITLE
fix(qa): prevent full suite test worker heap exhaustion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ tasks.register("formatCheck") {
 tasks.test {
     useJUnitPlatform()
     maxParallelForks = 1
+    maxHeapSize = "2g"
     reports.junitXml.apply {
         includeSystemOutLog.set(false)
         includeSystemErrLog.set(false)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - cotor-qa-gradle-coverage-20260604  (2026-06-04)
+# Graph Report - cotor-agent-execution-await-yeK1tg  (2026-06-04)
 
 ## Corpus Check
-- 380 files · ~638,736 words
+- 380 files · ~638,728 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -349,12 +349,12 @@
 ## Surprising Connections (you probably didn't know these)
 - `makeFallbackIcon()` --calls--> `Line`  [INFERRED]
   macos/Tools/generate-desktop-icon.swift → src/main/kotlin/com/cotor/app/DesktopAppService.kt
-- `language` --calls--> `userFacingIssueKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `userFacingDecisionTitle()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
-- `language` --calls--> `localizedSourceKind()`  [INFERRED]
-  macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/ContentView.swift
+- `userFacingIssueKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `userFacingDecisionTitle()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
+- `localizedSourceKind()` --calls--> `language`  [INFERRED]
+  macos/Sources/CotorDesktopApp/ContentView.swift → macos/Sources/CotorDesktopApp/Localization.swift
 - `preparedBrandMark()` --calls--> `Data`  [INFERRED]
   macos/Tools/generate-desktop-icon.swift → macos/Sources/CotorDesktopApp/DesktopAPI.swift
 


### PR DESCRIPTION
## Found Bug
- The post-merge QA rerun found that the full Gradle suite can intermittently fail during operator chat / skill-run integration coverage with `Java heap space` even after the agent-dispatch test stabilization landed on `master`.
- The failing state showed `SkillRunRecord.status=FAILED` with `error="Java heap space"`; rerunning with a larger test worker heap passed the full suite.

## Fix
- Set Gradle `tasks.test.maxHeapSize = "2g"` so the test worker has an explicit heap budget for the large app-service integration suite.
- Refreshed `graphify-out/GRAPH_REPORT.md` after the build configuration change.

## Retest Results
- PASS: `./gradlew --no-daemon test --tests 'com.cotor.app.DesktopAppServiceTest' --rerun-tasks --stacktrace`
- PASS: `./gradlew --no-daemon clean formatCheck test --rerun-tasks --stacktrace`
- PASS: `swift build` in `macos/`
- PASS: `node --test .github/scripts/*.test.js`
- PASS: `./shell/test-desktop-launcher-runtime.sh`
- PASS: `graphify update .`

## Notes
- `origin/master` already contains the deterministic wait fix for the arbitrary CLI agent dispatch test (`test(qa): stabilize arbitrary cli agent dispatch test`). This PR handles the remaining full-suite heap exhaustion found during the next QA loop.
