### PR TITLE
fix(security): isolate process env and stabilize desktop launch

### DIFF
--- a/docs/FULL_E2E_QA_CHECKLIST.ko.md
+++ b/docs/FULL_E2E_QA_CHECKLIST.ko.md
@@ -291,7 +291,7 @@
 - [ ] app boot 시 dashboard가 로드되거나 명확한 offline 상태를 보여준다.
 - [ ] 앱을 foreground/background로 전환해도 선택 company와 shell mode가 유지된다.
 - [ ] 앱 창 resize 시 Company summary, sidebar, board, detail drawer가 겹치거나 잘리지 않는다.
-- [ ] 마지막 desktop window를 닫으면 launcher-managed backend가 종료된다.
+- [ ] 마지막 desktop window를 닫으면 embedded backend가 종료된다.
 - [ ] backend process가 죽으면 desktop이 기존 snapshot을 유지하고 reconnect 상태를 보여준다.
 - [ ] backend를 다시 띄우면 수동 새로고침 또는 자동 reconnect 후 최신 snapshot으로 복구된다.
 

--- a/docs/TROUBLESHOOTING.ko.md
+++ b/docs/TROUBLESHOOTING.ko.md
@@ -93,8 +93,8 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 
 - 이전 실행의 stale runtime 파일
 - 현재 CLI/런타임 동작과 맞지 않는 오래된 설치 앱
-- packaged 앱 launcher와 앱 내부 backend 관리 주체가 서로 충돌
-- 앱 실행 사이에 `COTOR_APP_TOKEN`이 바뀌어 launcher/backend/client token이 어긋남
+- packaged 앱 executable과 앱 내부 backend 관리 주체가 서로 충돌
+- 앱 실행 사이에 `COTOR_APP_TOKEN`이 바뀌어 backend/client token이 어긋남
 
 ### 4.3 확인
 
@@ -441,7 +441,7 @@ Exit code 0이면 CLI는 정상입니다. 모델 에러로 실패하면 Cotor �
 - 회사 `시작` / `중지`가 앱 전체 연결 상태를 흔듦
 - 영구적인 publish-readiness 실패 뒤 같은 blocked issue가 무한 재오픈
 - QA나 CEO 결과가 stale task sync 때문에 반복 재적용
-- 마지막 데스크톱 창을 닫았는데 번들 backend가 남아 있음
+- 마지막 데스크톱 창을 닫았는데 embedded backend가 남아 있음
 - 현재 interactive 모드가 명시적 선택 없이 여러 에이전트로 fan-out
 
 리포트할 때는 아래를 같이 남기세요.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -93,8 +93,8 @@ curl -H "Authorization: Bearer $COTOR_APP_TOKEN" http://127.0.0.1:8787/health
 
 - stale bundled runtime files from a previous launch
 - old installed app bundle that does not match the current CLI/runtime behavior
-- packaged app launcher and in-app backend management disagreeing about who owns the backend
-- launcher/backend/client token drift when `COTOR_APP_TOKEN` was changed between app launches
+- packaged app executable and embedded backend management disagreeing about who owns the backend
+- backend/client token drift when `COTOR_APP_TOKEN` was changed between app launches
 
 ### 4.3 Confirm
 
@@ -441,7 +441,7 @@ Treat the problem as a fresh bug if a current build still shows any of these:
 - company `Start` / `Stop` flips the global app connection state
 - the same blocked issue reopens forever after a permanent publish-readiness failure
 - QA or CEO results get reapplied repeatedly from stale task sync
-- last desktop window closes but bundled backend stays alive
+- last desktop window closes but the embedded backend stays alive
 - current interactive mode silently fans out to multiple agents without explicit user choice
 
 When reporting it, include:

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - cotor-perf-state-store  (2026-06-04)
+# Graph Report - cotor-qa-gradle-coverage-20260604  (2026-06-04)
 
 ## Corpus Check
-- 392 files · ~643,257 words
+- 394 files · ~1,499,347 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5173 nodes · 7130 edges · 328 communities detected
+- 5189 nodes · 7146 edges · 329 communities detected
 - Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 917 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -52,7 +52,7 @@
 - [[_COMMUNITY_Community 39|Community 39]]
 - [[_COMMUNITY_Community 40|Community 40]]
 - [[_COMMUNITY_Community 41|Community 41]]
-- [[_COMMUNITY_Community 43|Community 43]]
+- [[_COMMUNITY_Community 42|Community 42]]
 - [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 46|Community 46]]
@@ -169,7 +169,6 @@
 - [[_COMMUNITY_Community 157|Community 157]]
 - [[_COMMUNITY_Community 158|Community 158]]
 - [[_COMMUNITY_Community 159|Community 159]]
-- [[_COMMUNITY_Community 160|Community 160]]
 - [[_COMMUNITY_Community 161|Community 161]]
 - [[_COMMUNITY_Community 162|Community 162]]
 - [[_COMMUNITY_Community 163|Community 163]]
@@ -203,13 +202,13 @@
 - [[_COMMUNITY_Community 191|Community 191]]
 - [[_COMMUNITY_Community 192|Community 192]]
 - [[_COMMUNITY_Community 193|Community 193]]
+- [[_COMMUNITY_Community 194|Community 194]]
 - [[_COMMUNITY_Community 195|Community 195]]
 - [[_COMMUNITY_Community 196|Community 196]]
 - [[_COMMUNITY_Community 197|Community 197]]
 - [[_COMMUNITY_Community 198|Community 198]]
 - [[_COMMUNITY_Community 199|Community 199]]
 - [[_COMMUNITY_Community 200|Community 200]]
-- [[_COMMUNITY_Community 201|Community 201]]
 - [[_COMMUNITY_Community 202|Community 202]]
 - [[_COMMUNITY_Community 203|Community 203]]
 - [[_COMMUNITY_Community 204|Community 204]]
@@ -241,8 +240,8 @@
 - [[_COMMUNITY_Community 230|Community 230]]
 - [[_COMMUNITY_Community 231|Community 231]]
 - [[_COMMUNITY_Community 232|Community 232]]
+- [[_COMMUNITY_Community 233|Community 233]]
 - [[_COMMUNITY_Community 234|Community 234]]
-- [[_COMMUNITY_Community 235|Community 235]]
 - [[_COMMUNITY_Community 236|Community 236]]
 - [[_COMMUNITY_Community 237|Community 237]]
 - [[_COMMUNITY_Community 238|Community 238]]
@@ -251,8 +250,8 @@
 - [[_COMMUNITY_Community 241|Community 241]]
 - [[_COMMUNITY_Community 242|Community 242]]
 - [[_COMMUNITY_Community 243|Community 243]]
+- [[_COMMUNITY_Community 244|Community 244]]
 - [[_COMMUNITY_Community 245|Community 245]]
-- [[_COMMUNITY_Community 246|Community 246]]
 - [[_COMMUNITY_Community 247|Community 247]]
 - [[_COMMUNITY_Community 248|Community 248]]
 - [[_COMMUNITY_Community 249|Community 249]]
@@ -335,9 +334,11 @@
 - [[_COMMUNITY_Community 326|Community 326]]
 - [[_COMMUNITY_Community 327|Community 327]]
 - [[_COMMUNITY_Community 328|Community 328]]
+- [[_COMMUNITY_Community 329|Community 329]]
 - [[_COMMUNITY_Community 330|Community 330]]
 - [[_COMMUNITY_Community 333|Community 333]]
-- [[_COMMUNITY_Community 334|Community 334]]
+- [[_COMMUNITY_Community 336|Community 336]]
+- [[_COMMUNITY_Community 337|Community 337]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `DesktopStore` - 260 edges
@@ -371,23 +372,23 @@ Nodes (59): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChat
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (49): A2aArtifactStore, CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), settings() (+41 more)
+Nodes (41): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+33 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (194): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+186 more)
+Cohesion: 0.01
+Nodes (141): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, CenterPaneView, CloneRepositorySheet (+133 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (122): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, CenterPaneView, CloneRepositorySheet, CollapsibleDisclosureHeader (+114 more)
+Nodes (190): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+182 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (35): RetryingFileChannel, Line, runSkill(), DirectChatMessage, BoundedDesktopCommandOutput, APIError, http, ConfigureGitHubOriginPayload (+27 more)
+Nodes (37): RetryingFileChannel, Line, runSkill(), BoundedDesktopCommandOutput, APIError, http, ConfigureGitHubOriginPayload, Data (+29 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (101): AppLanguage, english, korean, AppTheme, dark, light, system, DesktopStrings (+93 more)
+Nodes (99): AppLanguage, english, korean, AppTheme, dark, light, system, DesktopStrings (+91 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
@@ -395,7 +396,7 @@ Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgent
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (125): CodingKey, CodingKeys, community, confidenceScore, fileType, label, relation, source (+117 more)
+Nodes (119): DirectChatMessage, CodingKey, DirectChatView, CodingKeys, community, confidenceScore, fileType, id (+111 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
@@ -406,152 +407,152 @@ Cohesion: 0.02
 Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.04
-Nodes (19): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendHealthPayload, EmbeddedBackendLauncher (+11 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.02
 Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+72 more)
 
+### Community 11 - "Community 11"
+Cohesion: 0.04
+Nodes (17): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendLauncher, isBackendRuntimeJar() (+9 more)
+
 ### Community 12 - "Community 12"
 Cohesion: 0.02
-Nodes (3): CachedState, DesktopStateStore, SqliteCachedState
+Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.02
-Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+Cohesion: 0.03
+Nodes (1): DesktopStateStore
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
 Nodes (7): ClaudePlugin, CodexPlugin, CopilotPlugin, CursorPlugin, GeminiPlugin, LocalModelPlugin, OpenCodePlugin
 
 ### Community 15 - "Community 15"
-Cohesion: 0.04
-Nodes (25): StateCollection, Scanner, AppLogger, companyActivityTint(), relativeTimestamp(), roomLine(), containsInternalMemoryDetail(), issueTitle() (+17 more)
-
-### Community 16 - "Community 16"
 Cohesion: 0.09
 Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, MeetingRoomSceneMemoryStore, agent(), decision(), goal(), issue() (+8 more)
 
-### Community 17 - "Community 17"
+### Community 16 - "Community 16"
 Cohesion: 0.04
-Nodes (23): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView (+15 more)
+Nodes (28): CachedState, SqliteCachedState, StateCollection, Scanner, DesktopAppLifecycleDelegate, containsInternalMemoryDetail(), issueTitle(), labeledLineValue() (+20 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.08
+Nodes (7): A2aArtifactStore, settings(), AgentSkillCardRecord, CompanyEventStreamBackoff, isExpectedCompanyEventStreamInterruption(), AgentCapabilitySettingRecord, DesktopStoreTests
 
 ### Community 18 - "Community 18"
 Cohesion: 0.04
 Nodes (54): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+46 more)
 
 ### Community 19 - "Community 19"
+Cohesion: 0.09
+Nodes (5): AppLogger, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AppLoggerTests
+
+### Community 20 - "Community 20"
 Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
+Cohesion: 0.06
+Nodes (14): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, LinearPrFailureGateTest, KnowledgeStore, build_issue_update_input(), call_linear() (+6 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
-### Community 21 - "Community 21"
-Cohesion: 0.13
-Nodes (3): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas
-
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (8): ConcurrentGitMutationProcessManager, FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.06
 Nodes (2): DesktopTuiSessionService, RuntimeSession
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.06
 Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.07
 Nodes (8): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, LateProcessStartAgentExecutor, SyncCall
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.07
 Nodes (3): DurableRunIndex, DurableRunIndexEntry, DurableRuntimeStore
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.07
 Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.08
 Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.08
 Nodes (1): A2aRouter
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.09
 Nodes (5): ExecutionMetrics, MetricsCollector, ResourceMonitor, StructuredLogger, StructuredLogLevel
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.1
 Nodes (9): Binary, Expression, Grouping, Literal, Token, TokenType, Unary, Variable (+1 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.1
 Nodes (3): ActionLogIndex, ActionLogIndexEntry, ActionStore
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.11
 Nodes (1): DurableRuntimeService
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.11
 Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, StageExecution, StageStats, StatsDetails, StatsManager (+1 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.11
 Nodes (3): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (3): BoundedOutputBuffer, CoroutineProcessManager, ProcessManager
 
-### Community 46 - "Community 46"
-Cohesion: 0.12
-Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
-
 ### Community 47 - "Community 47"
 Cohesion: 0.12
-Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
+Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
 ### Community 48 - "Community 48"
 Cohesion: 0.12
@@ -563,1605 +564,1609 @@ Nodes (1): AgentCapabilityGuard
 
 ### Community 50 - "Community 50"
 Cohesion: 0.12
-Nodes (1): RecoveryExecutor
+Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
 ### Community 51 - "Community 51"
 Cohesion: 0.12
-Nodes (5): GuardTextSample, PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
+Nodes (1): RecoveryExecutor
 
 ### Community 52 - "Community 52"
 Cohesion: 0.12
-Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
+Nodes (5): GuardTextSample, PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
 ### Community 53 - "Community 53"
 Cohesion: 0.12
-Nodes (1): StarterAgentSpec
+Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
 ### Community 54 - "Community 54"
-Cohesion: 0.13
-Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
+Cohesion: 0.12
+Nodes (1): StarterAgentSpec
 
 ### Community 55 - "Community 55"
 Cohesion: 0.13
-Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
+Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
 ### Community 56 - "Community 56"
 Cohesion: 0.13
-Nodes (1): ConditionEvaluator
+Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
 ### Community 57 - "Community 57"
 Cohesion: 0.13
-Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
+Nodes (1): ConditionEvaluator
 
 ### Community 58 - "Community 58"
-Cohesion: 0.14
-Nodes (1): BoardControllerTest
+Cohesion: 0.13
+Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
 ### Community 59 - "Community 59"
 Cohesion: 0.14
-Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
+Nodes (1): BoardControllerTest
 
 ### Community 60 - "Community 60"
 Cohesion: 0.14
-Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
+Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
 ### Community 61 - "Community 61"
 Cohesion: 0.14
-Nodes (2): BoundedDirectChatLineReader, DirectChatService
+Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.14
-Nodes (2): DefaultSecurityValidator, SecurityValidator
+Nodes (2): BoundedDirectChatLineReader, DirectChatService
 
 ### Community 63 - "Community 63"
 Cohesion: 0.14
-Nodes (13): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, DurableRunSummary (+5 more)
+Nodes (2): DefaultSecurityValidator, SecurityValidator
 
 ### Community 64 - "Community 64"
 Cohesion: 0.14
-Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
+Nodes (13): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, DurableRunSummary (+5 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.14
-Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
+Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
 ### Community 66 - "Community 66"
-Cohesion: 0.15
-Nodes (3): LocalSkillOutputBuffer, LocalSkillProcessResult, LocalSkillProcessRunner
+Cohesion: 0.14
+Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
 ### Community 67 - "Community 67"
 Cohesion: 0.15
-Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
+Nodes (3): LocalSkillOutputBuffer, LocalSkillProcessResult, LocalSkillProcessRunner
 
 ### Community 68 - "Community 68"
 Cohesion: 0.15
-Nodes (12): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionLogSummary, ActionRequest (+4 more)
+Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
 ### Community 69 - "Community 69"
 Cohesion: 0.15
-Nodes (2): AgentRegistry, InMemoryAgentRegistry
+Nodes (12): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionLogSummary, ActionRequest (+4 more)
 
 ### Community 70 - "Community 70"
-Cohesion: 0.17
-Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
+Cohesion: 0.15
+Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
 ### Community 71 - "Community 71"
-Cohesion: 0.17
-Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
+Cohesion: 0.15
+Nodes (4): AgentExecutor, CommandValidatingProcessManager, DefaultAgentExecutor, RuntimeServices
 
 ### Community 72 - "Community 72"
 Cohesion: 0.17
-Nodes (1): GoalDrivenTaskPlannerTest
+Nodes (3): DesktopAppServiceZeroRunRecoveryTest, ZeroRunFakeGitProcessManager, ZeroRunFakeLinearTrackerAdapter
 
 ### Community 73 - "Community 73"
 Cohesion: 0.17
-Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
+Nodes (3): DesktopAppServiceTimeoutFollowUpTest, NoopTimeoutFollowUpLinearTrackerAdapter, TimeoutFollowUpGitProcessManager
 
 ### Community 74 - "Community 74"
 Cohesion: 0.17
-Nodes (2): CompanyEventStreamService, PublishRequest
+Nodes (1): GoalDrivenTaskPlannerTest
 
 ### Community 75 - "Community 75"
 Cohesion: 0.17
-Nodes (1): ChatTranscriptWriter
+Nodes (5): Error, InterpolationMode, Success, TemplateEngine, ValidationResult
 
 ### Community 76 - "Community 76"
 Cohesion: 0.17
-Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
+Nodes (2): CompanyEventStreamService, PublishRequest
 
 ### Community 77 - "Community 77"
 Cohesion: 0.17
-Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
+Nodes (1): ChatTranscriptWriter
 
 ### Community 78 - "Community 78"
-Cohesion: 0.18
-Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
+Cohesion: 0.17
+Nodes (3): AgentPlugin, PluginLoader, ReflectionPluginLoader
 
 ### Community 79 - "Community 79"
-Cohesion: 0.18
-Nodes (1): BoardServiceTest
+Cohesion: 0.17
+Nodes (4): CsvOutputFormatter, JsonOutputFormatter, OutputFormatter, TextOutputFormatter
 
 ### Community 80 - "Community 80"
 Cohesion: 0.18
-Nodes (1): TemplateEngineTest
+Nodes (6): AuditLogger, CreateOrderCommand, OrderItem, OrderRepository, OrderResult, UserService
 
 ### Community 81 - "Community 81"
 Cohesion: 0.18
-Nodes (3): DesktopAppServiceRuntimeCleanupTest, issue(), StartupRecordingBrowserSkillRunner
+Nodes (1): BoardServiceTest
 
 ### Community 82 - "Community 82"
 Cohesion: 0.18
-Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+Nodes (1): TemplateEngineTest
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
+Nodes (3): DesktopAppServiceRuntimeCleanupTest, issue(), StartupRecordingBrowserSkillRunner
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (1): VerificationBundleService
+Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
-Nodes (1): ProvenanceService
+Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
 ### Community 86 - "Community 86"
 Cohesion: 0.18
-Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
+Nodes (1): VerificationBundleService
 
 ### Community 87 - "Community 87"
 Cohesion: 0.18
-Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
+Nodes (1): ProvenanceService
 
 ### Community 88 - "Community 88"
 Cohesion: 0.18
-Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
+Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
 ### Community 89 - "Community 89"
 Cohesion: 0.18
-Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
+Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
 ### Community 90 - "Community 90"
 Cohesion: 0.18
-Nodes (2): ErrorMessages, UserFriendlyError
+Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
 ### Community 91 - "Community 91"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
 
 ### Community 92 - "Community 92"
 Cohesion: 0.18
-Nodes (1): StatsCommand
+Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 93 - "Community 93"
 Cohesion: 0.18
-Nodes (1): DoctorCommand
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 94 - "Community 94"
-Cohesion: 0.2
-Nodes (1): LocalPlaywrightDependencyResolver
+Cohesion: 0.18
+Nodes (1): StatsCommand
 
 ### Community 95 - "Community 95"
-Cohesion: 0.2
-Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
+Cohesion: 0.18
+Nodes (1): DoctorCommand
 
 ### Community 96 - "Community 96"
 Cohesion: 0.2
-Nodes (1): VerificationStore
+Nodes (1): LocalPlaywrightDependencyResolver
 
 ### Community 97 - "Community 97"
 Cohesion: 0.2
-Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
+Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
 ### Community 98 - "Community 98"
 Cohesion: 0.2
-Nodes (3): ErrorHelper, ErrorInfo, ErrorType
+Nodes (1): VerificationStore
 
 ### Community 99 - "Community 99"
 Cohesion: 0.2
-Nodes (3): AgentExecutor, DefaultAgentExecutor, RuntimeServices
+Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
 ### Community 100 - "Community 100"
 Cohesion: 0.2
-Nodes (3): SyntaxValidationCommand, SyntaxValidationResult, SyntaxValidator
+Nodes (3): ErrorHelper, ErrorInfo, ErrorType
 
 ### Community 101 - "Community 101"
 Cohesion: 0.2
-Nodes (1): PolicyStore
+Nodes (3): SyntaxValidationCommand, SyntaxValidationResult, SyntaxValidator
 
 ### Community 102 - "Community 102"
+Cohesion: 0.2
+Nodes (1): PolicyStore
+
+### Community 103 - "Community 103"
 Cohesion: 0.25
 Nodes (2): ErrorResponse, GlobalExceptionHandler
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (1): BoardService
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.22
 Nodes (3): RecordingBrowserSkillRunner, RecordingSecurityValidator, SkillRuntimeTest
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.22
 Nodes (3): ArtifactQualityFailingExecutor, ArtifactQualityFakeGitProcessManager, DesktopAppServiceExecutionLogFailureClassTest
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.22
 Nodes (7): SkillCatalogEntry, SkillRunEvidence, SkillRunRecord, SkillRunRequest, SkillRunResult, SkillValidationRequest, SkillValidationResult
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.22
 Nodes (3): DirectChatProviderCatalogEntry, ProviderCatalogEntry, ProviderScanResult
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (1): DesktopDirectChatService
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.22
 Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.22
 Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.22
 Nodes (3): BoundCompanyRuntime, CachedValue, CompanyRuntimeBindingService
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.22
 Nodes (1): LocalModelDefaults
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.22
 Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.25
 Nodes (1): BoardController
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.25
 Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.25
 Nodes (1): LocalModelPluginTest
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.25
 Nodes (1): DefaultResultAnalyzer
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.25
 Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (1): CompanyIssueReadiness
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.25
 Nodes (1): ChatSession
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.25
 Nodes (1): GitHubControlPlaneStore
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.25
 Nodes (1): OpenCodeDefaults
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.25
 Nodes (2): JsonParser, YamlParser
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.25
 Nodes (1): ProcessDescendantTracker
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.25
 Nodes (1): DiagramGenerator
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.25
 Nodes (2): Linter, LintResult
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.29
 Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.29
 Nodes (2): PipelineOrchestratorMapTest, TrackingAgentExecutor
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.29
 Nodes (2): A2aDedupeStore, StoredAck
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (2): A2aSessionPersistenceStore, Snapshot
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (1): DurableResumeCoordinator
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.29
 Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.29
 Nodes (1): FileReaderPlugin
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.29
 Nodes (1): OpenAIPlugin
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.29
 Nodes (1): InteractiveCommandCompleter
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.29
 Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (6): StatusState, connected, connecting, offlineMock, taskStarted, waitingForServer
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (1): DirectChatServiceTest
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (1): DesktopStateStoreTest
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.33
 Nodes (1): CompanyRuntimeBindingServiceTest
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (1): ProductionReliabilityBaselineTest
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.33
 Nodes (1): PipelineContextTest
 
-### Community 150 - "Community 150"
-Cohesion: 0.33
-Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
-
 ### Community 151 - "Community 151"
 Cohesion: 0.33
-Nodes (1): DesktopCommandProcessTest
+Nodes (3): BlockingProcessManager, CommandPluginTest, RecordingProcessManager
 
 ### Community 152 - "Community 152"
 Cohesion: 0.33
-Nodes (1): AuthCommandTest
+Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
 ### Community 153 - "Community 153"
 Cohesion: 0.33
-Nodes (2): CompanyVerificationDecision, CompanyVerifierService
+Nodes (1): DesktopCommandProcessTest
 
 ### Community 154 - "Community 154"
 Cohesion: 0.33
-Nodes (1): NetworkEndpointPolicy
+Nodes (1): AuthCommandTest
 
 ### Community 155 - "Community 155"
 Cohesion: 0.33
-Nodes (1): GitHubControlPlaneService
+Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
 ### Community 156 - "Community 156"
 Cohesion: 0.33
-Nodes (1): QaVerificationPlugin
+Nodes (1): NetworkEndpointPolicy
 
 ### Community 157 - "Community 157"
 Cohesion: 0.33
-Nodes (1): CommandPlugin
+Nodes (1): GitHubControlPlaneService
 
 ### Community 158 - "Community 158"
 Cohesion: 0.33
-Nodes (2): DefaultResultAggregator, ResultAggregator
+Nodes (1): QaVerificationPlugin
 
 ### Community 159 - "Community 159"
 Cohesion: 0.33
-Nodes (1): CodexDashboardCommand
-
-### Community 160 - "Community 160"
-Cohesion: 0.33
-Nodes (2): PluginCommand, PluginInitCommand
+Nodes (1): CommandPlugin
 
 ### Community 161 - "Community 161"
 Cohesion: 0.33
-Nodes (1): PolicyEngine
+Nodes (2): DefaultResultAggregator, ResultAggregator
 
 ### Community 162 - "Community 162"
-Cohesion: 0.4
-Nodes (1): OpenCodePluginTest
+Cohesion: 0.33
+Nodes (1): CodexDashboardCommand
 
 ### Community 163 - "Community 163"
-Cohesion: 0.4
-Nodes (2): PromptHandoffPluginTest, RecordingPromptProcessManager
+Cohesion: 0.33
+Nodes (2): PluginCommand, PluginInitCommand
 
 ### Community 164 - "Community 164"
-Cohesion: 0.4
-Nodes (1): PipelineOrchestratorOutputPropagationTest
+Cohesion: 0.33
+Nodes (1): PolicyEngine
 
 ### Community 165 - "Community 165"
 Cohesion: 0.4
-Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
+Nodes (1): OpenCodePluginTest
 
 ### Community 166 - "Community 166"
 Cohesion: 0.4
-Nodes (1): CliGoldenSnapshotTest
+Nodes (2): PromptHandoffPluginTest, RecordingPromptProcessManager
 
 ### Community 167 - "Community 167"
 Cohesion: 0.4
-Nodes (1): DesktopEndpointPolicy
+Nodes (1): PipelineOrchestratorOutputPropagationTest
 
 ### Community 168 - "Community 168"
 Cohesion: 0.4
-Nodes (1): EvidencePathPolicy
+Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
 ### Community 169 - "Community 169"
 Cohesion: 0.4
-Nodes (1): CompanyRuntimeMachine
+Nodes (1): CliGoldenSnapshotTest
 
 ### Community 170 - "Community 170"
 Cohesion: 0.4
-Nodes (1): WorkQueue
+Nodes (1): DesktopEndpointPolicy
 
 ### Community 171 - "Community 171"
 Cohesion: 0.4
-Nodes (1): CheckpointGraphStore
+Nodes (1): EvidencePathPolicy
 
 ### Community 172 - "Community 172"
 Cohesion: 0.4
-Nodes (1): SideEffectJournalStore
+Nodes (1): CompanyRuntimeMachine
 
 ### Community 173 - "Community 173"
 Cohesion: 0.4
-Nodes (1): ProvenanceStore
+Nodes (1): WorkQueue
 
 ### Community 174 - "Community 174"
 Cohesion: 0.4
-Nodes (1): CodexDefaults
+Nodes (1): CheckpointGraphStore
 
 ### Community 175 - "Community 175"
 Cohesion: 0.4
-Nodes (2): StuckDetector, StuckSignal
+Nodes (1): SideEffectJournalStore
 
 ### Community 176 - "Community 176"
 Cohesion: 0.4
-Nodes (1): AppServerCommand
+Nodes (1): ProvenanceStore
 
 ### Community 177 - "Community 177"
-Cohesion: 0.5
-Nodes (1): BoardServiceApplicationTests
+Cohesion: 0.4
+Nodes (1): CodexDefaults
 
 ### Community 178 - "Community 178"
-Cohesion: 0.67
-Nodes (2): fromEntity(), PostDetailResponse
+Cohesion: 0.4
+Nodes (2): StuckDetector, StuckSignal
 
 ### Community 179 - "Community 179"
-Cohesion: 0.67
-Nodes (2): fromEntity(), PostSummaryResponse
+Cohesion: 0.4
+Nodes (1): AppServerCommand
 
 ### Community 180 - "Community 180"
 Cohesion: 0.5
-Nodes (1): PostRepository
+Nodes (1): findPrimes()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.5
-Nodes (1): Post
+Nodes (1): BoardServiceApplicationTests
 
 ### Community 182 - "Community 182"
-Cohesion: 0.5
-Nodes (1): findPrimes()
-
-### Community 183 - "Community 183"
 Cohesion: 0.67
 Nodes (2): BoardServiceApplication, main()
 
+### Community 183 - "Community 183"
+Cohesion: 0.67
+Nodes (2): fromEntity(), PostDetailResponse
+
 ### Community 184 - "Community 184"
-Cohesion: 0.5
-Nodes (1): AgentCapabilityGuardTest
+Cohesion: 0.67
+Nodes (2): fromEntity(), PostSummaryResponse
 
 ### Community 185 - "Community 185"
 Cohesion: 0.5
-Nodes (1): DesktopTuiSessionServiceTest
+Nodes (1): PostRepository
 
 ### Community 186 - "Community 186"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceOwnershipTest
+Nodes (1): Post
 
 ### Community 187 - "Community 187"
 Cohesion: 0.5
-Nodes (1): DesktopAppServiceAgentModelNormalizationTest
+Nodes (1): AgentCapabilityGuardTest
 
 ### Community 188 - "Community 188"
 Cohesion: 0.5
-Nodes (2): CapturingProcessManager, QaVerificationPluginTest
+Nodes (1): DesktopTuiSessionServiceTest
 
 ### Community 189 - "Community 189"
 Cohesion: 0.5
-Nodes (2): CommandPluginTest, RecordingProcessManager
+Nodes (1): DesktopAppServiceOwnershipTest
 
 ### Community 190 - "Community 190"
 Cohesion: 0.5
-Nodes (2): ClaudePluginTest, RecordingClaudeProcessManager
+Nodes (1): DesktopAppServiceAgentModelNormalizationTest
 
 ### Community 191 - "Community 191"
 Cohesion: 0.5
-Nodes (2): FileReaderPluginTest, NoopProcessManager
+Nodes (2): CapturingProcessManager, QaVerificationPluginTest
 
 ### Community 192 - "Community 192"
 Cohesion: 0.5
-Nodes (1): PipelineOrchestratorPropertyTest
+Nodes (2): ClaudePluginTest, RecordingClaudeProcessManager
 
 ### Community 193 - "Community 193"
 Cohesion: 0.5
-Nodes (1): SyntaxValidatorTest
+Nodes (2): FileReaderPluginTest, NoopProcessManager
+
+### Community 194 - "Community 194"
+Cohesion: 0.5
+Nodes (1): PipelineOrchestratorPropertyTest
 
 ### Community 195 - "Community 195"
 Cohesion: 0.5
-Nodes (1): LocalPlaywrightMarketingBrowserRunner
+Nodes (1): SyntaxValidatorTest
 
 ### Community 196 - "Community 196"
 Cohesion: 0.5
-Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
+Nodes (1): LocalPlaywrightMarketingBrowserRunner
 
 ### Community 197 - "Community 197"
 Cohesion: 0.5
-Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
+Nodes (2): CompanyRuntimeLoopDisposition, CompanyRuntimeLoopFailureDisposition
 
 ### Community 198 - "Community 198"
 Cohesion: 0.5
-Nodes (1): StateRepository
+Nodes (3): EnsurePlanningIssue, RuntimeCommand, StartIssue
 
 ### Community 199 - "Community 199"
 Cohesion: 0.5
-Nodes (3): ChatMessage, ChatMode, ChatRole
+Nodes (1): StateRepository
 
 ### Community 200 - "Community 200"
 Cohesion: 0.5
-Nodes (1): DurableRuntimeFlags
-
-### Community 201 - "Community 201"
-Cohesion: 0.5
-Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
+Nodes (3): ChatMessage, ChatMode, ChatRole
 
 ### Community 202 - "Community 202"
 Cohesion: 0.5
-Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
+Nodes (1): DurableRuntimeFlags
 
 ### Community 203 - "Community 203"
 Cohesion: 0.5
-Nodes (2): TimelineCollector, TimelineResult
+Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
 ### Community 204 - "Community 204"
 Cohesion: 0.5
-Nodes (1): StageConflictDetector
+Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
 ### Community 205 - "Community 205"
 Cohesion: 0.5
-Nodes (1): SimpleCLI
+Nodes (2): TimelineCollector, TimelineResult
 
 ### Community 206 - "Community 206"
 Cohesion: 0.5
-Nodes (2): OutputValidator, StageValidationOutcome
+Nodes (1): StageConflictDetector
 
 ### Community 207 - "Community 207"
-Cohesion: 0.67
-Nodes (1): PostCreateRequest
+Cohesion: 0.5
+Nodes (1): SimpleCLI
 
 ### Community 208 - "Community 208"
-Cohesion: 0.67
-Nodes (1): PostUpdateRequest
+Cohesion: 0.5
+Nodes (2): OutputValidator, StageValidationOutcome
 
 ### Community 209 - "Community 209"
 Cohesion: 0.67
-Nodes (1): VersionConflictException
+Nodes (1): PostCreateRequest
 
 ### Community 210 - "Community 210"
 Cohesion: 0.67
-Nodes (1): PostNotFoundException
+Nodes (1): PostUpdateRequest
 
 ### Community 211 - "Community 211"
 Cohesion: 0.67
-Nodes (1): PermissionDeniedException
+Nodes (1): VersionConflictException
 
 ### Community 212 - "Community 212"
 Cohesion: 0.67
-Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
+Nodes (1): PostNotFoundException
 
 ### Community 213 - "Community 213"
 Cohesion: 0.67
-Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
+Nodes (1): PermissionDeniedException
 
 ### Community 214 - "Community 214"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIntegrationHarness
+Nodes (2): is_prime(), 주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo
 
 ### Community 215 - "Community 215"
 Cohesion: 0.67
-Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
+Nodes (2): bubble_sort(), 버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다
 
 ### Community 216 - "Community 216"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceExecutionMemoryTest
+Nodes (1): DesktopAppServiceIntegrationHarness
 
 ### Community 217 - "Community 217"
 Cohesion: 0.67
-Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
+Nodes (2): DesktopAppServiceReviewVerdictControlTest, MergeGuardFixture
 
 ### Community 218 - "Community 218"
 Cohesion: 0.67
-Nodes (1): CheckpointFixtureProcess
+Nodes (1): DesktopAppServiceExecutionMemoryTest
 
 ### Community 219 - "Community 219"
 Cohesion: 0.67
-Nodes (1): CheckpointResumeIntegrationTest
+Nodes (1): DesktopAppServiceIssueExecutionDetailsTest
 
 ### Community 220 - "Community 220"
 Cohesion: 0.67
-Nodes (1): StoreConcurrencyTest
+Nodes (1): CheckpointFixtureProcess
 
 ### Community 221 - "Community 221"
 Cohesion: 0.67
-Nodes (1): RuntimeConstructorConsistencyTest
+Nodes (1): CheckpointResumeIntegrationTest
 
 ### Community 222 - "Community 222"
 Cohesion: 0.67
-Nodes (1): ActionExecutionServiceTest
+Nodes (1): StoreConcurrencyTest
 
 ### Community 223 - "Community 223"
 Cohesion: 0.67
-Nodes (2): NonPluginWithStaticInitializer, PluginLoaderTest
+Nodes (1): RuntimeConstructorConsistencyTest
 
 ### Community 224 - "Community 224"
 Cohesion: 0.67
-Nodes (1): CotorHttpClientsTest
+Nodes (1): ActionExecutionServiceTest
 
 ### Community 225 - "Community 225"
 Cohesion: 0.67
-Nodes (1): CliProcessProbeTest
+Nodes (2): NonPluginWithStaticInitializer, PluginLoaderTest
 
 ### Community 226 - "Community 226"
 Cohesion: 0.67
-Nodes (1): TemplateCommandTest
+Nodes (1): CotorHttpClientsTest
 
 ### Community 227 - "Community 227"
 Cohesion: 0.67
-Nodes (1): InitCommandTest
+Nodes (1): CliProcessProbeTest
 
 ### Community 228 - "Community 228"
 Cohesion: 0.67
-Nodes (1): ValidateCommandTest
+Nodes (1): TemplateCommandTest
 
 ### Community 229 - "Community 229"
 Cohesion: 0.67
-Nodes (1): DesktopLifecycleCommandTest
+Nodes (1): InitCommandTest
 
 ### Community 230 - "Community 230"
 Cohesion: 0.67
-Nodes (1): ResultAnalyzer
+Nodes (1): ValidateCommandTest
 
 ### Community 231 - "Community 231"
 Cohesion: 0.67
-Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
+Nodes (1): DesktopLifecycleCommandTest
 
 ### Community 232 - "Community 232"
 Cohesion: 0.67
-Nodes (2): VideoPlanRequest, VideoPlanResult
+Nodes (1): ResultAnalyzer
+
+### Community 233 - "Community 233"
+Cohesion: 0.67
+Nodes (2): BrowserSmokeRequest, BrowserSmokeResult
 
 ### Community 234 - "Community 234"
 Cohesion: 0.67
-Nodes (1): DurableRuntimeContext
-
-### Community 235 - "Community 235"
-Cohesion: 0.67
-Nodes (1): HelloCommand
+Nodes (2): VideoPlanRequest, VideoPlanResult
 
 ### Community 236 - "Community 236"
 Cohesion: 0.67
-Nodes (1): WebCommand
+Nodes (1): DurableRuntimeContext
 
 ### Community 237 - "Community 237"
 Cohesion: 0.67
-Nodes (1): LintCommand
+Nodes (1): HelloCommand
 
 ### Community 238 - "Community 238"
 Cohesion: 0.67
-Nodes (1): ExplainCommand
+Nodes (1): WebCommand
 
 ### Community 239 - "Community 239"
 Cohesion: 0.67
-Nodes (1): CheckpointGCCommand
+Nodes (1): LintCommand
 
 ### Community 240 - "Community 240"
 Cohesion: 0.67
-Nodes (2): StageTimelineEntry, StageTimelineState
+Nodes (1): ExplainCommand
 
 ### Community 241 - "Community 241"
 Cohesion: 0.67
-Nodes (1): PipelineTemplateValidator
+Nodes (1): CheckpointGCCommand
 
 ### Community 242 - "Community 242"
 Cohesion: 0.67
-Nodes (1): DefaultOutputValidator
+Nodes (2): StageTimelineEntry, StageTimelineState
 
 ### Community 243 - "Community 243"
-Cohesion: 1.0
-Nodes (1): TemplateValidatorTest
+Cohesion: 0.67
+Nodes (1): PipelineTemplateValidator
+
+### Community 244 - "Community 244"
+Cohesion: 0.67
+Nodes (1): DefaultOutputValidator
 
 ### Community 245 - "Community 245"
 Cohesion: 1.0
-Nodes (1): KotestProjectConfig
-
-### Community 246 - "Community 246"
-Cohesion: 1.0
-Nodes (1): KoinResolutionSmokeTest
+Nodes (1): TemplateValidatorTest
 
 ### Community 247 - "Community 247"
 Cohesion: 1.0
-Nodes (1): CheckpointManagerTest
+Nodes (1): KotestProjectConfig
 
 ### Community 248 - "Community 248"
 Cohesion: 1.0
-Nodes (1): DefaultResultAnalyzerTest
+Nodes (1): KoinResolutionSmokeTest
 
 ### Community 249 - "Community 249"
 Cohesion: 1.0
-Nodes (1): CompanyIssueLifecyclePolicyTest
+Nodes (1): CheckpointManagerTest
 
 ### Community 250 - "Community 250"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceGitHubSyncTest
+Nodes (1): DefaultResultAnalyzerTest
 
 ### Community 251 - "Community 251"
 Cohesion: 1.0
-Nodes (1): AppServerPlatformRoutesTest
+Nodes (1): CompanyIssueLifecyclePolicyTest
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (1): EvidencePathPolicyTest
+Nodes (1): DesktopAppServiceGitHubSyncTest
 
 ### Community 253 - "Community 253"
 Cohesion: 1.0
-Nodes (1): AppServerDurableRuntimeTest
+Nodes (1): AppServerPlatformRoutesTest
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (1): ProviderModelsTest
+Nodes (1): EvidencePathPolicyTest
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceParallelDispatchTest
+Nodes (1): AppServerDurableRuntimeTest
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
+Nodes (1): ProviderModelsTest
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceDashboardRuntimeTest
+Nodes (1): DesktopAppServiceParallelDispatchTest
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): CompanyVerifierServiceTest
+Nodes (1): DesktopAppServiceAiOnlyIntegrationTest
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): AppServerVerificationRouteTest
+Nodes (1): DesktopAppServiceDashboardRuntimeTest
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): AppServerTest
+Nodes (1): CompanyVerifierServiceTest
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): DesktopStateStoreLockTest
+Nodes (1): AppServerVerificationRouteTest
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (1): DesktopEndpointPolicyTest
+Nodes (1): AppServerTest
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): ExecutionBackendsTest
+Nodes (1): DesktopStateStoreLockTest
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): CodexAppServerManagerTest
+Nodes (1): DesktopEndpointPolicyTest
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceMergeConfirmationTest
+Nodes (1): ExecutionBackendsTest
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): LocalPlaywrightDependencyTest
+Nodes (1): CodexAppServerManagerTest
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceDashboardPrCleanupTest
+Nodes (1): DesktopAppServiceMergeConfirmationTest
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): AutonomousDiscoveryServiceTest
+Nodes (1): LocalPlaywrightDependencyTest
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): SkillModelsTest
+Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): CompanyRuntimeMachineTest
+Nodes (1): AutonomousDiscoveryServiceTest
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): WorkQueueTest
+Nodes (1): SkillModelsTest
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): ChatTranscriptWriterTest
+Nodes (1): CompanyRuntimeMachineTest
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): ChatSessionTest
+Nodes (1): WorkQueueTest
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): NetworkEndpointPolicyTest
+Nodes (1): ChatTranscriptWriterTest
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): SecurityValidatorTest
+Nodes (1): ChatSessionTest
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): A2aArtifactStoreTest
+Nodes (1): NetworkEndpointPolicyTest
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): A2aApiTest
+Nodes (1): SecurityValidatorTest
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): A2aSessionStoreTest
+Nodes (1): A2aArtifactStoreTest
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): A2aPersistenceTest
+Nodes (1): A2aApiTest
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): A2aDedupeStoreTest
+Nodes (1): A2aSessionStoreTest
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): RecoveryExecutorTest
+Nodes (1): A2aPersistenceTest
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): GitHubControlPlaneServiceTest
+Nodes (1): A2aDedupeStoreTest
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): DurableRuntimeServiceTest
+Nodes (1): RecoveryExecutorTest
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): DurableResumeCoordinatorTest
+Nodes (1): GitHubControlPlaneServiceTest
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): AtomicFileWriterTest
+Nodes (1): DurableRuntimeServiceTest
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): LinearClientEndpointPolicyTest
+Nodes (1): DurableResumeCoordinatorTest
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): VerificationBundleServiceTest
+Nodes (1): AtomicFileWriterTest
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): KnowledgeServiceTest
+Nodes (1): LinearClientEndpointPolicyTest
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): LocalModelDefaultsTest
+Nodes (1): VerificationBundleServiceTest
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): ObservabilityServiceTest
+Nodes (1): KnowledgeServiceTest
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): FileConfigRepositoryTest
+Nodes (1): LocalModelDefaultsTest
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): QaTestGenerationFixtureTest
+Nodes (1): ObservabilityServiceTest
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): ConfigRepositoryImportTest
+Nodes (1): FileConfigRepositoryTest
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): ExampleConfigSmokeTest
+Nodes (1): QaTestGenerationFixtureTest
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): YamlParserTest
+Nodes (1): ConfigRepositoryImportTest
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): CodexPluginTest
+Nodes (1): ExampleConfigSmokeTest
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): ProcessManagerTest
+Nodes (1): YamlParserTest
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): ErrorHelperTest
+Nodes (1): CodexPluginTest
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): ResultAggregatorTest
+Nodes (1): ProcessManagerTest
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): ConditionEvaluatorTest
+Nodes (1): ErrorHelperTest
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): AgentExecutorTest
+Nodes (1): ResultAggregatorTest
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): StuckDetectorTest
+Nodes (1): ConditionEvaluatorTest
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): PipelineGuardServiceTest
+Nodes (1): AgentExecutorTest
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorDagValidationTest
+Nodes (1): StuckDetectorTest
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): StageConflictDetectorTest
+Nodes (1): PipelineGuardServiceTest
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorTemplatingTest
+Nodes (1): PipelineOrchestratorDagValidationTest
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): CoroutineEventBusTest
+Nodes (1): StageConflictDetectorTest
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): WebServerTest
+Nodes (1): PipelineOrchestratorTemplatingTest
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): CompletionCommandTest
+Nodes (1): CoroutineEventBusTest
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): HelpCommandTest
+Nodes (1): WebServerTest
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): AppServerCommandTest
+Nodes (1): CompletionCommandTest
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): StarterAgentResolverTest
+Nodes (1): HelpCommandTest
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandCompleterTest
+Nodes (1): AppServerCommandTest
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): AgentCommandTest
+Nodes (1): StarterAgentResolverTest
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): PluginCommandTest
+Nodes (1): InteractiveCommandCompleterTest
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): HelloCommandTest
+Nodes (1): AgentCommandTest
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): LintCommandTest
+Nodes (1): PluginCommandTest
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (1): CompanyCommandTest
+Nodes (1): HelloCommandTest
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandTest
+Nodes (1): LintCommandTest
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
-Nodes (1): StatsCommandTest
+Nodes (1): CompanyCommandTest
 
 ### Community 321 - "Community 321"
 Cohesion: 1.0
-Nodes (1): CodexDashboardCommandTest
+Nodes (1): InteractiveCommandTest
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (1): StatsManagerTest
+Nodes (1): StatsCommandTest
 
 ### Community 323 - "Community 323"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorTest
+Nodes (1): CodexDashboardCommandTest
 
 ### Community 324 - "Community 324"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorExtTest
+Nodes (1): StatsManagerTest
 
 ### Community 325 - "Community 325"
 Cohesion: 1.0
-Nodes (1): LinterTest
+Nodes (1): PipelineValidatorTest
 
 ### Community 326 - "Community 326"
 Cohesion: 1.0
-Nodes (1): DefaultOutputValidatorTest
+Nodes (1): PipelineValidatorExtTest
 
 ### Community 327 - "Community 327"
 Cohesion: 1.0
-Nodes (1): PolicyEngineTest
+Nodes (1): LinterTest
 
 ### Community 328 - "Community 328"
 Cohesion: 1.0
-Nodes (1): RiskApprovalInterceptorTest
+Nodes (1): DefaultOutputValidatorTest
+
+### Community 329 - "Community 329"
+Cohesion: 1.0
+Nodes (1): PolicyEngineTest
 
 ### Community 330 - "Community 330"
 Cohesion: 1.0
-Nodes (1): CheckpointConfig
+Nodes (1): RiskApprovalInterceptorTest
 
 ### Community 333 - "Community 333"
 Cohesion: 1.0
+Nodes (1): CheckpointConfig
+
+### Community 336 - "Community 336"
+Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 334 - "Community 334"
+### Community 337 - "Community 337"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
 - **1016 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+1011 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 25`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 13`** (77 nodes): `DesktopStateStore`, `.appendAtomicMoveFallbackLog()`, `.appendStateLoadLog()`, `.appHome()`, `.applyJsonCollectionChunksLocked()`, `.atomicMoveFallbackMessage()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactDirectChatConversation()`, `.compactDirectChatConversations()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.ensureSqliteSchema()`, `.jsonCollectionFile()`, `.jsonCollectionsDir()`, `.jsonCollectionsRevisionFile()`, `.jsonCollectionsRevisionFingerprint()`, `.load()`, `.loadCollection()`, `.loadGoals()`, `.loadIssues()`, `.loadJson()`, `.loadJsonCollection()`, `.loadJsonStateFromChunksLocked()`, `.loadJsonStateLocked()`, `.loadReviewQueue()`, `.loadRuns()`, `.loadSqlite()`, `.loadSqliteCollection()`, `.loadSqliteState()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.migrateJsonStateIfNeeded()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.readJsonCollectionLocked()`, `.readJsonStateForMigration()`, `.readSqliteCollection()`, `.save()`, `.saveJson()`, `.saveJsonLocked()`, `.saveSqlite()`, `.saveSqliteState()`, `.setSqliteMeta()`, `.sha256()`, `.sqliteCollectionCount()`, `.sqliteCollectionHashes()`, `.sqliteConnection()`, `.sqliteMeta()`, `.sqliteRevision()`, `.sqliteStateFile()`, `.stateCollection()`, `.stateFile()`, `.touchJsonCollectionsRevisionLocked()`, `.updateCache()`, `.updateCollection()`, `.updateJsonCollection()`, `.updateRuns()`, `.updateSqliteCollection()`, `.useJsonBackend()`, `.withStateFileLock()`, `.writeJsonCollectionChunksLocked()`, `.writeJsonCollectionLocked()`, `.writeLockMetadata()`, `.writeOwnerOnlyTextAtomically()`, `.writeSqliteCollection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 26`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 32`** (26 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.processPromptFileLines()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 31`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 33`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
+- **Thin community `Community 33`** (26 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.processPromptFileLines()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 38`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 34`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 43`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 39`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 44`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 45`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 49`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 51`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+- **Thin community `Community 54`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 56`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 57`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 59`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
+- **Thin community `Community 62`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 62`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
+- **Thin community `Community 63`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 70`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
+- **Thin community `Community 74`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (12 nodes): `CompanyEventStreamService`, `.clearReplay()`, `.events()`, `.gapSnapshot()`, `.hasGap()`, `.latestSequence()`, `.publish()`, `.publishRequest()`, `.remember()`, `.replayedEvents()`, `PublishRequest`, `CompanyEventStreamService.kt`
+- **Thin community `Community 76`** (12 nodes): `CompanyEventStreamService`, `.clearReplay()`, `.events()`, `.gapSnapshot()`, `.hasGap()`, `.latestSequence()`, `.publish()`, `.publishRequest()`, `.remember()`, `.replayedEvents()`, `PublishRequest`, `CompanyEventStreamService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (12 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.compactForResume()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.readUtf8Tail()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
+- **Thin community `Community 77`** (12 nodes): `ChatTranscriptWriter`, `.clearJsonl()`, `.compactForResume()`, `.ensureDir()`, `.flushMemoryIfNeeded()`, `.loadSessionMessages()`, `.readUtf8Tail()`, `.searchMemory()`, `.writeJsonl()`, `.writeMarkdown()`, `.writeRawText()`, `ChatTranscriptWriter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 79`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
+- **Thin community `Community 81`** (11 nodes): `BoardServiceTest`, `.`createPost should save a new post and return its details`()`, `.`deletePost should call delete on repository`()`, `.`deletePost should throw PermissionDeniedException for wrong user`()`, `.`getPostById should return post details and increment view count`()`, `.`getPostById should throw PostNotFoundException when post does not exist`()`, `.`updatePost should throw PermissionDeniedException for wrong user`()`, `.`updatePost should throw VersionConflictException for version mismatch`()`, `.`updatePost should update the post successfully`()`, `BoardServiceTest.kt`, `BoardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 80`** (11 nodes): `TemplateEngineTest`, `.setUp()`, `.`should cap legacy all outputs interpolation`()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
+- **Thin community `Community 82`** (11 nodes): `TemplateEngineTest`, `.setUp()`, `.`should cap legacy all outputs interpolation`()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 84`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 86`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 87`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 90`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 92`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 92`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 94`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 93`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 95`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 94`** (10 nodes): `LocalPlaywrightDependencyResolver`, `.allowRuntimeInstall()`, `.configuredNodeModulesPath()`, `.existingNodePath()`, `.hasPlaywrightPackage()`, `.installIfExplicitlyAllowed()`, `.playwrightSetupMessage()`, `.prewarm()`, `.requireNodePath()`, `LocalPlaywrightDependencyResolver.kt`
+- **Thin community `Community 96`** (10 nodes): `LocalPlaywrightDependencyResolver`, `.allowRuntimeInstall()`, `.configuredNodeModulesPath()`, `.existingNodePath()`, `.hasPlaywrightPackage()`, `.installIfExplicitlyAllowed()`, `.playwrightSetupMessage()`, `.prewarm()`, `.requireNodePath()`, `LocalPlaywrightDependencyResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 96`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 98`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
+- **Thin community `Community 102`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 102`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
+- **Thin community `Community 103`** (9 nodes): `ErrorResponse`, `GlobalExceptionHandler`, `.handleGenericException()`, `.handlePermissionDenied()`, `.handlePostNotFound()`, `.handleValidationExceptions()`, `.handleVersionConflict()`, `GlobalExceptionHandler.kt`, `GlobalExceptionHandler.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 103`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
+- **Thin community `Community 104`** (9 nodes): `BoardService`, `.createPost()`, `.deletePost()`, `.findPostByIdOrThrow()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardService.kt`, `BoardService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 108`** (9 nodes): `DesktopDirectChatService`, `.appendMessage()`, `.createConversation()`, `.deleteConversation()`, `.getConversation()`, `.listConversations()`, `.listModels()`, `.streamMessage()`, `DesktopDirectChatService.kt`
+- **Thin community `Community 109`** (9 nodes): `DesktopDirectChatService`, `.appendMessage()`, `.createConversation()`, `.deleteConversation()`, `.getConversation()`, `.listConversations()`, `.listModels()`, `.streamMessage()`, `DesktopDirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 109`** (9 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `AutonomousDiscoveryService.kt`
+- **Thin community `Community 110`** (9 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `AutonomousDiscoveryService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 114`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 118`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 119`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 120`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 121`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 123`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 124`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 125`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 126`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 127`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
+- **Thin community `Community 128`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 129`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 130`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 133`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 134`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 135`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 136`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 137`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 138`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 140`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 141`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 142`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
+- **Thin community `Community 145`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 146`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 147`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 148`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 149`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
+- **Thin community `Community 150`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 152`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
+- **Thin community `Community 153`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (6 nodes): `AuthCommandTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `AuthCommandTest.kt`
+- **Thin community `Community 154`** (6 nodes): `AuthCommandTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 155`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 156`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 157`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 158`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 159`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 161`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 162`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 163`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 164`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 165`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
+- **Thin community `Community 166`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
+- **Thin community `Community 167`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 168`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 169`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 170`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 171`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 172`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 173`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
+- **Thin community `Community 174`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
+- **Thin community `Community 175`** (5 nodes): `SideEffectJournalStore`, `.addApprovalPause()`, `.appendSideEffect()`, `.approve()`, `SideEffectJournalStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
+- **Thin community `Community 176`** (5 nodes): `ProvenanceStore`, `.graphFile()`, `.load()`, `.save()`, `ProvenanceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
+- **Thin community `Community 177`** (5 nodes): `CodexDefaults`, `.isRecoverableModelSelectionFailure()`, `.isRetiredModelAliasFailure()`, `.normalizeModel()`, `CodexDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
+- **Thin community `Community 178`** (5 nodes): `StuckDetector`, `.fingerprint()`, `.record()`, `StuckSignal`, `StuckDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
+- **Thin community `Community 179`** (5 nodes): `AppServerCommand`, `.run()`, `generateAppServerToken()`, `resolveAppServerToken()`, `AppServerCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
+- **Thin community `Community 180`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
+- **Thin community `Community 181`** (4 nodes): `BoardServiceApplicationTests`, `.contextLoads()`, `BoardServiceApplicationTests.kt`, `BoardServiceApplicationTests.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
+- **Thin community `Community 182`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
+- **Thin community `Community 183`** (4 nodes): `fromEntity()`, `PostDetailResponse`, `PostDetailResponse.kt`, `PostDetailResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
+- **Thin community `Community 184`** (4 nodes): `fromEntity()`, `PostSummaryResponse`, `PostSummaryResponse.kt`, `PostSummaryResponse.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (4 nodes): `findPrimes()`, `isPrime()`, `findPrimes.js`, `findPrimes.js`
+- **Thin community `Community 185`** (4 nodes): `PostRepository`, `.findByAuthorId()`, `PostRepository.kt`, `PostRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (4 nodes): `BoardServiceApplication`, `main()`, `BoardServiceApplication.kt`, `BoardServiceApplication.kt`
+- **Thin community `Community 186`** (4 nodes): `Post`, `.onPreUpdate()`, `Post.kt`, `Post.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
+- **Thin community `Community 187`** (4 nodes): `AgentCapabilityGuardTest`, `testAgent()`, `testCompany()`, `AgentCapabilityGuardTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (4 nodes): `DesktopTuiSessionServiceTest`, `eventuallyFalse()`, `waitForPid()`, `DesktopTuiSessionServiceTest.kt`
+- **Thin community `Community 188`** (4 nodes): `DesktopTuiSessionServiceTest`, `eventuallyFalse()`, `waitForPid()`, `DesktopTuiSessionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
+- **Thin community `Community 189`** (4 nodes): `company()`, `DesktopAppServiceOwnershipTest`, `ownershipService()`, `DesktopAppServiceOwnershipTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
+- **Thin community `Community 190`** (4 nodes): `DesktopAppServiceAgentModelNormalizationTest`, `normalizationTestService()`, `seedAgentModelWorkspace()`, `DesktopAppServiceAgentModelNormalizationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
+- **Thin community `Community 191`** (4 nodes): `CapturingProcessManager`, `.executeProcess()`, `QaVerificationPluginTest`, `QaVerificationPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (4 nodes): `CommandPluginTest`, `RecordingProcessManager`, `.executeProcess()`, `CommandPluginTest.kt`
+- **Thin community `Community 192`** (4 nodes): `ClaudePluginTest`, `RecordingClaudeProcessManager`, `.executeProcess()`, `ClaudePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (4 nodes): `ClaudePluginTest`, `RecordingClaudeProcessManager`, `.executeProcess()`, `ClaudePluginTest.kt`
+- **Thin community `Community 193`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (4 nodes): `FileReaderPluginTest`, `NoopProcessManager`, `.executeProcess()`, `FileReaderPluginTest.kt`
+- **Thin community `Community 194`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (4 nodes): `PipelineOrchestratorPropertyTest`, `.`MAP mode should preserve fanout cardinality for arbitrary item lists`()`, `.`MAP mode should reject arbitrary fanout stage counts other than one`()`, `PipelineOrchestratorPropertyTest.kt`
+- **Thin community `Community 195`** (4 nodes): `isProcessAlive()`, `SyntaxValidatorTest`, `waitUntilNotAlive()`, `SyntaxValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (4 nodes): `isProcessAlive()`, `SyntaxValidatorTest`, `waitUntilNotAlive()`, `SyntaxValidatorTest.kt`
+- **Thin community `Community 196`** (4 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (4 nodes): `LocalPlaywrightMarketingBrowserRunner`, `.execute()`, `marketingCommandAvailable()`, `LocalPlaywrightMarketingBrowserRunner.kt`
+- **Thin community `Community 197`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (4 nodes): `CompanyRuntimeLoopDisposition`, `.failure()`, `CompanyRuntimeLoopFailureDisposition`, `CompanyRuntimeLoopDisposition.kt`
+- **Thin community `Community 199`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
+- **Thin community `Community 202`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 205`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 206`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 207`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
+- **Thin community `Community 208`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (4 nodes): `OutputValidator`, `.validate()`, `StageValidationOutcome`, `OutputValidator.kt`
+- **Thin community `Community 209`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (3 nodes): `PostCreateRequest`, `PostCreateRequest.kt`, `PostCreateRequest.kt`
+- **Thin community `Community 210`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (3 nodes): `PostUpdateRequest`, `PostUpdateRequest.kt`, `PostUpdateRequest.kt`
+- **Thin community `Community 211`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (3 nodes): `VersionConflictException`, `VersionConflictException.kt`, `VersionConflictException.kt`
+- **Thin community `Community 212`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (3 nodes): `PostNotFoundException`, `PostNotFoundException.kt`, `PostNotFoundException.kt`
+- **Thin community `Community 213`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (3 nodes): `PermissionDeniedException`, `PermissionDeniedException.kt`, `PermissionDeniedException.kt`
+- **Thin community `Community 214`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (3 nodes): `is_prime()`, `주어진 정수가 소수인지 판별합니다.      Args:         n (int): 판별할 정수      Returns:         boo`, `is_prime.py`
+- **Thin community `Community 215`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (3 nodes): `bubble_sort()`, `버블 정렬 알고리즘 구현      인접한 두 원소를 비교하여 정렬하는 알고리즘입니다.     가장 큰 값이 배열의 끝으로 "버블"처럼 이동합니다`, `claude_bubble_sort.py`
+- **Thin community `Community 216`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (3 nodes): `createDesktopAppServiceIntegrationHarness()`, `DesktopAppServiceIntegrationHarness`, `DesktopAppServiceIntegrationHarness.kt`
+- **Thin community `Community 217`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (3 nodes): `DesktopAppServiceReviewVerdictControlTest`, `MergeGuardFixture`, `DesktopAppServiceReviewVerdictControlTest.kt`
+- **Thin community `Community 218`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (3 nodes): `DesktopAppServiceExecutionMemoryTest`, `seedExecutionMemoryWorkspace()`, `DesktopAppServiceExecutionMemoryTest.kt`
+- **Thin community `Community 219`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (3 nodes): `DesktopAppServiceIssueExecutionDetailsTest`, `seedIssueExecutionWorkspace()`, `DesktopAppServiceIssueExecutionDetailsTest.kt`
+- **Thin community `Community 220`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (3 nodes): `CheckpointFixtureProcess`, `.main()`, `CheckpointFixtureProcess.kt`
+- **Thin community `Community 221`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (3 nodes): `CheckpointResumeIntegrationTest`, `waitForCheckpoint()`, `CheckpointResumeIntegrationTest.kt`
+- **Thin community `Community 222`** (3 nodes): `actionRecord()`, `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (3 nodes): `actionRecord()`, `StoreConcurrencyTest`, `StoreConcurrencyTest.kt`
+- **Thin community `Community 223`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (3 nodes): `readPrivate()`, `RuntimeConstructorConsistencyTest`, `RuntimeConstructorConsistencyTest.kt`
+- **Thin community `Community 224`** (3 nodes): `ActionExecutionServiceTest`, `actionRecord()`, `ActionExecutionServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (3 nodes): `ActionExecutionServiceTest`, `actionRecord()`, `ActionExecutionServiceTest.kt`
+- **Thin community `Community 225`** (3 nodes): `NonPluginWithStaticInitializer`, `PluginLoaderTest`, `PluginLoaderTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (3 nodes): `NonPluginWithStaticInitializer`, `PluginLoaderTest`, `PluginLoaderTest.kt`
+- **Thin community `Community 226`** (3 nodes): `CotorHttpClientsTest`, `localTextServer()`, `CotorHttpClientsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (3 nodes): `CotorHttpClientsTest`, `localTextServer()`, `CotorHttpClientsTest.kt`
+- **Thin community `Community 227`** (3 nodes): `CliProcessProbeTest`, `executableScript()`, `CliProcessProbeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (3 nodes): `CliProcessProbeTest`, `executableScript()`, `CliProcessProbeTest.kt`
+- **Thin community `Community 228`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (3 nodes): `deleteRecursively()`, `TemplateCommandTest`, `TemplateCommandTest.kt`
+- **Thin community `Community 229`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (3 nodes): `deleteRecursively()`, `InitCommandTest`, `InitCommandTest.kt`
+- **Thin community `Community 230`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (3 nodes): `singlePipelineConfig()`, `ValidateCommandTest`, `ValidateCommandTest.kt`
+- **Thin community `Community 231`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (3 nodes): `createPackagedBundle()`, `DesktopLifecycleCommandTest`, `DesktopLifecycleCommandTest.kt`
+- **Thin community `Community 232`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (3 nodes): `ResultAnalyzer`, `.analyze()`, `ResultAnalyzer.kt`
+- **Thin community `Community 233`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (3 nodes): `BrowserSmokeRequest`, `BrowserSmokeResult`, `BrowserModels.kt`
+- **Thin community `Community 234`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (3 nodes): `VideoPlanRequest`, `VideoPlanResult`, `VideoModels.kt`
+- **Thin community `Community 236`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (3 nodes): `currentDurableRuntimeContext()`, `DurableRuntimeContext`, `DurableRuntimeContext.kt`
+- **Thin community `Community 237`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (3 nodes): `HelloCommand`, `.run()`, `HelloCommand.kt`
+- **Thin community `Community 238`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (3 nodes): `WebCommand`, `.run()`, `WebCommand.kt`
+- **Thin community `Community 239`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (3 nodes): `LintCommand`, `.run()`, `LintCommand.kt`
+- **Thin community `Community 240`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (3 nodes): `ExplainCommand`, `.run()`, `ExplainCommand.kt`
+- **Thin community `Community 241`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (3 nodes): `CheckpointGCCommand`, `.run()`, `CheckpointGCCommand.kt`
+- **Thin community `Community 242`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (3 nodes): `StageTimeline.kt`, `StageTimelineEntry`, `StageTimelineState`
+- **Thin community `Community 243`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (3 nodes): `PipelineTemplateValidator.kt`, `PipelineTemplateValidator`, `.validate()`
+- **Thin community `Community 244`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (3 nodes): `DefaultOutputValidator`, `.validate()`, `DefaultOutputValidator.kt`
+- **Thin community `Community 245`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (2 nodes): `TemplateValidatorTest`, `TemplateValidatorTest.kt`
+- **Thin community `Community 247`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (2 nodes): `KotestProjectConfig.kt`, `KotestProjectConfig`
+- **Thin community `Community 248`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (2 nodes): `KoinResolutionSmokeTest`, `KoinResolutionSmokeTest.kt`
+- **Thin community `Community 249`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (2 nodes): `CheckpointManagerTest`, `CheckpointManagerTest.kt`
+- **Thin community `Community 250`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (2 nodes): `DefaultResultAnalyzerTest`, `DefaultResultAnalyzerTest.kt`
+- **Thin community `Community 251`** (2 nodes): `CompanyIssueLifecyclePolicyTest`, `CompanyIssueLifecyclePolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (2 nodes): `CompanyIssueLifecyclePolicyTest`, `CompanyIssueLifecyclePolicyTest.kt`
+- **Thin community `Community 252`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (2 nodes): `DesktopAppServiceGitHubSyncTest`, `DesktopAppServiceGitHubSyncTest.kt`
+- **Thin community `Community 253`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (2 nodes): `AppServerPlatformRoutesTest`, `AppServerPlatformRoutesTest.kt`
+- **Thin community `Community 254`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (2 nodes): `EvidencePathPolicyTest`, `EvidencePathPolicyTest.kt`
+- **Thin community `Community 255`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (2 nodes): `AppServerDurableRuntimeTest`, `AppServerDurableRuntimeTest.kt`
+- **Thin community `Community 256`** (2 nodes): `ProviderModelsTest`, `ProviderModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (2 nodes): `ProviderModelsTest`, `ProviderModelsTest.kt`
+- **Thin community `Community 257`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (2 nodes): `DesktopAppServiceParallelDispatchTest`, `DesktopAppServiceParallelDispatchTest.kt`
+- **Thin community `Community 258`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (2 nodes): `DesktopAppServiceAiOnlyIntegrationTest`, `DesktopAppServiceAiOnlyIntegrationTest.kt`
+- **Thin community `Community 259`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (2 nodes): `DesktopAppServiceDashboardRuntimeTest`, `DesktopAppServiceDashboardRuntimeTest.kt`
+- **Thin community `Community 260`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (2 nodes): `CompanyVerifierServiceTest`, `CompanyVerifierServiceTest.kt`
+- **Thin community `Community 261`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (2 nodes): `AppServerVerificationRouteTest`, `AppServerVerificationRouteTest.kt`
+- **Thin community `Community 262`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (2 nodes): `AppServerTest`, `AppServerTest.kt`
+- **Thin community `Community 263`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
+- **Thin community `Community 264`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 265`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 266`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 267`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 268`** (2 nodes): `LocalPlaywrightDependencyTest`, `LocalPlaywrightDependencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `LocalPlaywrightDependencyTest`, `LocalPlaywrightDependencyTest.kt`
+- **Thin community `Community 269`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 270`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 271`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 272`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 273`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
+- **Thin community `Community 274`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 275`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 276`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 277`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 278`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 279`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 280`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 281`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
+- **Thin community `Community 282`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 283`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 284`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 285`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 286`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 287`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
+- **Thin community `Community 288`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 289`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 290`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 291`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 292`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 293`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 294`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 295`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 296`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 297`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 298`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 299`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 300`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 301`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 302`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 303`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 304`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 305`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 306`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 307`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 308`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 309`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 310`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 311`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 312`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 313`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 314`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 315`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 316`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 317`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 318`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 319`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 320`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 321`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 322`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 323`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 324`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 325`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 326`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 327`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 328`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 329`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 330`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 333`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 336`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 334`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 337`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 10`, `Community 17`?**
-  _High betweenness centrality (0.077) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 8`, `Community 15`, `Community 21`?**
-  _High betweenness centrality (0.030) - this node is a cross-community bridge._
+- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 11`, `Community 17`, `Community 21`?**
+  _High betweenness centrality (0.082) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 8`, `Community 16`, `Community 19`?**
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
 - **Why does `DesktopTextKey` connect `Community 8` to `Community 1`, `Community 5`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
+  _High betweenness centrality (0.029) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
   _`DesktopStore` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 14 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -230,8 +230,18 @@ struct CotorDesktopApp: App {
     }
 }
 
+@MainActor
 final class DesktopAppLifecycleDelegate: NSObject, NSApplicationDelegate {
     private var terminationInFlight = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        bringApplicationToForeground(notification.object as? NSApplication ?? NSApp)
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        bringApplicationToForeground(sender)
+        return true
+    }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
@@ -251,6 +261,12 @@ final class DesktopAppLifecycleDelegate: NSObject, NSApplicationDelegate {
             }
         }
         return .terminateLater
+    }
+
+    private func bringApplicationToForeground(_ application: NSApplication) {
+        application.setActivationPolicy(.regular)
+        application.activate(ignoringOtherApps: true)
+        application.windows.first?.makeKeyAndOrderFront(nil)
     }
 }
 

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -94,7 +94,7 @@ case "$MODE" in
   --debug|debug)
     stop_running_app
     build_bundle
-    lldb -- "$APP_BUNDLE/Contents/MacOS/CotorDesktopLauncher"
+    lldb -- "$APP_BUNDLE/Contents/MacOS/CotorDesktopBinary"
     ;;
   --logs|logs)
     stop_running_app

--- a/shell/build-desktop-app-bundle.sh
+++ b/shell/build-desktop-app-bundle.sh
@@ -178,7 +178,7 @@ fi
 prebundle_playwright_if_requested
 
 sed \
-    -e "s#__EXECUTABLE__#CotorDesktopLauncher#g" \
+    -e "s#__EXECUTABLE__#CotorDesktopBinary#g" \
     -e "s#__VERSION__#$VERSION#g" \
     -e "s#__BUILD__#$BUILD_NUMBER#g" \
     "$PACKAGING_ROOT/Info.plist.template" > "$APP_CONTENTS/Info.plist"

--- a/src/main/kotlin/com/cotor/app/AgentCapabilityGuard.kt
+++ b/src/main/kotlin/com/cotor/app/AgentCapabilityGuard.kt
@@ -4,6 +4,7 @@ import com.cotor.runtime.actions.ActionInterceptor
 import com.cotor.runtime.actions.ActionInterceptorDecision
 import com.cotor.runtime.actions.ActionKind
 import com.cotor.runtime.actions.ActionRequest
+import com.cotor.runtime.actions.ActionScope
 import java.net.URI
 import java.nio.file.Path
 
@@ -214,15 +215,26 @@ class AgentCapabilityGuard(
         else -> false
     }
 
-    private fun ActionRequest.requiresScopedSubject(): Boolean = when (kind) {
-        ActionKind.GIT_PUBLISH,
-        ActionKind.GITHUB_REVIEW,
-        ActionKind.GITHUB_COMMENT,
-        ActionKind.GITHUB_MERGE,
-        ActionKind.WEB_PUBLISH,
-        ActionKind.SOCIAL_POST_CREATE,
-        ActionKind.MARKETING_ANALYTICS_READ -> true
-        else -> false
+    private fun ActionRequest.requiresScopedSubject(): Boolean {
+        if (scope == ActionScope.RUN) {
+            return false
+        }
+        return when (kind) {
+            ActionKind.SHELL_EXEC,
+            ActionKind.FILE_WRITE,
+            ActionKind.AGENT_EXEC,
+            ActionKind.SKILL_RUN,
+            ActionKind.GIT_WORKTREE,
+            ActionKind.GIT_PUBLISH,
+            ActionKind.GITHUB_REVIEW,
+            ActionKind.GITHUB_COMMENT,
+            ActionKind.GITHUB_MERGE,
+            ActionKind.SECRET_READ,
+            ActionKind.WEB_PUBLISH,
+            ActionKind.SOCIAL_POST_CREATE,
+            ActionKind.MARKETING_ANALYTICS_READ -> true
+            else -> false
+        }
     }
 
     private fun ActionRequest.hasRecordedApproval(): Boolean =

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -38,7 +38,6 @@ import com.cotor.model.Pipeline
 import com.cotor.model.PipelineContext
 import com.cotor.model.PipelineStage
 import com.cotor.model.ProcessExecutionException
-import com.cotor.model.SecurityConfig
 import com.cotor.model.StageType
 import com.cotor.policy.PolicyDecision
 import com.cotor.policy.PolicyEngine
@@ -64,6 +63,7 @@ import com.cotor.runtime.durable.DurableRuntimeStore
 import com.cotor.runtime.durable.ReplayMode
 import com.cotor.security.DefaultSecurityValidator
 import com.cotor.security.SecurityValidator
+import com.cotor.security.defaultSecurityConfig
 import com.cotor.verification.VerificationBundle
 import com.cotor.verification.VerificationBundleService
 import kotlinx.coroutines.CancellationException
@@ -304,7 +304,7 @@ class DesktopAppService(
     private val autonomousDiscoveryService: AutonomousDiscoveryService = AutonomousDiscoveryService(),
     private val companyRuntimeRetention: CompanyRuntimeRetention = CompanyRuntimeRetention(),
     private val securityValidator: SecurityValidator = DefaultSecurityValidator(
-        SecurityConfig(useWhitelist = false, enablePathValidation = false),
+        defaultSecurityConfig(),
         org.slf4j.LoggerFactory.getLogger("Cotor")
     ),
     private val marketingBrowserRunner: MarketingBrowserRunner = LocalPlaywrightMarketingBrowserRunner(

--- a/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
+++ b/src/main/kotlin/com/cotor/app/LocalSkillProcess.kt
@@ -5,6 +5,7 @@ import com.cotor.data.process.buildEffectivePath
 import com.cotor.data.process.cleanupSurvivingDescendants
 import com.cotor.data.process.destroyProcessTree
 import com.cotor.data.process.resolveExecutablePath
+import com.cotor.data.process.sanitizeProcessEnvironment
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.IOException
@@ -48,7 +49,7 @@ internal fun runLocalSkillProcess(
 ): LocalSkillProcessResult {
     require(command.isNotEmpty()) { "command is required" }
     require(timeoutSeconds > 0) { "timeoutSeconds must be positive" }
-    val processEnvironment = System.getenv().toMutableMap().apply { putAll(environment) }
+    val processEnvironment = sanitizeProcessEnvironment(environment)
     val resolvedCommand = resolveLocalSkillCommand(command, processEnvironment)
     val process = try {
         ProcessBuilder(resolvedCommand)
@@ -56,7 +57,8 @@ internal fun runLocalSkillProcess(
             .redirectErrorStream(true)
             .also { builder ->
                 val builderEnvironment = builder.environment()
-                builderEnvironment.putAll(environment)
+                builderEnvironment.clear()
+                builderEnvironment.putAll(processEnvironment)
                 val resolvedExecutable = resolvedCommand.firstOrNull()
                     ?.let { runCatching { Path.of(it) }.getOrNull() }
                 val effectivePath = buildEffectivePath(

--- a/src/main/kotlin/com/cotor/data/plugin/CommandPlugin.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/CommandPlugin.kt
@@ -67,8 +67,6 @@ class CommandPlugin : AgentPlugin {
         if (argvTemplate.isEmpty()) {
             throw IllegalArgumentException("argvJson must contain at least one element (the executable)")
         }
-        context.validateCommand?.invoke(argvTemplate)
-
         val argv = argvTemplate.map { token ->
             if (token.contains("{input}")) {
                 token.replace("{input}", context.input.orEmpty())

--- a/src/main/kotlin/com/cotor/data/plugin/QaVerificationPlugin.kt
+++ b/src/main/kotlin/com/cotor/data/plugin/QaVerificationPlugin.kt
@@ -62,6 +62,8 @@ class QaVerificationPlugin : AgentPlugin {
 
         val stdin = if (context.parameters["stdin"]?.lowercase() == "true") context.input else null
 
+        // AgentExecutor wraps the process manager with mandatory command validation,
+        // so autodetected and explicit QA commands share the same execution guard.
         val result = processManager.executeProcess(
             command = argv,
             input = stdin,

--- a/src/main/kotlin/com/cotor/data/process/ProcessEnvironment.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessEnvironment.kt
@@ -1,0 +1,107 @@
+package com.cotor.data.process
+
+/**
+ * Builds child-process environments without inheriting ambient developer secrets.
+ *
+ * Parent process variables are allowlisted because they are implicit. Explicit
+ * per-run variables are preserved unless their names look like secrets, with a
+ * narrow exception for the scoped A2A token that Cotor intentionally injects
+ * into company run subprocesses.
+ */
+internal fun sanitizeProcessEnvironment(
+    environment: Map<String, String>,
+    parentEnvironment: Map<String, String> = System.getenv()
+): MutableMap<String, String> {
+    val sanitized = linkedMapOf<String, String>()
+
+    parentEnvironment.forEach { (key, value) ->
+        if (isValidEnvironmentKey(key) && isAllowedParentEnvironmentKey(key) && !isBlockedProcessEnvironmentKey(key)) {
+            sanitized[key] = value
+        }
+    }
+
+    environment.forEach { (key, value) ->
+        if (isValidEnvironmentKey(key) && isAllowedExplicitEnvironmentKey(key)) {
+            sanitized[key] = value
+        }
+    }
+
+    return sanitized
+}
+
+internal fun isBlockedProcessEnvironmentKey(key: String): Boolean {
+    val normalized = key.trim().uppercase()
+    if (normalized in allowedScopedSecretEnvironmentKeys) {
+        return false
+    }
+    if (normalized in blockedProcessEnvironmentKeys) {
+        return true
+    }
+    return blockedProcessEnvironmentFragments.any { normalized.contains(it) }
+}
+
+private fun isAllowedExplicitEnvironmentKey(key: String): Boolean =
+    !isBlockedProcessEnvironmentKey(key)
+
+private fun isAllowedParentEnvironmentKey(key: String): Boolean {
+    val normalized = key.trim().uppercase()
+    return normalized in allowedParentEnvironmentKeys ||
+        allowedParentEnvironmentPrefixes.any { normalized.startsWith(it) }
+}
+
+private fun isValidEnvironmentKey(key: String): Boolean =
+    key.isNotBlank() && key.none { it == '=' || it == '\u0000' }
+
+private val allowedParentEnvironmentKeys = setOf(
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "TERM",
+    "COLORTERM",
+    "NO_COLOR",
+    "PATH",
+    "JAVA_HOME",
+    "CODEX_HOME",
+    "COTOR_CODEX_OAUTH_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME"
+)
+
+private val allowedParentEnvironmentPrefixes = setOf(
+    "LC_"
+)
+
+private val allowedScopedSecretEnvironmentKeys = setOf(
+    "COTOR_A2A_TOKEN"
+)
+
+private val blockedProcessEnvironmentKeys = setOf(
+    "OPENAI_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GIT_ASKPASS",
+    "LINEAR_API_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "COTOR_APP_TOKEN",
+    "COTOR_APP_CONTROL_TOKEN"
+)
+
+private val blockedProcessEnvironmentFragments = setOf(
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "API_KEY",
+    "ACCESS_KEY",
+    "PRIVATE_KEY",
+    "CREDENTIAL"
+)

--- a/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
+++ b/src/main/kotlin/com/cotor/data/process/ProcessManager.kt
@@ -191,7 +191,8 @@ class CoroutineProcessManager(
         onStdoutChunk: ((String) -> Unit)?,
         onStderrChunk: ((String) -> Unit)?
     ): ProcessResult = withContext(Dispatchers.IO) {
-        val resolvedCommand = resolveProcessCommand(command)
+        val processEnvironment = sanitizeProcessEnvironment(environment)
+        val resolvedCommand = resolveProcessCommand(command, processEnvironment)
         val processBuilder = ProcessBuilder(resolvedCommand)
             .redirectErrorStream(false)
 
@@ -203,16 +204,19 @@ class CoroutineProcessManager(
             processBuilder.directory(it.toFile())
         }
 
-        // Set environment variables
-        processBuilder.environment().putAll(environment)
+        // Replace the inherited process environment so ambient developer
+        // secrets cannot leak into agent subprocesses.
+        val builderEnvironment = processBuilder.environment()
+        builderEnvironment.clear()
+        builderEnvironment.putAll(processEnvironment)
         val resolvedExecutable = resolvedCommand.firstOrNull()?.let { runCatching { Path.of(it) }.getOrNull() }
         val effectivePath = buildEffectivePath(
-            inheritedPath = processBuilder.environment()["PATH"],
+            inheritedPath = builderEnvironment["PATH"],
             overridePath = environment["PATH"],
             resolvedExecutable = resolvedExecutable
         )
         if (effectivePath.isNotBlank()) {
-            processBuilder.environment()["PATH"] = effectivePath
+            builderEnvironment["PATH"] = effectivePath
         }
 
         logger.debug("Starting process: ${redactedCommandForLogs(resolvedCommand)}")
@@ -483,10 +487,10 @@ fun resolveExecutablePath(
     }
 }
 
-private fun resolveProcessCommand(command: List<String>): List<String> {
+private fun resolveProcessCommand(command: List<String>, environment: Map<String, String>): List<String> {
     if (command.isEmpty()) {
         return command
     }
-    val executable = resolveExecutablePath(command.first())?.toString() ?: command.first()
+    val executable = resolveExecutablePath(command.first(), environment = environment)?.toString() ?: command.first()
     return listOf(executable) + command.drop(1)
 }

--- a/src/main/kotlin/com/cotor/di/KoinModules.kt
+++ b/src/main/kotlin/com/cotor/di/KoinModules.kt
@@ -26,7 +26,6 @@ import com.cotor.data.plugin.PluginLoader
 import com.cotor.data.plugin.ReflectionPluginLoader
 import com.cotor.data.process.CoroutineProcessManager
 import com.cotor.data.process.ProcessManager
-import com.cotor.data.process.resolveExecutablePath
 import com.cotor.data.registry.AgentRegistry
 import com.cotor.data.registry.InMemoryAgentRegistry
 import com.cotor.domain.aggregator.DefaultResultAggregator
@@ -59,6 +58,7 @@ import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.runtime.durable.DurableRuntimeStore
 import com.cotor.security.DefaultSecurityValidator
 import com.cotor.security.SecurityValidator
+import com.cotor.security.defaultSecurityConfig
 import com.cotor.stats.StatsManager
 import com.cotor.validation.output.DefaultOutputValidator
 import com.cotor.validation.output.OutputValidator
@@ -67,10 +67,6 @@ import com.cotor.verification.VerificationBundleService
 import org.koin.dsl.module
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.io.path.Path
 
 /**
  * Main Koin module for Cotor system
@@ -140,14 +136,7 @@ val cotorModule = module {
     single { DesktopTuiSessionService(get(), get(), get(), get()) }
 
     // Security
-    single<SecurityConfig> {
-        val allowedExecutables = defaultAllowedExecutables()
-        SecurityConfig(
-            useWhitelist = true,
-            allowedExecutables = allowedExecutables,
-            allowedDirectories = defaultAllowedDirectories(allowedExecutables)
-        )
-    }
+    single<SecurityConfig> { defaultSecurityConfig() }
     single<SecurityValidator> { DefaultSecurityValidator(get(), get()) }
 
     // Domain Layer
@@ -200,40 +189,4 @@ fun initializeCotor() {
     org.koin.core.context.startKoin {
         modules(cotorModule)
     }
-}
-
-private fun defaultAllowedExecutables(): Set<String> = setOf(
-    "python3", "node", "java", "git", "gh", "lsof",
-    "claude", "codex", "copilot", "gemini", "cursor-cli", "opencode", "qwen", "graphify"
-)
-
-private fun defaultAllowedDirectories(allowedExecutables: Set<String>): List<Path> {
-    val pathDirectories = System.getenv("PATH")
-        .orEmpty()
-        .split(File.pathSeparator)
-        .mapNotNull { it.trim().takeIf(String::isNotBlank) }
-        .map { Path(it).toAbsolutePath().normalize() }
-    val executableDirectories = allowedExecutables.mapNotNull { executable ->
-        runCatching { resolveExecutablePath(executable)?.parent }.getOrNull()
-    }
-    val userHome = Path(System.getProperty("user.home")).toAbsolutePath().normalize()
-    val conventionalDirectories = listOf(
-        Path("/usr/bin"),
-        Path("/bin"),
-        Path("/usr/sbin"),
-        Path("/sbin"),
-        Path("/usr/local/bin"),
-        Path("/usr/local/Cellar"),
-        Path("/usr/local/opt"),
-        Path("/opt/homebrew/bin"),
-        Path("/opt/homebrew/Cellar"),
-        Path("/opt/homebrew/opt"),
-        Path("/opt/cotor"),
-        userHome.resolve("Library").resolve("Python"),
-        userHome.resolve("Library").resolve("Application Support").resolve("CotorDesktop")
-    )
-    return (pathDirectories + executableDirectories + conventionalDirectories)
-        .map { it.toAbsolutePath().normalize() }
-        .filter { Files.exists(it) }
-        .distinct()
 }

--- a/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
+++ b/src/main/kotlin/com/cotor/domain/executor/AgentExecutor.kt
@@ -25,6 +25,7 @@ import com.cotor.runtime.durable.DurableRuntimeService
 import com.cotor.security.SecurityValidator
 import kotlinx.coroutines.*
 import org.slf4j.Logger
+import java.nio.file.Path
 import java.time.Instant
 
 /**
@@ -212,6 +213,11 @@ class DefaultAgentExecutor(
                         metadata.workingDirectory?.let { put("worktreePath", it.toAbsolutePath().normalize().toString()) }
                     }
                 )
+                val commandValidatingProcessManager = CommandValidatingProcessManager(
+                    delegate = processManager,
+                    validateCommand = securityValidator::validateCommand
+                )
+
                 val pluginOutput = actionExecutionService.run(
                     request = actionRequest,
                     onSuccess = { output ->
@@ -224,7 +230,7 @@ class DefaultAgentExecutor(
                     }
                 ) {
                     withTimeout(agent.timeout) {
-                        plugin.execute(context, processManager)
+                        plugin.execute(context, commandValidatingProcessManager)
                     }
                 }
                 val duration = System.currentTimeMillis() - startTime
@@ -324,5 +330,96 @@ class DefaultAgentExecutor(
         }
 
         return lastResult ?: throw IllegalStateException("No result after retries")
+    }
+}
+
+private class CommandValidatingProcessManager(
+    private val delegate: ProcessManager,
+    private val validateCommand: (List<String>) -> Unit
+) : ProcessManager {
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        validateCommand(command)
+        return delegate.executeProcess(
+            command = command,
+            input = input,
+            environment = environment,
+            timeout = timeout,
+            workingDirectory = workingDirectory,
+            onStart = onStart
+        )
+    }
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?
+    ): ProcessResult {
+        validateCommand(command)
+        return delegate.executeProcess(
+            command = command,
+            input = input,
+            environment = environment,
+            timeout = timeout,
+            workingDirectory = workingDirectory,
+            onStart = onStart,
+            onStdoutChunk = onStdoutChunk
+        )
+    }
+
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?,
+        onStderrChunk: ((String) -> Unit)?
+    ): ProcessResult {
+        validateCommand(command)
+        return delegate.executeProcess(
+            command = command,
+            input = input,
+            environment = environment,
+            timeout = timeout,
+            workingDirectory = workingDirectory,
+            onStart = onStart,
+            onStdoutChunk = onStdoutChunk,
+            onStderrChunk = onStderrChunk
+        )
+    }
+
+    override suspend fun executeProcessWithInputFile(
+        command: List<String>,
+        inputFile: Path,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?,
+        onStdoutChunk: ((String) -> Unit)?,
+        onStderrChunk: ((String) -> Unit)?
+    ): ProcessResult {
+        validateCommand(command)
+        return delegate.executeProcessWithInputFile(
+            command = command,
+            inputFile = inputFile,
+            environment = environment,
+            timeout = timeout,
+            workingDirectory = workingDirectory,
+            onStart = onStart,
+            onStdoutChunk = onStdoutChunk,
+            onStderrChunk = onStderrChunk
+        )
     }
 }

--- a/src/main/kotlin/com/cotor/security/DefaultSecurityConfig.kt
+++ b/src/main/kotlin/com/cotor/security/DefaultSecurityConfig.kt
@@ -1,0 +1,80 @@
+package com.cotor.security
+
+import com.cotor.data.process.resolveExecutablePath
+import com.cotor.model.SecurityConfig
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+fun defaultSecurityConfig(): SecurityConfig {
+    val allowedExecutables = defaultAllowedExecutables()
+    return SecurityConfig(
+        useWhitelist = true,
+        allowedExecutables = allowedExecutables,
+        allowedDirectories = defaultAllowedDirectories(allowedExecutables),
+        enablePathValidation = true
+    )
+}
+
+fun defaultAllowedExecutables(): Set<String> = setOf(
+    "python3",
+    "python",
+    "node",
+    "npm",
+    "npx",
+    "java",
+    "git",
+    "gh",
+    "lsof",
+    "claude",
+    "codex",
+    "copilot",
+    "gemini",
+    "cursor-cli",
+    "opencode",
+    "qwen",
+    "graphify",
+    "ollama",
+    "swift",
+    "gradle",
+    "gradlew",
+    "mvn",
+    "mvnw",
+    "pnpm",
+    "yarn",
+    "pytest",
+    "go",
+    "cargo"
+)
+
+fun defaultAllowedDirectories(allowedExecutables: Set<String> = defaultAllowedExecutables()): List<Path> {
+    val pathDirectories = System.getenv("PATH")
+        .orEmpty()
+        .split(File.pathSeparator)
+        .mapNotNull { it.trim().takeIf(String::isNotBlank) }
+        .map { Path(it).toAbsolutePath().normalize() }
+    val executableDirectories = allowedExecutables.mapNotNull { executable ->
+        runCatching { resolveExecutablePath(executable)?.parent }.getOrNull()
+    }
+    val userHome = Path(System.getProperty("user.home")).toAbsolutePath().normalize()
+    val conventionalDirectories = listOf(
+        Path("/usr/bin"),
+        Path("/bin"),
+        Path("/usr/sbin"),
+        Path("/sbin"),
+        Path("/usr/local/bin"),
+        Path("/usr/local/Cellar"),
+        Path("/usr/local/opt"),
+        Path("/opt/homebrew/bin"),
+        Path("/opt/homebrew/Cellar"),
+        Path("/opt/homebrew/opt"),
+        Path("/opt/cotor"),
+        userHome.resolve("Library").resolve("Python"),
+        userHome.resolve("Library").resolve("Application Support").resolve("CotorDesktop")
+    )
+    return (pathDirectories + executableDirectories + conventionalDirectories)
+        .map { it.toAbsolutePath().normalize() }
+        .filter { Files.exists(it) }
+        .distinct()
+}

--- a/src/test/kotlin/com/cotor/app/AgentCapabilityGuardTest.kt
+++ b/src/test/kotlin/com/cotor/app/AgentCapabilityGuardTest.kt
@@ -2,6 +2,7 @@ package com.cotor.app
 
 import com.cotor.runtime.actions.ActionKind
 import com.cotor.runtime.actions.ActionRequest
+import com.cotor.runtime.actions.ActionScope
 import com.cotor.runtime.actions.ActionSubject
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -371,18 +372,48 @@ class AgentCapabilityGuardTest : FunSpec({
         recordedPublishApproval.requiresApproval shouldBe false
     }
 
-    test("unscoped generic agent execution stays outside company capability authority") {
+    test("unscoped global agent execution is denied while pipeline run scope remains independent") {
         val guard = AgentCapabilityGuard(DesktopStateStore { Files.createTempDirectory("capability-guard-unscoped-home") })
 
-        val decision = guard.before(
+        val globalDecision = guard.before(
             ActionRequest(
                 kind = ActionKind.AGENT_EXEC,
                 label = "agent.exec:pipeline"
             )
         )
+        val runDecision = guard.before(
+            ActionRequest(
+                kind = ActionKind.AGENT_EXEC,
+                label = "agent.exec:pipeline-run",
+                scope = ActionScope.RUN
+            )
+        )
 
-        decision.allow shouldBe true
-        decision.requireApproval shouldBe false
+        globalDecision.allow shouldBe false
+        globalDecision.reason shouldBe "Capability SHELL_EXEC cannot evaluate agent.exec without company and agent subject metadata."
+        runDecision.allow shouldBe true
+        runDecision.requireApproval shouldBe false
+    }
+
+    test("unscoped global execution file skill and worktree actions are denied") {
+        val guard = AgentCapabilityGuard(DesktopStateStore { Files.createTempDirectory("capability-guard-unscoped-actions-home") })
+
+        listOf(
+            ActionKind.SHELL_EXEC,
+            ActionKind.FILE_WRITE,
+            ActionKind.SKILL_RUN,
+            ActionKind.GIT_WORKTREE,
+            ActionKind.SECRET_READ
+        ).forEach { kind ->
+            val decision = guard.before(
+                ActionRequest(
+                    kind = kind,
+                    label = "${kind.wireValue}:unscoped"
+                )
+            )
+
+            decision.allow shouldBe false
+        }
     }
 
     test("repository scoped company agent execution honors path allowlists") {

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceRuntimeDispositionSchedulerTest.kt
@@ -23,6 +23,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.delay
 import java.nio.file.Files
 
+private const val AGENT_EXECUTOR_START_TIMEOUT_MS = 5_000L
+
 class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
     afterTest {
         DesktopAppService.shutdownAllForTesting()
@@ -213,7 +215,7 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         snapshot.lastAction.orEmpty() shouldContain "started:$issueId"
         refreshed.tasks.shouldNotBeEmpty()
         refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
-        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+        coVerify(timeout = AGENT_EXECUTOR_START_TIMEOUT_MS, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 
     test("runCompanyRuntimeTick starts backlog issues") {
@@ -278,7 +280,7 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         snapshot.lastAction.orEmpty() shouldContain "started:$issueId"
         refreshed.tasks.shouldNotBeEmpty()
         refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
-        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+        coVerify(timeout = AGENT_EXECUTOR_START_TIMEOUT_MS, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 
     test("runCompanyRuntimeTick starts stranded in-progress issues") {
@@ -343,7 +345,7 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         snapshot.lastAction.orEmpty() shouldContain "started:$issueId"
         refreshed.tasks.shouldNotBeEmpty()
         refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
-        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+        coVerify(timeout = AGENT_EXECUTOR_START_TIMEOUT_MS, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 
     test("runCompanyRuntimeTick does not duplicate active in-progress issues") {
@@ -497,7 +499,7 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         snapshot.lastAction.orEmpty() shouldContain "started:$issueId"
         refreshed.tasks.shouldNotBeEmpty()
         refreshed.issues.first { it.id == issueId }.status shouldBe IssueStatus.IN_PROGRESS
-        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+        coVerify(timeout = AGENT_EXECUTOR_START_TIMEOUT_MS, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 
     test("runCompanyRuntimeTick records dependency waits in the durable queue") {
@@ -623,7 +625,7 @@ class DesktopAppServiceRuntimeDispositionSchedulerTest : FunSpec({
         snapshot.lastAction.orEmpty() shouldContain "started:$downstreamId"
         downstreamWorkItem.status shouldBe CompanyRuntimeWorkItemStatus.RUNNING
         refreshed.issues.first { it.id == downstreamId }.status shouldBe IssueStatus.IN_PROGRESS
-        coVerify(timeout = 2_000, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
+        coVerify(timeout = AGENT_EXECUTOR_START_TIMEOUT_MS, exactly = 1) { agentExecutor.executeAgent(any(), any(), any()) }
     }
 })
 

--- a/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
+++ b/src/test/kotlin/com/cotor/app/SkillRuntimeTest.kt
@@ -9,6 +9,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.nio.file.Files
@@ -115,6 +116,31 @@ class SkillRuntimeTest : FunSpec({
         result.status shouldBe "FAILED"
         result.error shouldContain "blocked by test validator"
         validator.commands shouldBe listOf(listOf("graphify", "update", "."))
+    }
+
+    test("local skill process strips secret environment overrides before launch") {
+        val appHome = Files.createTempDirectory("skill-process-env-home")
+
+        val result = runLocalSkillProcess(
+            command = listOf("/usr/bin/env"),
+            workingDirectory = appHome,
+            timeoutSeconds = 5,
+            timeoutMessage = "env probe timed out",
+            environment = mapOf(
+                "GITHUB_TOKEN" to "secret-github",
+                "OPENAI_API_KEY" to "secret-openai",
+                "SAFE_LOCAL_SKILL_PROBE" to "local-value",
+                "COTOR_A2A_TOKEN" to "scoped-a2a-token"
+            )
+        )
+
+        result.exitCode shouldBe 0
+        result.output shouldContain "SAFE_LOCAL_SKILL_PROBE=local-value"
+        result.output shouldContain "COTOR_A2A_TOKEN=scoped-a2a-token"
+        result.output shouldNotContain "GITHUB_TOKEN="
+        result.output shouldNotContain "OPENAI_API_KEY="
+        result.output shouldNotContain "secret-github"
+        result.output shouldNotContain "secret-openai"
     }
 
     test("runSkill executes browser-smoke with browser evidence") {

--- a/src/test/kotlin/com/cotor/data/plugin/CommandPluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/CommandPluginTest.kt
@@ -10,30 +10,28 @@ import io.kotest.matchers.shouldBe
 import java.nio.file.Path
 
 class CommandPluginTest : FunSpec({
-    test("command plugin validates argv template before execution") {
-        val processManager = RecordingProcessManager()
+    test("command plugin delegates command guarding to the provided process manager") {
+        val processManager = BlockingProcessManager()
         val plugin = CommandPlugin()
 
-        shouldThrow<IllegalStateException> {
+        val error = shouldThrow<IllegalStateException> {
             plugin.execute(
                 ExecutionContext(
                     agentName = "command",
                     input = null,
                     parameters = mapOf("argvJson" to "[\"sh\",\"-c\",\"id\"]"),
                     environment = emptyMap(),
-                    timeout = 1000,
-                    validateCommand = { throw IllegalStateException("blocked") }
+                    timeout = 1000
                 ),
                 processManager
             )
         }
 
-        processManager.commands.size shouldBe 0
+        error.message shouldBe "blocked by process manager guard"
     }
 
-    test("command plugin validates template while passing substituted input as literal argv") {
+    test("command plugin passes substituted input as literal argv") {
         val processManager = RecordingProcessManager()
-        val validatedCommands = mutableListOf<List<String>>()
         val plugin = CommandPlugin()
 
         plugin.execute(
@@ -42,13 +40,11 @@ class CommandPluginTest : FunSpec({
                 input = "literal ; | < > input",
                 parameters = mapOf("argvJson" to "[\"/opt/homebrew/bin/qwen\",\"{input}\"]"),
                 environment = emptyMap(),
-                timeout = 1000,
-                validateCommand = { validatedCommands += it }
+                timeout = 1000
             ),
             processManager
         )
 
-        validatedCommands.single().shouldContainExactly(listOf("/opt/homebrew/bin/qwen", "{input}"))
         processManager.commands.single().shouldContainExactly(listOf("/opt/homebrew/bin/qwen", "literal ; | < > input"))
     }
 })
@@ -66,5 +62,18 @@ private class RecordingProcessManager : ProcessManager {
     ): ProcessResult {
         commands += command
         return ProcessResult(exitCode = 0, stdout = "ok", stderr = "", isSuccess = true)
+    }
+}
+
+private class BlockingProcessManager : ProcessManager {
+    override suspend fun executeProcess(
+        command: List<String>,
+        input: String?,
+        environment: Map<String, String>,
+        timeout: Long,
+        workingDirectory: Path?,
+        onStart: ((Long) -> Unit)?
+    ): ProcessResult {
+        throw IllegalStateException("blocked by process manager guard")
     }
 }

--- a/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
+++ b/src/test/kotlin/com/cotor/data/process/ProcessManagerTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.mockk
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
@@ -91,6 +92,56 @@ class ProcessManagerTest : FunSpec({
 
         result.isSuccess shouldBe true
         result.stdout.trim() shouldBe "fake-node:$tool"
+    }
+
+    test("sanitizeProcessEnvironment keeps safe parent keys and strips parent secrets") {
+        val sanitized = sanitizeProcessEnvironment(
+            parentEnvironment = mapOf(
+                "HOME" to "/tmp/cotor-home",
+                "PATH" to "/usr/bin:/bin",
+                "OPENAI_API_KEY" to "secret-openai",
+                "GITHUB_TOKEN" to "secret-github",
+                "SAFE_PARENT_PROBE" to "parent-value"
+            ),
+            environment = mapOf(
+                "SAFE_EXPLICIT_PROBE" to "explicit-value",
+                "GH_TOKEN" to "secret-gh",
+                "COTOR_APP_TOKEN" to "app-token",
+                "COTOR_A2A_TOKEN" to "scoped-a2a-token"
+            )
+        )
+
+        sanitized["HOME"] shouldBe "/tmp/cotor-home"
+        sanitized["PATH"] shouldBe "/usr/bin:/bin"
+        sanitized["SAFE_PARENT_PROBE"] shouldBe null
+        sanitized["OPENAI_API_KEY"] shouldBe null
+        sanitized["GITHUB_TOKEN"] shouldBe null
+        sanitized["SAFE_EXPLICIT_PROBE"] shouldBe "explicit-value"
+        sanitized["GH_TOKEN"] shouldBe null
+        sanitized["COTOR_APP_TOKEN"] shouldBe null
+        sanitized["COTOR_A2A_TOKEN"] shouldBe "scoped-a2a-token"
+    }
+
+    test("executeProcess strips secret environment overrides before launch") {
+        val processManager = CoroutineProcessManager(mockk<Logger>(relaxed = true))
+
+        val result = processManager.executeProcess(
+            command = listOf("/usr/bin/env"),
+            input = null,
+            environment = mapOf(
+                "OPENAI_API_KEY" to "secret-openai",
+                "GITHUB_TOKEN" to "secret-github",
+                "SAFE_EXPLICIT_PROBE" to "explicit-value"
+            ),
+            timeout = 5_000
+        )
+
+        result.isSuccess shouldBe true
+        result.stdout shouldContain "SAFE_EXPLICIT_PROBE=explicit-value"
+        result.stdout shouldNotContain "OPENAI_API_KEY="
+        result.stdout shouldNotContain "GITHUB_TOKEN="
+        result.stdout shouldNotContain "secret-openai"
+        result.stdout shouldNotContain "secret-github"
     }
 
     test("executeProcess times out even when the child keeps pipes open") {

--- a/src/test/kotlin/com/cotor/domain/executor/AgentExecutorTest.kt
+++ b/src/test/kotlin/com/cotor/domain/executor/AgentExecutorTest.kt
@@ -15,10 +15,13 @@ import com.cotor.model.AgentConfig
 import com.cotor.model.ExecutionContext
 import com.cotor.model.PluginExecutionOutput
 import com.cotor.model.ProcessExecutionException
+import com.cotor.model.ProcessResult
+import com.cotor.model.SecurityException
 import com.cotor.security.SecurityValidator
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -170,5 +173,113 @@ class AgentExecutorTest : FunSpec({
         result.isSuccess shouldBe true
         result.output shouldBe "validated"
         verify(exactly = 1) { mockSecurityValidator.validateCommand(listOf("git", "status")) }
+    }
+
+    test("should validate plugin process commands centrally before execution") {
+        val processManager = mockk<ProcessManager>()
+        val pluginLoader = mockk<PluginLoader>()
+        val securityValidator = mockk<SecurityValidator>()
+        val executor = DefaultAgentExecutor(
+            processManager,
+            pluginLoader,
+            securityValidator,
+            mockk<Logger>(relaxed = true)
+        )
+        val agentConfig = AgentConfig(
+            name = "qa-agent",
+            pluginClass = "com.example.ProcessCallingPlugin",
+            timeout = 5000
+        )
+        val plugin = mockk<AgentPlugin>()
+        coEvery { plugin.execute(any(), any()) } coAnswers {
+            secondArg<ProcessManager>().executeProcess(
+                command = listOf("git", "status"),
+                input = null,
+                environment = emptyMap(),
+                timeout = 1000
+            ).let { PluginExecutionOutput(it.stdout, it.processId) }
+        }
+        every { plugin.validateInput(any()) } returns com.cotor.model.ValidationResult.Success
+        every { pluginLoader.loadPlugin(any()) } returns plugin
+        every { securityValidator.validate(any()) } just runs
+        every { securityValidator.validateCommand(any()) } just runs
+        coEvery {
+            processManager.executeProcess(
+                command = listOf("git", "status"),
+                input = null,
+                environment = emptyMap(),
+                timeout = 1000,
+                workingDirectory = null,
+                onStart = null
+            )
+        } returns ProcessResult(
+            exitCode = 0,
+            stdout = "clean",
+            stderr = "",
+            isSuccess = true,
+            processId = 42L
+        )
+
+        val result = executor.executeAgent(agentConfig, null)
+
+        result.isSuccess shouldBe true
+        result.output shouldBe "clean"
+        result.processId shouldBe 42L
+        verify(exactly = 1) { securityValidator.validateCommand(listOf("git", "status")) }
+        coVerify(exactly = 1) {
+            processManager.executeProcess(
+                command = listOf("git", "status"),
+                input = null,
+                environment = emptyMap(),
+                timeout = 1000,
+                workingDirectory = null,
+                onStart = null
+            )
+        }
+    }
+
+    test("should block plugin process execution when central command validation rejects it") {
+        val processManager = mockk<ProcessManager>()
+        val pluginLoader = mockk<PluginLoader>()
+        val securityValidator = mockk<SecurityValidator>()
+        val executor = DefaultAgentExecutor(
+            processManager,
+            pluginLoader,
+            securityValidator,
+            mockk<Logger>(relaxed = true)
+        )
+        val agentConfig = AgentConfig(
+            name = "unsafe-agent",
+            pluginClass = "com.example.UnsafePlugin",
+            timeout = 5000
+        )
+        val plugin = mockk<AgentPlugin>()
+        coEvery { plugin.execute(any(), any()) } coAnswers {
+            secondArg<ProcessManager>().executeProcess(
+                command = listOf("rm", "-rf", "/tmp/cotor-test"),
+                input = null,
+                environment = emptyMap(),
+                timeout = 1000
+            ).let { PluginExecutionOutput(it.stdout, it.processId) }
+        }
+        every { plugin.validateInput(any()) } returns com.cotor.model.ValidationResult.Success
+        every { pluginLoader.loadPlugin(any()) } returns plugin
+        every { securityValidator.validate(any()) } just runs
+        every { securityValidator.validateCommand(listOf("rm", "-rf", "/tmp/cotor-test")) } throws SecurityException("blocked command")
+
+        val result = executor.executeAgent(agentConfig, null)
+
+        result.isSuccess shouldBe false
+        result.error?.contains("blocked command") shouldBe true
+        coVerify(exactly = 0) {
+            processManager.executeProcess(
+                command = any(),
+                input = any(),
+                environment = any(),
+                timeout = any(),
+                workingDirectory = any(),
+                onStart = any()
+            )
+        }
     }
 })

--- a/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
@@ -4,11 +4,21 @@ import com.cotor.model.SecurityConfig
 import com.cotor.model.SecurityException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import kotlin.io.path.createSymbolicLinkPointingTo
 
 class SecurityValidatorTest : FunSpec({
+    test("default security config is defensive for direct service construction") {
+        val config = defaultSecurityConfig()
+
+        config.useWhitelist shouldBe true
+        config.enablePathValidation shouldBe true
+        config.allowedExecutables.contains("opencode") shouldBe true
+        config.allowedExecutables.contains("graphify") shouldBe true
+    }
+
     test("command whitelist accepts absolute executable path by basename") {
         val validator = DefaultSecurityValidator(
             SecurityConfig(allowedExecutables = setOf("qwen")),


### PR DESCRIPTION
## What changed

- Sanitized agent and local-skill subprocess environments so ambient parent-shell secrets such as `OPENAI_API_KEY`, `GITHUB_TOKEN`, `GH_TOKEN`, and `LINEAR_API_TOKEN` are not inherited by child processes.
- Added a shared defensive security config and made `DesktopAppService` use it by default instead of relying on Koin-only production wiring.
- Wrapped the `ProcessManager` passed to plugins from `AgentExecutor`, forcing command validation immediately before any plugin process launch.
- Expanded capability scoping so unscoped global shell, file, agent, skill, worktree, and secret actions cannot bypass company/agent capability evaluation.
- Fixed the packaged macOS app launch path so the bundle opens `CotorDesktopBinary` directly, allowing the SwiftUI window and embedded backend lifecycle to behave as a normal desktop app.
- Updated desktop troubleshooting and E2E checklist wording from launcher-managed ownership to embedded backend ownership.

## Root cause

The previous execution boundary trusted individual plugins to call `validateCommand` and let subprocess launchers inherit or merge too much ambient process state. That made future plugins easy to wire incorrectly and created a risk of leaking local credentials into yolo/auto-approved agent CLIs.

Manual desktop QA also exposed that the packaged app could start the backend while leaving the SwiftUI window inaccessible because the app bundle opened through the shell launcher instead of the GUI binary. The desktop shell already has an embedded backend launcher, so the packaged executable should be the SwiftUI binary.

## Validation

- `./gradlew test --console=plain`
- `swift test --package-path macos`
- `shell/test-desktop-launcher-runtime.sh`
- `graphify update .`
- `shell/update-desktop-app.sh`
- `codesign --verify --deep --strict --verbose=2 '/Applications/Cotor Desktop.app'`
- Installed app smoke: launched `/Applications/Cotor Desktop.app`, verified `CFBundleExecutable=CotorDesktopBinary`, verified `http://127.0.0.1:8787/health`, captured the Cotor window, clicked sidebar navigation into Meeting Room and Performance views, and confirmed closing the window stopped the 8787 embedded backend.
- GitHub CI: `verify-format`, `verify-desktop`, `verify-scripts`, `verify-app-company`, `verify-app-company-runtime`, and all matrix `verify (...)` jobs succeeded.

## Notes

`dist/` and `qa-artifacts/` were left untracked as local verification artifacts and are not part of this PR.
