### PR TITLE
fix(desktop): isolate launcher instance cleanup

### DIFF
--- a/macos/Packaging/CotorDesktopLauncher.sh.template
+++ b/macos/Packaging/CotorDesktopLauncher.sh.template
@@ -313,9 +313,7 @@ terminate_existing_desktop_instances() {
         [[ -n "$pid" ]] || continue
         [[ "$pid" == "$$" ]] && continue
         [[ "$args" == *"$BINARY_PATH"* ||
-            "$args" == *"$SCRIPT_DIR/CotorDesktopLauncher"* ||
-            "$args" == *"/Cotor Desktop.app/Contents/MacOS/CotorDesktopBinary"* ||
-            "$args" == *"/Cotor Desktop.app/Contents/MacOS/CotorDesktopLauncher"* ]] || continue
+            "$args" == *"$SCRIPT_DIR/CotorDesktopLauncher"* ]] || continue
         existing_pids+=("$pid")
     done < <(ps -axo pid=,args=)
 

--- a/shell/test-desktop-launcher-runtime.sh
+++ b/shell/test-desktop-launcher-runtime.sh
@@ -139,10 +139,10 @@ terminate_existing_desktop_instances
 
 if [[ "$terminated_instances" != *"123"* ||
   "$terminated_instances" != *"124"* ||
-  "$terminated_instances" != *"126"* ||
-  "$terminated_instances" != *"127"* ||
+  "$terminated_instances" == *"126"* ||
+  "$terminated_instances" == *"127"* ||
   "$terminated_instances" == *"125"* ]]; then
-  echo "terminate_existing_desktop_instances did not target only old desktop instances"
+  echo "terminate_existing_desktop_instances did not target only same-bundle desktop instances"
   exit 1
 fi
 


### PR DESCRIPTION
## 발견된 버그

- 설치된 `/Applications/Cotor Desktop.app`을 직접 실행해 수동 QA하던 중 `CotorDesktopLauncher`가 다른 워크트리의 `Cotor Desktop.app` 인스턴스까지 종료하는 충돌을 확인했습니다.
- 원인은 `terminate_existing_desktop_instances()`가 `*/Cotor Desktop.app/Contents/MacOS/CotorDesktopBinary` 및 `*/Cotor Desktop.app/Contents/MacOS/CotorDesktopLauncher`를 와일드카드로 매칭해, 현재 번들이 아닌 다른 에이전트/워크트리 실행 앱까지 종료 대상에 넣는 구조였습니다.
- 이 동작은 여러 Cotor 작업을 동시에 돌릴 때 사용자/다른 에이전트의 실행 중인 desktop QA를 깨뜨립니다.

## 수정 내용

- `macos/Packaging/CotorDesktopLauncher.sh.template`의 duplicate-instance cleanup 대상을 현재 launcher의 exact `BINARY_PATH` 및 exact `SCRIPT_DIR/CotorDesktopLauncher`로 제한했습니다.
- 같은 번들에서 재실행할 때 기존 인스턴스를 교체하는 동작은 유지하고, 다른 번들/워크트리의 `Cotor Desktop.app`은 종료하지 않도록 `shell/test-desktop-launcher-runtime.sh` 회귀 테스트 기대값을 갱신했습니다.

## 재테스트 결과

- 직접 실행/클릭 QA:
  - `/Applications/Cotor Desktop.app` 재설치 후 실행 확인
  - embedded backend health 확인: `ok=true`, `version=1.0.6`
  - 격리 HOME에서 설치본 UI 실행 후 Company, Meeting Room, Operator Chat, Goals, Reports, Issues 화면을 실제 버튼 클릭으로 확인
  - QA 중 launcher가 다른 워크트리 앱을 종료하는 충돌을 발견했고 본 PR에서 수정
- `bash shell/test-desktop-launcher-runtime.sh` ✅
- `swift build` in `macos/` ✅
- `node --test .github/scripts/*.test.js` ✅
- Homebrew/Cask metadata version check ✅
- `graphify update .` ✅
- `./gradlew --no-daemon test --tests 'com.cotor.app.AppServerTest' --rerun-tasks --stacktrace` ✅
- `./gradlew --no-daemon clean formatCheck test --rerun-tasks --stacktrace` ✅
  - `tests=901 failures=0 errors=0 skipped=0`

## 문서

- 사용자 노출 명령/제품 동작 문서 변경은 없습니다. 런처의 충돌 범위를 좁히는 패키징 안전성 수정입니다.

## 리스크

- 같은 bundle path에서 중복 실행된 기존 인스턴스는 계속 종료됩니다.
- 다른 bundle path에서 실행된 앱은 더 이상 종료하지 않으므로, 각 번들은 자신의 app home/backend isolation을 책임져야 합니다.
