### PR TITLE
fix(qa): automate desktop update verification and ship flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ Thank you for contributing to Cotor.
 - [ ] Describe **what changed** and **why**.
 - [ ] Run relevant tests or checks locally.
 - [ ] Keep docs aligned with behavior changes.
+- [ ] For desktop install/update changes, run `cotor update --verify` or `shell/update-desktop-app.sh --verify` and include the installed-app smoke result.
+- [ ] For self-merge delivery, prefer `shell/cotor-merge-pr.sh --wait --delete-branch <pr>` so the base branch is pulled in the worktree that owns it.
 - [ ] If source layout, route payloads, public import paths, or configuration paths changed, update `docs/ARCHITECTURE.md`, `docs/modules/README.md`, and add a migration note or compatibility statement.
 - [ ] Run `graphify update .` after source or documentation changes; run `graphify cluster-only .` after large boundary changes.
 - [ ] AI agents follow `AGENTS.md` when changing code, docs, tests, or workflows.
@@ -52,6 +54,8 @@ Cotor에 기여해 주셔서 감사합니다.
 - [ ] **무엇이** 변경되었는지와 **왜** 변경했는지 설명합니다.
 - [ ] 관련 테스트/점검을 로컬에서 실행합니다.
 - [ ] 동작 변경 시 문서도 함께 맞춰 갱신합니다.
+- [ ] 데스크톱 설치/업데이트를 바꿨다면 `cotor update --verify` 또는 `shell/update-desktop-app.sh --verify`를 실행하고 설치 앱 smoke 결과를 남깁니다.
+- [ ] 자체 머지 전달에는 `shell/cotor-merge-pr.sh --wait --delete-branch <pr>`를 우선 사용해서 base branch가 해당 branch를 소유한 worktree에서 pull되게 합니다.
 - [ ] 소스 구조, route payload, public import path, config path를 바꿨다면 `docs/ARCHITECTURE.md`, `docs/modules/README.md`를 갱신하고 migration note 또는 compatibility statement를 남깁니다.
 - [ ] source 또는 documentation 변경 후 `graphify update .`를 실행합니다. 큰 경계 변경 뒤에는 `graphify cluster-only .`도 실행합니다.
 - [ ] AI 에이전트는 코드, 문서, 테스트, 워크플로 변경 시 `AGENTS.md`를 따릅니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -98,8 +98,13 @@ JDK 17과 CLI가 함께 설치되며, 번들된 데스크톱 앱도 포함됩니
 업데이트:
 
 ```bash
-brew upgrade bssm-oss/cotor/cotor
+cotor update --verify
+# 또는: cotor upgrade --verify
 ```
+
+packaged install에서는 `cotor update --verify`가 Homebrew formula를 업그레이드하고,
+번들된 데스크톱 앱을 Applications에 복사한 뒤 codesign, 설치 앱 실행, `/health`
+확인을 이어서 수행합니다.
 
 ### DMG 직접 다운로드
 
@@ -155,7 +160,8 @@ open "/Applications/Cotor Desktop.app"
 
 ```bash
 cotor install   # 처음 설치
-cotor update    # 업데이트
+cotor update --verify
+cotor upgrade --verify
 cotor delete    # 삭제
 ```
 
@@ -163,6 +169,7 @@ cotor delete    # 삭제
 - 소스 설치: `cotor install`이 로컬에서 빌드 후 설치
 - `cotor install`은 정확한 설치 경로를 출력
 - `/Applications`에 쓸 수 없으면 `~/Applications` 사용
+- 설정 화면에서 현재 backend owner, build, 가능한 경우 source commit, health, 설치 앱 경로, Homebrew update 여부를 확인할 수 있습니다.
 
 현재 데스크톱 셸 구조:
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,13 @@ Run `cotor install` after `brew install` to copy `Cotor Desktop.app` into Applic
 Update:
 
 ```bash
-brew upgrade bssm-oss/cotor/cotor
+cotor update --verify
+# or: cotor upgrade --verify
 ```
+
+For packaged installs, `cotor update --verify` upgrades the Homebrew formula,
+copies the bundled desktop app into Applications, verifies codesign, launches
+the installed app, and checks `/health`.
 
 ### Direct DMG Download
 
@@ -150,7 +155,8 @@ After `brew install cotor`, install the packaged desktop app with:
 
 ```bash
 cotor install    # Install bundled app from Homebrew package
-cotor update     # Reinstall bundled app from Homebrew package
+cotor update --verify
+cotor upgrade --verify
 cotor delete     # Remove app
 ```
 
@@ -160,6 +166,8 @@ that starter intentionally falls back to `example-agent` echo mode instead of fa
 If you run `cotor` inside a repo that already contains `./cotor.yaml`, that local config still wins.
 
 From a source checkout, the same commands still rebuild the desktop app locally before installing it.
+The Settings screen shows the current backend owner, build, source commit when
+available, health, installed app path, and whether Homebrew reports an update.
 
 Current desktop model:
 

--- a/docs/DESKTOP_APP.ko.md
+++ b/docs/DESKTOP_APP.ko.md
@@ -16,6 +16,7 @@ cotor install
 
 - Homebrew 패키지에는 `Cotor Desktop.app` 번들이 함께 들어 있습니다.
 - `cotor install`, `cotor update`는 Homebrew prefix 안에서 재빌드하지 않고, 패키지된 번들을 그대로 재사용합니다.
+- `cotor update --verify`, `cotor upgrade --verify`는 설치본 smoke check도 함께 실행합니다. 이 check는 codesign 검증, 설치 앱 실행, `/health` 확인으로 구성됩니다.
 - packaged install에서 로컬 config가 없을 때 `cotor` 인터랙티브 starter config는 `~/.cotor/interactive/default/cotor.yaml` 아래에 생성됩니다.
 - packaged 설치와 첫 실행 규칙은 [HOMEBREW_INSTALL.md](HOMEBREW_INSTALL.md)를 보면 됩니다.
 
@@ -29,7 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/bssm-oss/cotor/master/shell/brew-in
 
 ```bash
 cotor install
-cotor update
+cotor update --verify
 cotor delete
 ```
 
@@ -101,20 +102,26 @@ open "/Applications/Cotor Desktop.app" || open "$HOME/Applications/Cotor Desktop
 마지막 데스크톱 창을 닫으면 앱도 종료되고 번들 백엔드도 같이 내려갑니다.
 
 ```bash
-cotor update
+cotor update --verify
+cotor upgrade --verify
 cotor delete
 ```
 
 `cotor delete`는 표준 `/Applications`, `~/Applications`, 다운로드 산출물을 지웁니다. `COTOR_DESKTOP_INSTALL_ROOT`가 설정되어 있으면 그 override 설치 루트의 `Cotor Desktop.app`도 함께 제거합니다.
+CI나 로컬 source-checkout 검증에서는 `shell/update-desktop-app.sh --verify` 뒤에
+`shell/test-installed-desktop-app.sh`를 실행하면 같은 설치 앱, codesign, 실행, `/health`
+경로를 확인할 수 있습니다.
 
 ### 설치 레이아웃별 차이
 
 - **Homebrew / packaged install**
   - 패키지 안에 들어 있는 데스크톱 번들을 복사합니다.
+  - `cotor update --verify`는 Homebrew formula를 업그레이드한 뒤 번들 앱 복사와 설치 앱 검증까지 수행합니다.
   - 런타임 시점에 Gradle/Swift 재빌드는 하지 않습니다.
   - 브라우저 스킬은 번들을 `COTOR_PREBUNDLE_PLAYWRIGHT=1`로 빌드했을 때 포함된 Playwright를 사용합니다. 런타임 `npm install`은 `COTOR_BROWSER_SKILL_ALLOW_NPM_INSTALL=1`을 명시적으로 설정한 경우에만 허용됩니다.
 - **소스 체크아웃**
   - 로컬에서 번들을 다시 빌드한 뒤 설치합니다.
+  - `shell/update-desktop-app.sh --verify`는 재빌드, 재설치, codesign 검증, 설치 앱 실행, `/health` 확인을 한 번에 수행합니다.
   - 소스 빌드는 `COTOR_PREBUNDLE_PLAYWRIGHT=1`로 Playwright를 미리 포함하거나 `COTOR_BROWSER_SKILL_NODE_PATH`로 기존 의존성 경로를 지정할 수 있습니다.
 
 ## 현재 셸 모델
@@ -180,6 +187,7 @@ cotor delete
 현재 company-first 라우트:
 
 - `GET /api/app/metrics`
+- `GET /api/app/update-status`
 - `GET /api/app/companies`
 - `POST /api/app/companies`
 - `GET /api/app/companies/{companyId}`

--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -12,6 +12,8 @@ cotor install         # Copies Cotor Desktop.app into Applications
 
 The Homebrew package carries a bundled `Cotor Desktop.app` asset. `cotor install`
 and `cotor update` reuse that packaged bundle instead of rebuilding from the Homebrew prefix.
+`cotor update --verify` and `cotor upgrade --verify` also run the installed-app
+smoke check: codesign verification, installed app launch, and `/health`.
 When `cotor` launches interactive mode with no local config in packaged installs, it writes the
 starter config under `~/.cotor/interactive/default/cotor.yaml`.
 See `docs/HOMEBREW_INSTALL.md` for the full packaged-install and first-run behavior.
@@ -26,7 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/bssm-oss/cotor/master/shell/brew-in
 
 ```bash
 cotor install    # Build + install to /Applications
-cotor update     # Rebuild + reinstall
+cotor update --verify
 cotor delete     # Remove app
 ```
 
@@ -98,20 +100,26 @@ Closing the last desktop window quits the app and shuts down the bundled backend
 You can update or remove the installed bundle from the CLI:
 
 ```bash
-cotor update
+cotor update --verify
+cotor upgrade --verify
 cotor delete
 ```
 
 `cotor delete` removes the standard `/Applications`, `~/Applications`, and download artifacts. When `COTOR_DESKTOP_INSTALL_ROOT` is set, it also removes `Cotor Desktop.app` from that override install root.
+For CI or local source-checkout verification, run `shell/test-installed-desktop-app.sh`
+after `shell/update-desktop-app.sh --verify` to exercise the same installed app,
+codesign, launch, and `/health` path.
 
 Behavior depends on the install layout:
 
 - Homebrew / packaged install
   - `cotor install` and `cotor update` copy the packaged desktop bundle from the install root
+  - `cotor update --verify` upgrades the Homebrew formula before copying the bundled app and verifying the installed app
   - no Gradle or Swift rebuild happens at runtime
   - browser skills use prebundled Playwright when the bundle was built with `COTOR_PREBUNDLE_PLAYWRIGHT=1`; runtime `npm install` is disabled unless `COTOR_BROWSER_SKILL_ALLOW_NPM_INSTALL=1` is explicitly set
 - Source checkout
   - `cotor install` and `cotor update` rebuild the desktop bundle locally, then install it
+  - `shell/update-desktop-app.sh --verify` rebuilds, reinstalls, verifies codesign, launches the installed app, and checks `/health`
   - source builds can prebundle Playwright with `COTOR_PREBUNDLE_PLAYWRIGHT=1` or point the backend at an existing dependency with `COTOR_BROWSER_SKILL_NODE_PATH`
 
 ## Current Shell Model
@@ -173,6 +181,7 @@ The current macOS shell has two top-level modes.
 Current company-first routes:
 
 - `GET /api/app/metrics`
+- `GET /api/app/update-status`
 - `GET /api/app/companies`
 - `POST /api/app/companies`
 - `GET /api/app/companies/{companyId}`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - cotor-qa-gradle-coverage-20260604  (2026-06-04)
+# Graph Report - cotor  (2026-06-08)
 
 ## Corpus Check
-- 394 files · ~1,499,347 words
+- 403 files · ~747,227 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5189 nodes · 7146 edges · 329 communities detected
-- Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 917 edges (avg confidence: 0.8)
+- 5291 nodes · 7392 edges · 329 communities detected
+- Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 997 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -52,7 +52,7 @@
 - [[_COMMUNITY_Community 39|Community 39]]
 - [[_COMMUNITY_Community 40|Community 40]]
 - [[_COMMUNITY_Community 41|Community 41]]
-- [[_COMMUNITY_Community 42|Community 42]]
+- [[_COMMUNITY_Community 43|Community 43]]
 - [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 46|Community 46]]
@@ -168,7 +168,7 @@
 - [[_COMMUNITY_Community 156|Community 156]]
 - [[_COMMUNITY_Community 157|Community 157]]
 - [[_COMMUNITY_Community 158|Community 158]]
-- [[_COMMUNITY_Community 159|Community 159]]
+- [[_COMMUNITY_Community 160|Community 160]]
 - [[_COMMUNITY_Community 161|Community 161]]
 - [[_COMMUNITY_Community 162|Community 162]]
 - [[_COMMUNITY_Community 163|Community 163]]
@@ -181,7 +181,6 @@
 - [[_COMMUNITY_Community 170|Community 170]]
 - [[_COMMUNITY_Community 171|Community 171]]
 - [[_COMMUNITY_Community 172|Community 172]]
-- [[_COMMUNITY_Community 173|Community 173]]
 - [[_COMMUNITY_Community 174|Community 174]]
 - [[_COMMUNITY_Community 175|Community 175]]
 - [[_COMMUNITY_Community 176|Community 176]]
@@ -209,11 +208,11 @@
 - [[_COMMUNITY_Community 198|Community 198]]
 - [[_COMMUNITY_Community 199|Community 199]]
 - [[_COMMUNITY_Community 200|Community 200]]
+- [[_COMMUNITY_Community 201|Community 201]]
 - [[_COMMUNITY_Community 202|Community 202]]
 - [[_COMMUNITY_Community 203|Community 203]]
 - [[_COMMUNITY_Community 204|Community 204]]
 - [[_COMMUNITY_Community 205|Community 205]]
-- [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
 - [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
@@ -336,21 +335,22 @@
 - [[_COMMUNITY_Community 328|Community 328]]
 - [[_COMMUNITY_Community 329|Community 329]]
 - [[_COMMUNITY_Community 330|Community 330]]
-- [[_COMMUNITY_Community 333|Community 333]]
-- [[_COMMUNITY_Community 336|Community 336]]
+- [[_COMMUNITY_Community 331|Community 331]]
+- [[_COMMUNITY_Community 334|Community 334]]
 - [[_COMMUNITY_Community 337|Community 337]]
+- [[_COMMUNITY_Community 338|Community 338]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `DesktopStore` - 260 edges
+1. `DesktopStore` - 261 edges
 2. `DesktopTextKey` - 128 edges
-3. `DesktopAPI` - 114 edges
+3. `DesktopAPI` - 115 edges
 4. `CodingKeys` - 106 edges
 5. `GitWorkspaceService` - 79 edges
 6. `DesktopStateStore` - 77 edges
 7. `DesktopStoreTests` - 71 edges
-8. `language` - 60 edges
-9. `Data` - 36 edges
-10. `ModelsTests` - 35 edges
+8. `language` - 61 edges
+9. `Data` - 38 edges
+10. `ModelsTests` - 36 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `makeFallbackIcon()` --calls--> `Line`  [INFERRED]
@@ -361,8 +361,8 @@
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/UserFacingTextFormatters.swift
 - `language` --calls--> `localizedSourceKind()`  [INFERRED]
   macos/Sources/CotorDesktopApp/Localization.swift → macos/Sources/CotorDesktopApp/UserFacingTextFormatters.swift
-- `sceneState()` --calls--> `PixelOfficeLayout`  [INFERRED]
-  macos/Tests/CotorDesktopAppTests/MeetingRoomProjectionTests.swift → macos/Sources/CotorDesktopApp/MeetingRoomScene.swift
+- `N까지의 모든 소수를 찾는 함수 (에라토스테네스의 체 알고리즘 사용)      :param n: 소수를 찾을 범위의 상한값 (n > 1)` --rationale_for--> `find_primes()`  [EXTRACTED]
+  test-gemini/test/results/primes.py → test/results/primes.py
 
 ## Communities
 
@@ -372,55 +372,55 @@ Nodes (59): BrowserTarget, CachedAgentModels, CachedPullRequestMetadata, CeoChat
 
 ### Community 1 - "Community 1"
 Cohesion: 0.02
-Nodes (41): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), companyEvents(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime() (+33 more)
+Nodes (43): CompanyMarketingDashboardProjection, availableAgentModels(), companyDashboard(), dashboard(), runIssue(), startCompanyRuntime(), stopCompanyRuntime(), updateGoal() (+35 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.01
-Nodes (141): App, ButtonStyle, Commands, AgentSkillCardView, AgentWorkSummaryRow, Array, CenterPaneView, CloneRepositorySheet (+133 more)
+Cohesion: 0.02
+Nodes (35): A2aArtifactStore, runSkill(), settings(), DirectChatMessage, BoundedDesktopCommandOutput, AgentSkillCardRecord, APIError, http (+27 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.02
-Nodes (190): CaseIterable, Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly (+182 more)
+Cohesion: 0.01
+Nodes (157): App, ButtonStyle, CaseIterable, Commands, AgentSkillCardView, AgentWorkSummaryRow, CenterPaneView, CloneRepositorySheet (+149 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (37): RetryingFileChannel, Line, runSkill(), BoundedDesktopCommandOutput, APIError, http, ConfigureGitHubOriginPayload, Data (+29 more)
+Nodes (231): Codable, AgentSkillChipRecord, AgentSkillPolicy, approvalRequired, auto, disabled, readOnly, AgentSkillScope (+223 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (99): AppLanguage, english, korean, AppTheme, dark, light, system, DesktopStrings (+91 more)
+Nodes (40): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, Scanner, AppLogger (+32 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.02
-Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
+Cohesion: 0.01
+Nodes (130): AppLanguage, english, korean, DesktopStrings, DesktopTextKey, agentRuns, agentRunsSubtitle, agents (+122 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (119): DirectChatMessage, CodingKey, DirectChatView, CodingKeys, community, confidenceScore, fileType, id (+111 more)
+Nodes (64): CompanyAgentAddCommand, CompanyAgentBatchUpdateCommand, CompanyAgentCapabilitiesCommand, CompanyAgentCapabilitySetCommand, CompanyAgentCommand, CompanyAgentListCommand, CompanyAgentUpdateCommand, CompanyAutonomyCommand (+56 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (126): DesktopTextKey, agentRuns, agentRunsSubtitle, agents, appHome, appLocation, appName, availableAgents (+118 more)
+Nodes (124): CodingKey, EmbeddedBackendHealthPayload, CodingKeys, community, confidenceScore, fileType, label, relation (+116 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
+Nodes (52): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand (+44 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+72 more)
+Nodes (59): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel, RetryingFileChannel, AutonomousDiscoveryScanResult, AutonomousDiscoveryService, Line, ShellConnectionState (+51 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.04
-Nodes (17): ResumeApproveCommand, ResumeCommand, ResumeContinueCommand, ResumeForkCommand, ResumeInspectCommand, Parser, EmbeddedBackendLauncher, isBackendRuntimeJar() (+9 more)
+Cohesion: 0.02
+Nodes (13): BaseBranchSyncResult, BranchRestackResult, GitHubPublishEnvironment, GitHubPublishReadiness, GitHubRepositoryRef, GitWorkspaceService, ManagedPullRequestCleanupResult, MergeCommitRef (+5 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.02
-Nodes (40): BrowserCommand, BrowserSmokeCommand, CapabilityCommand, CapabilityInspectCommand, CapabilityListCommand, CapabilitySimulateCommand, EvidenceCommand, EvidenceFileCommand (+32 more)
+Nodes (80): AgentAssignmentPlan, AgentCollaborationEdge, AgentContextEntry, AgentMessage, AgentPerformanceDataSufficiency, AgentPerformanceSnapshot, AgentRun, AgentRunStatus (+72 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.03
-Nodes (1): DesktopStateStore
+Cohesion: 0.02
+Nodes (4): CachedState, DesktopStateStore, SqliteCachedState, StateCollection
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
@@ -432,79 +432,79 @@ Nodes (16): OrgProfileBatchEditPayloadDraft, Entry, MeetingRoomSceneLedger, Meet
 
 ### Community 16 - "Community 16"
 Cohesion: 0.04
-Nodes (28): CachedState, SqliteCachedState, StateCollection, Scanner, DesktopAppLifecycleDelegate, containsInternalMemoryDetail(), issueTitle(), labeledLineValue() (+20 more)
+Nodes (55): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+47 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (7): A2aArtifactStore, settings(), AgentSkillCardRecord, CompanyEventStreamBackoff, isExpectedCompanyEventStreamInterruption(), AgentCapabilitySettingRecord, DesktopStoreTests
-
-### Community 18 - "Community 18"
-Cohesion: 0.04
-Nodes (54): BatchUpdateCompanyAgentDefinitionsRequest, BudgetResponse, ChatAssignmentPreview, ChatIntakeRequest, ChatIntakeResponse, CloneRepositoryRequest, CompanyDashboardResponse, CompanyEventEnvelope (+46 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.09
-Nodes (5): AppLogger, MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AppLoggerTests
-
-### Community 20 - "Community 20"
 Cohesion: 0.04
 Nodes (41): AgentConfig, AgentExecutionMetadata, AgentMetadata, AgentMetrics, AgentReference, AgentResult, AggregatedResult, BackoffStrategy (+33 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (14): A2aSessionStore, BuiltinAgentCatalog, BuiltinAgentSpec, VideoBaseCommand, LinearPrFailureGateTest, KnowledgeStore, build_issue_update_input(), call_linear() (+6 more)
+### Community 18 - "Community 18"
+Cohesion: 0.07
+Nodes (11): runTask(), DesktopAppServiceRuntimeCleanupTest, issue(), StartupRecordingBrowserSkillRunner, task(), DesktopAPIClient, DesktopAPIError, http (+3 more)
 
-### Community 22 - "Community 22"
+### Community 19 - "Community 19"
+Cohesion: 0.12
+Nodes (6): MeetingRoomSceneReducer, PixelOfficeLayout, PixelOfficeCanvas, AgentRunStatus, Color, DesktopTaskStatus
+
+### Community 20 - "Community 20"
 Cohesion: 0.05
 Nodes (5): DefaultObservabilityService, NoopObservabilityService, ObservabilityService, ObservationHandle, TraceContext
 
-### Community 23 - "Community 23"
+### Community 21 - "Community 21"
 Cohesion: 0.06
 Nodes (12): CheatSheetPrinter, CheckpointCommand, CliHelpLanguage, CompletionCommand, CotorCli, CotorCommand, HelpCommand, InitCommand (+4 more)
 
-### Community 24 - "Community 24"
+### Community 22 - "Community 22"
 Cohesion: 0.06
 Nodes (8): ConcurrentGitMutationProcessManager, FakeHttpClient, FakeHttpResponse, FakeHttpResponseSpec, FakeProcessManager, GitWorkspaceServiceTest, RecordedHttpRequest, Step
 
-### Community 25 - "Community 25"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (7): AppServer, DesktopAppServerInstanceGuard, DesktopAppServerInstanceMetadata, DesktopAppServerInstanceStatus, DesktopAppServerLockRecord, IssueAssigneeUpdateRequest, ReviewQueueVerdictRequest
 
-### Community 26 - "Community 26"
+### Community 24 - "Community 24"
 Cohesion: 0.06
 Nodes (2): DesktopTuiSessionService, RuntimeSession
 
-### Community 27 - "Community 27"
+### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (4): DecisionStageResult, DefaultPipelineOrchestrator, LoopStageResult, PipelineOrchestrator
 
-### Community 28 - "Community 28"
+### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (11): AgentResultPayload, ConfigResponse, EditorPipelineDetail, EditorPipelineRequest, EditorPipelineSummary, EditorStagePayload, EditorTemplatePayload, RunResponse (+3 more)
 
-### Community 29 - "Community 29"
+### Community 27 - "Community 27"
 Cohesion: 0.07
 Nodes (8): CommandCall, CommentCall, DesktopAppServiceFixture, DesktopAppServiceTest, FakeGitProcessManager, FakeLinearTrackerAdapter, LateProcessStartAgentExecutor, SyncCall
 
-### Community 30 - "Community 30"
+### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (3): DurableRunIndex, DurableRunIndexEntry, DurableRuntimeStore
 
-### Community 31 - "Community 31"
+### Community 29 - "Community 29"
 Cohesion: 0.07
 Nodes (2): GoalDrivenTaskPlanner, PlanningParticipant
 
-### Community 32 - "Community 32"
+### Community 30 - "Community 30"
+Cohesion: 0.1
+Nodes (10): DesktopAppLifecycleDelegate, Coordinator, SessionConfig, TerminalWebView, WebView, KnowledgeStore, NSApplicationDelegate, NSObject (+2 more)
+
+### Community 31 - "Community 31"
 Cohesion: 0.08
 Nodes (23): A2aAck, A2aAckMessagesRequest, A2aAckMessagesResponse, A2aAckResponse, A2aArtifactListResponse, A2aArtifactRegistration, A2aArtifactRegistrationRequest, A2aArtifactRegistrationResponse (+15 more)
 
-### Community 33 - "Community 33"
+### Community 32 - "Community 32"
 Cohesion: 0.08
 Nodes (1): InteractiveCommand
 
-### Community 34 - "Community 34"
+### Community 33 - "Community 33"
 Cohesion: 0.08
 Nodes (1): A2aRouter
+
+### Community 34 - "Community 34"
+Cohesion: 0.15
+Nodes (3): Array, MeetingRoomAgentResolver, MeetingRoomProjection
 
 ### Community 35 - "Community 35"
 Cohesion: 0.09
@@ -519,12 +519,12 @@ Cohesion: 0.1
 Nodes (3): CompanyRuntimeRetention, RetentionScope, WorktreeReferences
 
 ### Community 38 - "Community 38"
-Cohesion: 0.1
-Nodes (3): ActionLogIndex, ActionLogIndexEntry, ActionStore
+Cohesion: 0.11
+Nodes (1): DurableRuntimeService
 
 ### Community 39 - "Community 39"
 Cohesion: 0.11
-Nodes (1): DurableRuntimeService
+Nodes (3): ActionLogIndex, ActionLogIndexEntry, ActionStore
 
 ### Community 40 - "Community 40"
 Cohesion: 0.11
@@ -534,121 +534,121 @@ Nodes (9): ExecutionStatus, PerformanceTrend, PipelineExecution, PipelineStats, 
 Cohesion: 0.11
 Nodes (6): EstimatedDuration, Failure, PipelineValidator, StageEstimate, Success, ValidationResult
 
-### Community 42 - "Community 42"
-Cohesion: 0.11
-Nodes (3): AppServerInstanceGuardTest, FakeFileLock, IOExceptionFileChannel
-
-### Community 44 - "Community 44"
+### Community 43 - "Community 43"
 Cohesion: 0.11
 Nodes (1): TemplateCommand
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (2): ConfigRepository, ParsedConfig
 
-### Community 46 - "Community 46"
-Cohesion: 0.12
-Nodes (3): BoundedOutputBuffer, CoroutineProcessManager, ProcessManager
-
-### Community 47 - "Community 47"
+### Community 45 - "Community 45"
 Cohesion: 0.12
 Nodes (5): InteractiveAgentSummary, InteractiveSessionLogger, InteractiveTurnException, InteractiveTurnLogContext, InteractiveTurnOutcome
 
-### Community 48 - "Community 48"
+### Community 46 - "Community 46"
 Cohesion: 0.12
 Nodes (4): CheckpointManager, CheckpointSummary, PipelineCheckpoint, StageCheckpoint
 
-### Community 49 - "Community 49"
+### Community 47 - "Community 47"
 Cohesion: 0.12
 Nodes (1): AgentCapabilityGuard
 
-### Community 50 - "Community 50"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (4): CodexAppServerManager, ManagedCodexServerStatus, ManagedProcess, PreparedManagedLaunch
 
-### Community 51 - "Community 51"
+### Community 49 - "Community 49"
 Cohesion: 0.12
 Nodes (1): RecoveryExecutor
 
-### Community 52 - "Community 52"
+### Community 50 - "Community 50"
+Cohesion: 0.12
+Nodes (3): BoundedOutputBuffer, CoroutineProcessManager, ProcessManager
+
+### Community 51 - "Community 51"
 Cohesion: 0.12
 Nodes (5): GuardTextSample, PipelineGuardFinding, PipelineGuardResult, PipelineGuardService, PipelineGuardSeverity
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.12
 Nodes (3): DesktopInstallAction, DesktopInstallLayout, DesktopInstallLayoutKind
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.12
 Nodes (1): StarterAgentSpec
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.13
 Nodes (3): DesktopAppServiceRequeueOrphanedTest, NoopLinearTrackerAdapter, RequeueGitProcessManager
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (4): DefaultLinearTrackerAdapter, LinearClient, LinearIssueMirror, LinearTrackerAdapter
 
-### Community 57 - "Community 57"
+### Community 56 - "Community 56"
 Cohesion: 0.13
 Nodes (1): ConditionEvaluator
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.13
 Nodes (6): AuthCommand, CodexOAuthBaseCommand, CodexOAuthCommand, CodexOAuthLoginCommand, CodexOAuthLogoutCommand, CodexOAuthStatusCommand
 
-### Community 59 - "Community 59"
+### Community 58 - "Community 58"
 Cohesion: 0.14
 Nodes (1): BoardControllerTest
 
-### Community 60 - "Community 60"
+### Community 59 - "Community 59"
 Cohesion: 0.14
 Nodes (6): CodexAppServerBackend, ExecutionBackend, ExecutionBackendRequest, LocalCotorBackend, RemoteExecutionRequest, RemoteExecutionResponse
 
-### Community 61 - "Community 61"
+### Community 60 - "Community 60"
 Cohesion: 0.14
 Nodes (11): MarketingActionRecord, MarketingActionStatus, MarketingBrowserCommand, MarketingBrowserResult, MarketingBrowserRunner, MarketingChannelAccount, MarketingDelegationPolicy, MarketingRunRecord (+3 more)
 
-### Community 62 - "Community 62"
+### Community 61 - "Community 61"
 Cohesion: 0.14
 Nodes (2): BoundedDirectChatLineReader, DirectChatService
 
-### Community 63 - "Community 63"
+### Community 62 - "Community 62"
 Cohesion: 0.14
 Nodes (2): DefaultSecurityValidator, SecurityValidator
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.14
 Nodes (13): ApprovalPauseState, ApprovalPauseStatus, CheckpointNode, CheckpointNodeState, DurableExecutionPlan, DurableRunSnapshot, DurableRunStatus, DurableRunSummary (+5 more)
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.14
 Nodes (3): ActionExecutionService, ActionInterceptor, ActionInterceptorDecision
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.14
 Nodes (5): AgentAddCommand, AgentCommand, AgentListCommand, AgentPreset, InstallScope
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (3): LocalSkillOutputBuffer, LocalSkillProcessResult, LocalSkillProcessRunner
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.15
 Nodes (4): BrowserSkillCommand, BrowserSkillResult, BrowserSkillRunner, LocalPlaywrightBrowserSkillRunner
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.15
 Nodes (12): ActionApprovalRequiredException, ActionDeniedException, ActionEvidence, ActionExecutionRecord, ActionKind, ActionLogSnapshot, ActionLogSummary, ActionRequest (+4 more)
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.15
 Nodes (2): AgentRegistry, InMemoryAgentRegistry
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.15
 Nodes (4): AgentExecutor, CommandValidatingProcessManager, DefaultAgentExecutor, RuntimeServices
+
+### Community 71 - "Community 71"
+Cohesion: 0.17
+Nodes (12): MeetingRoomSpriteAction, approving, blocked, celebrating, listening, reviewing, sitting, stretching (+4 more)
 
 ### Community 72 - "Community 72"
 Cohesion: 0.17
@@ -696,75 +696,75 @@ Nodes (1): TemplateEngineTest
 
 ### Community 83 - "Community 83"
 Cohesion: 0.18
-Nodes (3): DesktopAppServiceRuntimeCleanupTest, issue(), StartupRecordingBrowserSkillRunner
+Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
 
 ### Community 84 - "Community 84"
 Cohesion: 0.18
-Nodes (2): AgentPerformanceCalculator, AgentPerformanceSubject
+Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
-Nodes (8): AgentCapabilityProfile, AgentCapabilitySetting, CapabilityCatalogEntry, CapabilityKey, CapabilityMode, CapabilitySimulationRequest, CapabilitySimulationResult, UpdateAgentCapabilitiesRequest
+Nodes (1): VerificationBundleService
 
 ### Community 86 - "Community 86"
 Cohesion: 0.18
-Nodes (1): VerificationBundleService
+Nodes (1): ProvenanceService
 
 ### Community 87 - "Community 87"
 Cohesion: 0.18
-Nodes (1): ProvenanceService
+Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
 
 ### Community 88 - "Community 88"
 Cohesion: 0.18
-Nodes (10): AgentExecutionException, ConfigurationException, CotorException, PipelineAbortedException, PipelineException, PluginLoadException, ProcessExecutionException, SecurityException (+2 more)
+Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
 
 ### Community 89 - "Community 89"
 Cohesion: 0.18
-Nodes (3): PipelineRunSnapshot, PipelineRunStatus, PipelineRunTracker
+Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
 
 ### Community 90 - "Community 90"
 Cohesion: 0.18
-Nodes (3): PipelineMonitor, StageExecutionInfo, StageState
+Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
 
 ### Community 91 - "Community 91"
 Cohesion: 0.18
-Nodes (3): BoundedHttpTextResponse, BoundedText, CotorHttpClients
+Nodes (2): ErrorMessages, UserFriendlyError
 
 ### Community 92 - "Community 92"
 Cohesion: 0.18
-Nodes (2): ErrorMessages, UserFriendlyError
+Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
 
 ### Community 93 - "Community 93"
 Cohesion: 0.18
-Nodes (10): AgentCompletedEvent, AgentFailedEvent, AgentStartedEvent, CotorEvent, PipelineCompletedEvent, PipelineFailedEvent, PipelineStartedEvent, StageCompletedEvent (+2 more)
+Nodes (1): StatsCommand
 
 ### Community 94 - "Community 94"
 Cohesion: 0.18
-Nodes (1): StatsCommand
-
-### Community 95 - "Community 95"
-Cohesion: 0.18
 Nodes (1): DoctorCommand
 
-### Community 96 - "Community 96"
+### Community 95 - "Community 95"
 Cohesion: 0.2
 Nodes (1): LocalPlaywrightDependencyResolver
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.2
 Nodes (9): CheckRollupSnapshot, CheckSnapshot, GitHubProviderEvent, GitHubProviderState, GitHubSyncResponse, MergeQueueState, MergeRequirement, ProviderEventDedupeKey (+1 more)
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.2
 Nodes (1): VerificationStore
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.2
 Nodes (3): NullablePathSerializer, PathListSerializer, PathSerializer
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.2
 Nodes (3): ErrorHelper, ErrorInfo, ErrorType
+
+### Community 100 - "Community 100"
+Cohesion: 0.2
+Nodes (6): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand, UpgradeCommand
 
 ### Community 101 - "Community 101"
 Cohesion: 0.2
@@ -804,253 +804,249 @@ Nodes (1): DesktopDirectChatService
 
 ### Community 110 - "Community 110"
 Cohesion: 0.22
-Nodes (2): AutonomousDiscoveryScanResult, AutonomousDiscoveryService
+Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
 
 ### Community 111 - "Community 111"
 Cohesion: 0.22
-Nodes (3): CompanyIssueReadinessOverrides, CompanyIssueReadinessResolution, CompanyIssueReadinessResolver
+Nodes (3): BoundCompanyRuntime, CachedValue, CompanyRuntimeBindingService
 
 ### Community 112 - "Community 112"
 Cohesion: 0.22
-Nodes (3): BoundCompanyRuntime, CachedValue, CompanyRuntimeBindingService
+Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
 
 ### Community 113 - "Community 113"
 Cohesion: 0.22
-Nodes (8): VerificationArtifactRef, VerificationBundle, VerificationContract, VerificationObservation, VerificationOutcome, VerificationOutcomeStatus, VerificationSignal, VerificationSignalStatus
+Nodes (1): LocalModelDefaults
 
 ### Community 114 - "Community 114"
 Cohesion: 0.22
-Nodes (1): LocalModelDefaults
+Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
 
 ### Community 115 - "Community 115"
 Cohesion: 0.22
-Nodes (3): CodeGeneratorPlugin, EchoPlugin, NaturalLanguageProcessorPlugin
-
-### Community 116 - "Community 116"
-Cohesion: 0.22
 Nodes (3): EnhancedRunCommand, TestCommand, ValidateCommand
 
-### Community 117 - "Community 117"
-Cohesion: 0.22
-Nodes (5): DeleteCommand, DesktopLifecycleCommand, DesktopScriptResult, InstallCommand, UpdateCommand
-
-### Community 118 - "Community 118"
+### Community 116 - "Community 116"
 Cohesion: 0.25
 Nodes (1): BoardController
 
-### Community 119 - "Community 119"
+### Community 117 - "Community 117"
 Cohesion: 0.25
 Nodes (1): GitWorkspaceServiceRealGitIntegrationTest
 
-### Community 120 - "Community 120"
+### Community 118 - "Community 118"
 Cohesion: 0.25
 Nodes (1): LocalModelPluginTest
 
-### Community 121 - "Community 121"
+### Community 119 - "Community 119"
 Cohesion: 0.25
 Nodes (1): DefaultResultAnalyzer
 
-### Community 122 - "Community 122"
+### Community 120 - "Community 120"
 Cohesion: 0.25
 Nodes (5): HelpGuideContent, HelpGuideItem, HelpGuidePayload, HelpGuideSection, HelpGuideTopic
 
-### Community 123 - "Community 123"
+### Community 121 - "Community 121"
+Cohesion: 0.25
+Nodes (2): BrewStatus, UpdateStatusCommandResult
+
+### Community 122 - "Community 122"
 Cohesion: 0.25
 Nodes (1): CompanyIssueReadiness
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (1): ChatSession
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.25
 Nodes (1): GitHubControlPlaneStore
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.25
 Nodes (1): OpenCodeDefaults
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.25
 Nodes (2): JsonParser, YamlParser
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.25
 Nodes (1): ProcessDescendantTracker
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.25
 Nodes (1): DiagramGenerator
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.25
 Nodes (2): Linter, LintResult
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.25
 Nodes (7): PolicyAuditLog, PolicyDecision, PolicyDocument, PolicyEffect, PolicyExplanation, PolicyRule, PolicyScopeLevel
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.29
 Nodes (3): DesktopAppServiceMarketingTest, NoOpMarketingBrowserRunner, RecordingMarketingBrowserRunner
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.29
 Nodes (2): ImmediateEventBus, PipelineRunTrackerTest
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (2): PipelineOrchestratorMapTest, TrackingAgentExecutor
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.29
 Nodes (2): A2aDedupeStore, StoredAck
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.29
 Nodes (2): A2aDedupePersistenceStore, SnapshotEntry
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (2): A2aSessionPersistenceStore, Snapshot
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.29
 Nodes (1): DurableResumeCoordinator
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (6): EvidenceBundle, EvidenceEdge, EvidenceGraph, EvidenceNode, EvidenceNodeKind, EvidenceReference
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.29
 Nodes (1): FileReaderPlugin
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.29
 Nodes (1): OpenAIPlugin
 
-### Community 142 - "Community 142"
+### Community 141 - "Community 141"
 Cohesion: 0.29
 Nodes (1): InteractiveCommandCompleter
 
-### Community 143 - "Community 143"
+### Community 142 - "Community 142"
 Cohesion: 0.29
 Nodes (4): ApprovalRequirement, RiskApprovalInterceptor, RiskScore, RiskSignal
 
-### Community 144 - "Community 144"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (6): StatusState, connected, connecting, offlineMock, taskStarted, waitingForServer
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.33
 Nodes (1): DirectChatServiceTest
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.33
 Nodes (1): DesktopStateStoreTest
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (1): DesktopAppServiceRuntimeDispositionSchedulerTest
 
-### Community 148 - "Community 148"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (1): CompanyRuntimeBindingServiceTest
 
-### Community 149 - "Community 149"
+### Community 148 - "Community 148"
 Cohesion: 0.33
 Nodes (1): ProductionReliabilityBaselineTest
 
-### Community 150 - "Community 150"
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (1): PipelineContextTest
 
-### Community 151 - "Community 151"
+### Community 150 - "Community 150"
 Cohesion: 0.33
 Nodes (3): BlockingProcessManager, CommandPluginTest, RecordingProcessManager
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (2): PipelineOrchestratorConditionalTest, RecordingAgentExecutor
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.33
 Nodes (1): DesktopCommandProcessTest
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (1): AuthCommandTest
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.33
 Nodes (2): CompanyVerificationDecision, CompanyVerifierService
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (1): NetworkEndpointPolicy
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (1): GitHubControlPlaneService
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.33
 Nodes (1): QaVerificationPlugin
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (1): CommandPlugin
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (2): DefaultResultAggregator, ResultAggregator
 
-### Community 162 - "Community 162"
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (1): CodexDashboardCommand
 
-### Community 163 - "Community 163"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (2): PluginCommand, PluginInitCommand
 
-### Community 164 - "Community 164"
+### Community 163 - "Community 163"
 Cohesion: 0.33
 Nodes (1): PolicyEngine
 
-### Community 165 - "Community 165"
+### Community 164 - "Community 164"
 Cohesion: 0.4
 Nodes (1): OpenCodePluginTest
 
-### Community 166 - "Community 166"
+### Community 165 - "Community 165"
 Cohesion: 0.4
 Nodes (2): PromptHandoffPluginTest, RecordingPromptProcessManager
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.4
 Nodes (1): PipelineOrchestratorOutputPropagationTest
 
-### Community 168 - "Community 168"
+### Community 167 - "Community 167"
 Cohesion: 0.4
 Nodes (2): MappedDelayedAgentExecutor, PipelineOrchestratorTimeoutTest
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 0.4
 Nodes (1): CliGoldenSnapshotTest
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.4
 Nodes (1): DesktopEndpointPolicy
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.4
 Nodes (1): EvidencePathPolicy
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.4
 Nodes (1): CompanyRuntimeMachine
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.4
 Nodes (1): WorkQueue
 
@@ -1162,23 +1158,23 @@ Nodes (1): StateRepository
 Cohesion: 0.5
 Nodes (3): ChatMessage, ChatMode, ChatRole
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.5
 Nodes (1): DurableRuntimeFlags
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (3): KnowledgeConflictStatus, KnowledgeRecord, KnowledgeSnapshot
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.5
 Nodes (3): AgentParameter, AgentParameterSchema, ParameterType
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.5
 Nodes (2): TimelineCollector, TimelineResult
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.5
 Nodes (1): StageConflictDetector
 
@@ -1404,318 +1400,320 @@ Nodes (1): DesktopStateStoreLockTest
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): DesktopEndpointPolicyTest
+Nodes (1): DesktopUpdateStatusTest
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): ExecutionBackendsTest
+Nodes (1): DesktopEndpointPolicyTest
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): CodexAppServerManagerTest
+Nodes (1): ExecutionBackendsTest
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceMergeConfirmationTest
+Nodes (1): CodexAppServerManagerTest
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): LocalPlaywrightDependencyTest
+Nodes (1): DesktopAppServiceMergeConfirmationTest
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): DesktopAppServiceDashboardPrCleanupTest
+Nodes (1): LocalPlaywrightDependencyTest
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): AutonomousDiscoveryServiceTest
+Nodes (1): DesktopAppServiceDashboardPrCleanupTest
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): SkillModelsTest
+Nodes (1): AutonomousDiscoveryServiceTest
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): CompanyRuntimeMachineTest
+Nodes (1): SkillModelsTest
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): WorkQueueTest
+Nodes (1): CompanyRuntimeMachineTest
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): ChatTranscriptWriterTest
+Nodes (1): WorkQueueTest
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): ChatSessionTest
+Nodes (1): ChatTranscriptWriterTest
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): NetworkEndpointPolicyTest
+Nodes (1): ChatSessionTest
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): SecurityValidatorTest
+Nodes (1): NetworkEndpointPolicyTest
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): A2aArtifactStoreTest
+Nodes (1): SecurityValidatorTest
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): A2aApiTest
+Nodes (1): A2aArtifactStoreTest
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): A2aSessionStoreTest
+Nodes (1): A2aApiTest
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): A2aPersistenceTest
+Nodes (1): A2aSessionStoreTest
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): A2aDedupeStoreTest
+Nodes (1): A2aPersistenceTest
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): RecoveryExecutorTest
+Nodes (1): A2aDedupeStoreTest
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): GitHubControlPlaneServiceTest
+Nodes (1): RecoveryExecutorTest
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): DurableRuntimeServiceTest
+Nodes (1): GitHubControlPlaneServiceTest
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): DurableResumeCoordinatorTest
+Nodes (1): DurableRuntimeServiceTest
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): AtomicFileWriterTest
+Nodes (1): DurableResumeCoordinatorTest
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): LinearClientEndpointPolicyTest
+Nodes (1): AtomicFileWriterTest
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): VerificationBundleServiceTest
+Nodes (1): LinearClientEndpointPolicyTest
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): KnowledgeServiceTest
+Nodes (1): VerificationBundleServiceTest
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): LocalModelDefaultsTest
+Nodes (1): KnowledgeServiceTest
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): ObservabilityServiceTest
+Nodes (1): LocalModelDefaultsTest
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): FileConfigRepositoryTest
+Nodes (1): ObservabilityServiceTest
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): QaTestGenerationFixtureTest
+Nodes (1): FileConfigRepositoryTest
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): ConfigRepositoryImportTest
+Nodes (1): QaTestGenerationFixtureTest
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): ExampleConfigSmokeTest
+Nodes (1): ConfigRepositoryImportTest
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): YamlParserTest
+Nodes (1): ExampleConfigSmokeTest
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): CodexPluginTest
+Nodes (1): YamlParserTest
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): ProcessManagerTest
+Nodes (1): CodexPluginTest
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): ErrorHelperTest
+Nodes (1): ProcessManagerTest
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): ResultAggregatorTest
+Nodes (1): ErrorHelperTest
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): ConditionEvaluatorTest
+Nodes (1): ResultAggregatorTest
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): AgentExecutorTest
+Nodes (1): ConditionEvaluatorTest
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): StuckDetectorTest
+Nodes (1): AgentExecutorTest
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): PipelineGuardServiceTest
+Nodes (1): StuckDetectorTest
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorDagValidationTest
+Nodes (1): PipelineGuardServiceTest
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): StageConflictDetectorTest
+Nodes (1): PipelineOrchestratorDagValidationTest
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): PipelineOrchestratorTemplatingTest
+Nodes (1): StageConflictDetectorTest
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): CoroutineEventBusTest
+Nodes (1): PipelineOrchestratorTemplatingTest
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): WebServerTest
+Nodes (1): CoroutineEventBusTest
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): CompletionCommandTest
+Nodes (1): WebServerTest
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): HelpCommandTest
+Nodes (1): CompletionCommandTest
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): AppServerCommandTest
+Nodes (1): HelpCommandTest
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): StarterAgentResolverTest
+Nodes (1): AppServerCommandTest
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandCompleterTest
+Nodes (1): StarterAgentResolverTest
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): AgentCommandTest
+Nodes (1): InteractiveCommandCompleterTest
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): PluginCommandTest
+Nodes (1): AgentCommandTest
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (1): HelloCommandTest
+Nodes (1): PluginCommandTest
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (1): LintCommandTest
+Nodes (1): HelloCommandTest
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
-Nodes (1): CompanyCommandTest
+Nodes (1): LintCommandTest
 
 ### Community 321 - "Community 321"
 Cohesion: 1.0
-Nodes (1): InteractiveCommandTest
+Nodes (1): CompanyCommandTest
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (1): StatsCommandTest
+Nodes (1): InteractiveCommandTest
 
 ### Community 323 - "Community 323"
 Cohesion: 1.0
-Nodes (1): CodexDashboardCommandTest
+Nodes (1): StatsCommandTest
 
 ### Community 324 - "Community 324"
 Cohesion: 1.0
-Nodes (1): StatsManagerTest
+Nodes (1): CodexDashboardCommandTest
 
 ### Community 325 - "Community 325"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorTest
+Nodes (1): StatsManagerTest
 
 ### Community 326 - "Community 326"
 Cohesion: 1.0
-Nodes (1): PipelineValidatorExtTest
+Nodes (1): PipelineValidatorTest
 
 ### Community 327 - "Community 327"
 Cohesion: 1.0
-Nodes (1): LinterTest
+Nodes (1): PipelineValidatorExtTest
 
 ### Community 328 - "Community 328"
 Cohesion: 1.0
-Nodes (1): DefaultOutputValidatorTest
+Nodes (1): LinterTest
 
 ### Community 329 - "Community 329"
 Cohesion: 1.0
-Nodes (1): PolicyEngineTest
+Nodes (1): DefaultOutputValidatorTest
 
 ### Community 330 - "Community 330"
 Cohesion: 1.0
+Nodes (1): PolicyEngineTest
+
+### Community 331 - "Community 331"
+Cohesion: 1.0
 Nodes (1): RiskApprovalInterceptorTest
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 1.0
 Nodes (1): CheckpointConfig
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 1.0
 Nodes (1): CotorProperties
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 1.0
 Nodes (1): RealtimeEvent
 
 ## Knowledge Gaps
-- **1016 isolated node(s):** `repositoryMap`, `browserQA`, `marketing`, `video`, `videoRender` (+1011 more)
+- **1038 isolated node(s):** `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus`, `local`, `cloned` (+1033 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 13`** (77 nodes): `DesktopStateStore`, `.appendAtomicMoveFallbackLog()`, `.appendStateLoadLog()`, `.appHome()`, `.applyJsonCollectionChunksLocked()`, `.atomicMoveFallbackMessage()`, `.backupStateFile()`, `.cleanupStateTempFiles()`, `.clearLockMetadata()`, `.compactDirectChatConversation()`, `.compactDirectChatConversations()`, `.compactRequiredText()`, `.compactRunForPersistence()`, `.compactStateForPersistence()`, `.compactTaskForPersistence()`, `.compactText()`, `.currentFingerprint()`, `.decodeState()`, `.decodeStateLenient()`, `.decodeStateOrNull()`, `.enforceOwnerOnlyPermissions()`, `.ensureSqliteSchema()`, `.jsonCollectionFile()`, `.jsonCollectionsDir()`, `.jsonCollectionsRevisionFile()`, `.jsonCollectionsRevisionFingerprint()`, `.load()`, `.loadCollection()`, `.loadGoals()`, `.loadIssues()`, `.loadJson()`, `.loadJsonCollection()`, `.loadJsonStateFromChunksLocked()`, `.loadJsonStateLocked()`, `.loadReviewQueue()`, `.loadRuns()`, `.loadSqlite()`, `.loadSqliteCollection()`, `.loadSqliteState()`, `.lockFile()`, `.lockMetadataFile()`, `.managedReposRoot()`, `.migrateJsonStateIfNeeded()`, `.normalizeLegacyCompanyRuntimeState()`, `.normalizeStateForPersistence()`, `.pruneDanglingCompanyReferences()`, `.readJsonCollectionLocked()`, `.readJsonStateForMigration()`, `.readSqliteCollection()`, `.save()`, `.saveJson()`, `.saveJsonLocked()`, `.saveSqlite()`, `.saveSqliteState()`, `.setSqliteMeta()`, `.sha256()`, `.sqliteCollectionCount()`, `.sqliteCollectionHashes()`, `.sqliteConnection()`, `.sqliteMeta()`, `.sqliteRevision()`, `.sqliteStateFile()`, `.stateCollection()`, `.stateFile()`, `.touchJsonCollectionsRevisionLocked()`, `.updateCache()`, `.updateCollection()`, `.updateJsonCollection()`, `.updateRuns()`, `.updateSqliteCollection()`, `.useJsonBackend()`, `.withStateFileLock()`, `.writeJsonCollectionChunksLocked()`, `.writeJsonCollectionLocked()`, `.writeLockMetadata()`, `.writeOwnerOnlyTextAtomically()`, `.writeSqliteCollection()`
+- **Thin community `Community 24`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (32 nodes): `DesktopTuiSessionService`, `.buildCommand()`, `.buildDesktopCliPath()`, `.buildPtyCommand()`, `.commandAvailability()`, `.failedSessionDelta()`, `.failedTuiSession()`, `.getDelta()`, `.getSession()`, `.listSessions()`, `.loadConfiguredAgents()`, `.materializePtyBridge()`, `.openSession()`, `.rememberFailedTuiSession()`, `.resolveBuiltinInteractiveAgent()`, `.resolveInteractiveAgent()`, `.sendInput()`, `.shouldReuse()`, `.shutdown()`, `.startReader()`, `.supportedConfigPaths()`, `.terminateRuntimeSession()`, `.terminateSession()`, `.watchProcess()`, `.writeIsolatedConfig()`, `isExpectedTuiExit()`, `RuntimeSession`, `.append()`, `.delta()`, `.snapshot()`, `.updateStatus()`, `DesktopTuiSessionService.kt`
+- **Thin community `Community 29`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 31`** (27 nodes): `GoalDrivenTaskPlanner`, `.buildApprovalAssignment()`, `.buildAssignedPrompt()`, `.buildExecutionAssignments()`, `.buildPlan()`, `.buildPlanForParticipants()`, `.buildReviewAssignments()`, `.buildSubtasks()`, `.defaultWorkItems()`, `.enrichWorkItems()`, `.executionRelevanceScore()`, `.extractWorkItems()`, `.fallbackWorkItem()`, `.isActionableWorkItem()`, `.isChief()`, `.isExecutionParticipant()`, `.isReviewer()`, `.participantFocus()`, `.participantRank()`, `.participantRoutingDescriptor()`, `.prioritizeExecutionParticipants()`, `.selectChief()`, `.selectExecutionParticipants()`, `.summarizeGoal()`, `.toSubtaskTitle()`, `PlanningParticipant`, `GoalDrivenTaskPlanner.kt`
+- **Thin community `Community 32`** (26 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.processPromptFileLines()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 33`** (26 nodes): `InteractiveCommand`, `.buildLineReader()`, `.defaultSaveDir()`, `.executeLoggedTurn()`, `.extractAgentSummaries()`, `.loadBootstrapContext()`, `.loadInteractiveConfig()`, `.normalizeInteractiveInput()`, `.parseAgentsOption()`, `.preferredSingleAgent()`, `.printAgents()`, `.printDesktopPrompt()`, `.printHelp()`, `.processPromptFileLines()`, `.resolveActiveAgent()`, `.resolveInitialChatMode()`, `.resolveStarterAgent()`, `.run()`, `.runInteractiveLoop()`, `.runTurn()`, `.runTurnWithSpinner()`, `.shouldRefreshStarterConfig()`, `.toInteractiveSummary()`, `.writeStarterConfig()`, `normalizeInteractiveInput()`, `InteractiveCommand.kt`
+- **Thin community `Community 33`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 34`** (25 nodes): `A2aRouter`, `.acknowledgeMessages()`, `.artifactCount()`, `.enqueueSnapshotResponse()`, `.heartbeat()`, `.listArtifacts()`, `.normalizeArtifactKind()`, `.normalizeArtifactLabel()`, `.normalizeArtifactLocalPath()`, `.normalizeArtifactReference()`, `.normalizeArtifactTenant()`, `.normalizeArtifactUrl()`, `.openSession()`, `.persistInternalMessage()`, `.postMessage()`, `.pullMessages()`, `.recipientsFor()`, `.registerArtifact()`, `.requesterSessionsFor()`, `.snapshot()`, `.validateEnvelope()`, `.validateSenderTenant()`, `normalized()`, `normalizedForRouting()`, `A2aRouter.kt`
+- **Thin community `Community 38`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 39`** (19 nodes): `DurableRuntimeService`, `.approve()`, `.beginPipelineRun()`, `.buildExecutionPlan()`, `.compactDurableRuntimeText()`, `.completeRun()`, `.createFork()`, `.failRun()`, `.importLegacyCheckpoint()`, `.inspectRun()`, `.listRuns()`, `.listRunSummaries()`, `.nextOrdinal()`, `.parseReplayMode()`, `.recordSideEffect()`, `.recordStageCompleted()`, `.recordStageFailed()`, `.recordStageStarted()`, `DurableRuntimeService.kt`
+- **Thin community `Community 43`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (18 nodes): `TemplateCommand`, `.applyFills()`, `.buildCustomTemplate()`, `.generateBlockedEscalationTemplate()`, `.generateChainTemplate()`, `.generateCompareTemplate()`, `.generateConsensusTemplate()`, `.generateCustomTemplate()`, `.generateFanoutTemplate()`, `.generateInteractiveTemplate()`, `.generateReleaseTemplate()`, `.generateReviewTemplate()`, `.generateSelfHealTemplate()`, `.generateTemplate()`, `.generateVerifiedTemplate()`, `.run()`, `.showTemplateList()`, `TemplateCommand.kt`
+- **Thin community `Community 44`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (17 nodes): `ConfigRepository`, `.loadConfig()`, `.loadConfigExact()`, `.saveConfig()`, `listOverrideFiles()`, `listYamlFiles()`, `loadConfig()`, `loadConfigExact()`, `loadConfigInternal()`, `loadConfigWithImports()`, `mergeCollection()`, `mergeConfigs()`, `mergeParsedConfigs()`, `parseConfig()`, `ParsedConfig`, `resolveImportPath()`, `ConfigRepository.kt`
+- **Thin community `Community 47`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 49`** (16 nodes): `AgentCapabilityGuard`, `.allowlistsPermit()`, `.before()`, `.capabilityFor()`, `.classifyGitCapability()`, `.classifyShellCapability()`, `.hasRecordedApproval()`, `.isReadAction()`, `.isWithin()`, `.matchesDomainAllowlist()`, `.requiresScopedSubject()`, `.resolveSetting()`, `.simulate()`, `.toHostOrNull()`, `.toNormalizedPathOrNull()`, `AgentCapabilityGuard.kt`
+- **Thin community `Community 49`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 51`** (16 nodes): `RecoveryExecutor`, `.applyValidation()`, `.buildSelfRepairInput()`, `.escalatedForAttempt()`, `.executeRetryThenFallback()`, `.executeWithFallback()`, `.executeWithoutRecovery()`, `.executeWithRecovery()`, `.executeWithRetry()`, `.executeWithSkip()`, `.failureResult()`, `.isRetryable()`, `.resolvePath()`, `.runAgent()`, `.shouldAttemptSelfRepair()`, `RecoveryExecutor.kt`
+- **Thin community `Community 53`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 54`** (16 nodes): `canUseRealAiStarter()`, `defaultInteractiveConfigPath()`, `defaultInteractiveSaveDir()`, `hasStarterCommand()`, `isClaudeReadyForStarter()`, `isCodexReadyForStarter()`, `isGeminiReadyForStarter()`, `resolveInteractiveConfigPath()`, `resolveStarterAgentSpec()`, `runStatusProbe()`, `safeLocalStarterAgentSpec()`, `StarterAgentSpec`, `starterAllowedDirectories()`, `starterAllowedDirectoriesYaml()`, `starterHomeDirectory()`, `StarterAgentResolver.kt`
+- **Thin community `Community 56`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (15 nodes): `ConditionEvaluator`, `.asDouble()`, `.attemptCoercion()`, `.compareNumbers()`, `.evaluate()`, `.isEqual()`, `.isTruthy()`, `.resolveStageReference()`, `.resolveValue()`, `.visitBinaryExpr()`, `.visitGroupingExpr()`, `.visitLiteralExpr()`, `.visitUnaryExpr()`, `.visitVariableExpr()`, `ConditionEvaluator.kt`
+- **Thin community `Community 58`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (14 nodes): `BoardControllerTest`, `.createDummyPost()`, `.`createPost should return 201 Created with post details`()`, `.`createPost with invalid request should return 400 Bad Request`()`, `.`deletePost should return 204 No Content`()`, `.`deletePost should return 403 Forbidden for permission denied`()`, `.`getAllPosts should return 200 OK with paginated posts`()`, `.`getPostById should return 200 OK with post details`()`, `.`getPostById should return 404 Not Found when post does not exist`()`, `.`updatePost should return 200 OK with updated post details`()`, `.`updatePost should return 403 Forbidden for permission denied`()`, `.`updatePost should return 409 Conflict for version mismatch`()`, `BoardControllerTest.kt`, `BoardControllerTest.kt`
+- **Thin community `Community 61`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 62`** (14 nodes): `BoundedDirectChatLineReader`, `.readLine()`, `DirectChatService`, `.buildClaudeCliPrompt()`, `.buildOllamaMessages()`, `.jsonString()`, `.listAvailableModels()`, `.streamChat()`, `.streamClaudeCli()`, `.streamLmStudio()`, `.streamOllama()`, `.updatedStreamContentChars()`, `.validateAndNormalizeBaseUrl()`, `DirectChatService.kt`
+- **Thin community `Community 62`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 63`** (14 nodes): `DefaultSecurityValidator`, `.containsInjectionPattern()`, `.isShellExecuteOption()`, `.isShellInterpreter()`, `.validate()`, `.validateCommand()`, `.validateEnvironment()`, `.validateParameters()`, `.validatePath()`, `SecurityValidator`, `.validate()`, `.validateCommand()`, `.validatePath()`, `SecurityValidator.kt`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 70`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
+- **Thin community `Community 69`** (13 nodes): `AgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `InMemoryAgentRegistry`, `.findAgentsByTag()`, `.getAgent()`, `.getAllAgents()`, `.registerAgent()`, `.unregisterAgent()`, `AgentRegistry.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 74`** (12 nodes): `GoalDrivenTaskPlannerTest`, `.`builder execution focus does not infer frontend from the word builder`()`, `.`buildPlan creates deterministic assignments for a high-level goal`()`, `.`buildPlan ignores workflow history bullets inside context sections`()`, `.`buildPlan includes A2A collaboration metadata in assigned prompts`()`, `.`buildPlan preserves explicit checklist items when present`()`, `.`collaboration notes do not accidentally turn builders into reviewers`()`, `.`default work items avoid internal planning jargon`()`, `.`generic builder fallback still fans out when multiple work items are available`()`, `.`generic goal with enterprise roster falls back to Builder instead of UX roles`()`, `.`short natural language prompts are enriched into a larger execution portfolio`()`, `GoalDrivenTaskPlannerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1727,21 +1725,21 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 82`** (11 nodes): `TemplateEngineTest`, `.setUp()`, `.`should cap legacy all outputs interpolation`()`, `.`should handle invalid expressions gracefully`()`, `.`should handle multiple expressions`()`, `.`should handle nonexistent stage output`()`, `.`should interpolate environment variables`()`, `.`should interpolate pipeline name`()`, `.`should interpolate stage output expression`()`, `.`should maintain legacy mustache syntax for shared state`()`, `TemplateEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
+- **Thin community `Community 83`** (11 nodes): `AgentPerformanceCalculator`, `.belongsToScope()`, `.compute()`, `.isRejection()`, `.matchRun()`, `.normalizedKey()`, `.recentDeliveryRate()`, `.score()`, `.subjects()`, `AgentPerformanceSubject`, `AgentPerformanceCalculator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
+- **Thin community `Community 85`** (11 nodes): `VerificationBundleService.kt`, `VerificationBundleService`, `.buildArtifactRefs()`, `.buildContract()`, `.buildForIssue()`, `.buildObservations()`, `.bundleFromEvaluation()`, `.evaluate()`, `.loadOutcome()`, `.parseChecks()`, `.persistForIssue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
+- **Thin community `Community 86`** (11 nodes): `ProvenanceService`, `.bundleForFile()`, `.bundleForPullRequest()`, `.bundleForRef()`, `.bundleForRun()`, `.mergeEdges()`, `.mergeNodes()`, `.recordAction()`, `.recordIssueRunLink()`, `.recordPullRequestState()`, `ProvenanceService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 92`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
+- **Thin community `Community 91`** (11 nodes): `buildMessage()`, `ErrorMessages`, `.agentNotFound()`, `.configNotFound()`, `.pipelineNotFound()`, `.pluginExecutionFailed()`, `.securityViolation()`, `.stageTimeout()`, `.validationFailed()`, `UserFriendlyError`, `UserFriendlyErrors.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 94`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
+- **Thin community `Community 93`** (11 nodes): `StatsCommand`, `.formatDuration()`, `.printAllStatsCsv()`, `.printDetailedStatsCsv()`, `.printStageDetailsCsv()`, `.run()`, `.showAllStats()`, `.showDetailedStats()`, `.showHistory()`, `.showStageDetails()`, `StatsCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 95`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
+- **Thin community `Community 94`** (11 nodes): `defaultCommandAvailable()`, `DoctorCommand`, `.checkBinary()`, `.checkConfig()`, `.checkExamples()`, `.checkJar()`, `.checkJava()`, `.findCliJar()`, `.run()`, `isWindows()`, `DoctorCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 96`** (10 nodes): `LocalPlaywrightDependencyResolver`, `.allowRuntimeInstall()`, `.configuredNodeModulesPath()`, `.existingNodePath()`, `.hasPlaywrightPackage()`, `.installIfExplicitlyAllowed()`, `.playwrightSetupMessage()`, `.prewarm()`, `.requireNodePath()`, `LocalPlaywrightDependencyResolver.kt`
+- **Thin community `Community 95`** (10 nodes): `LocalPlaywrightDependencyResolver`, `.allowRuntimeInstall()`, `.configuredNodeModulesPath()`, `.existingNodePath()`, `.hasPlaywrightPackage()`, `.installIfExplicitlyAllowed()`, `.playwrightSetupMessage()`, `.prewarm()`, `.requireNodePath()`, `LocalPlaywrightDependencyResolver.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 98`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
+- **Thin community `Community 97`** (10 nodes): `VerificationStore.kt`, `VerificationStore`, `.appendObservation()`, `.dir()`, `.listOutcomes()`, `.loadObservations()`, `.loadOutcome()`, `.observationFile()`, `.outcomeFile()`, `.saveOutcome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 102`** (10 nodes): `PolicyStore`, `.appendDecision()`, `.auditFile()`, `.defaultPermissiveProfile()`, `.listDocuments()`, `.loadAudit()`, `.loadDocument()`, `.policiesDir()`, `.saveDocument()`, `PolicyStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1751,105 +1749,105 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 109`** (9 nodes): `DesktopDirectChatService`, `.appendMessage()`, `.createConversation()`, `.deleteConversation()`, `.getConversation()`, `.listConversations()`, `.listModels()`, `.streamMessage()`, `DesktopDirectChatService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 110`** (9 nodes): `AutonomousDiscoveryScanResult`, `AutonomousDiscoveryService`, `.discoverSignals()`, `.markTriaged()`, `.mergeSignals()`, `.scan()`, `.selectActionableSignal()`, `.severityRank()`, `AutonomousDiscoveryService.kt`
+- **Thin community `Community 113`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (9 nodes): `LocalModelDefaults`, `.installedGemma4Models()`, `.isGemma4Model()`, `.isGemmaFamilyModel()`, `.isLocalOllamaTag()`, `.normalizeBaseUrl()`, `.normalizeModel()`, `.preferredInstalledGemmaModels()`, `LocalModelDefaults.kt`
+- **Thin community `Community 116`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (8 nodes): `BoardController`, `.createPost()`, `.deletePost()`, `.getPostById()`, `.getPosts()`, `.updatePost()`, `BoardController.kt`, `BoardController.kt`
+- **Thin community `Community 117`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (8 nodes): `cloneRepo()`, `git()`, `GitWorkspaceServiceRealGitIntegrationTest`, `initBareRemote()`, `initRepoWithCommit()`, `mockkStateStore()`, `realGitService()`, `GitWorkspaceServiceRealGitIntegrationTest.kt`
+- **Thin community `Community 118`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (8 nodes): `eventuallyProcessExited()`, `localJsonServer()`, `localModelContext()`, `LocalModelPluginTest`, `localRoutingServer()`, `respondJson()`, `unusedProcessManager()`, `LocalModelPluginTest.kt`
+- **Thin community `Community 119`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (8 nodes): `DefaultResultAnalyzer`, `.analysisOutput()`, `.analyze()`, `.extractConfidence()`, `.percent()`, `.similarity()`, `.tokenize()`, `DefaultResultAnalyzer.kt`
+- **Thin community `Community 121`** (8 nodes): `BrewStatus`, `desktopUpdateStatusResponse()`, `resolveBrewUpdateStatus()`, `resolveInstalledDesktopAppPath()`, `resolveSourceCommit()`, `runUpdateStatusCommand()`, `UpdateStatusCommandResult`, `DesktopUpdateStatus.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
+- **Thin community `Community 122`** (8 nodes): `CompanyIssueReadiness`, `.dependenciesSatisfied()`, `.dependencyIds()`, `.isDependencySatisfied()`, `.isRuntimeStartCandidate()`, `.isSupersededCanceledDependency()`, `.runtimeDisposition()`, `CompanyIssueReadiness.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
+- **Thin community `Community 123`** (8 nodes): `ChatSession`, `.addAssistant()`, `.addUser()`, `.buildPrompt()`, `.clear()`, `.compactHistory()`, `.snapshot()`, `ChatSession.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
+- **Thin community `Community 124`** (8 nodes): `GitHubControlPlaneStore`, `.file()`, `.load()`, `.loadUnlocked()`, `.save()`, `.update()`, `.writeState()`, `GitHubControlPlaneStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
+- **Thin community `Community 125`** (8 nodes): `OpenCodeDefaults`, `.isForbiddenCloudModel()`, `.isLocalOllamaModel()`, `.isSelectableModel()`, `.localOllamaEnvironment()`, `.normalizeModel()`, `.ollamaTagForOpenCodeModel()`, `OpenCodeDefaults.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
+- **Thin community `Community 126`** (8 nodes): `JsonParser`, `.parse()`, `.serialize()`, `YamlParser`, `.generateSnippet()`, `.parse()`, `.serialize()`, `ConfigParsers.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
+- **Thin community `Community 127`** (8 nodes): `cleanupSurvivingDescendants()`, `destroyProcessTree()`, `ProcessDescendantTracker`, `.recordDescendants()`, `.stopAndSnapshot()`, `terminateUnixChildren()`, `waitForProcessHandles()`, `ProcessTree.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
+- **Thin community `Community 128`** (8 nodes): `DiagramGenerator`, `.appendStageDetails()`, `.generate()`, `.generateDag()`, `.generateMap()`, `.generateParallel()`, `.generateSequential()`, `DiagramGenerator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
+- **Thin community `Community 129`** (8 nodes): `Linter.kt`, `Linter`, `.checkDuplicateAgentNames()`, `.checkDuplicateStageIds()`, `.checkUndefinedAgentReferences()`, `.checkUnusedAgents()`, `.lint()`, `LintResult`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
+- **Thin community `Community 132`** (7 nodes): `completedResult()`, `ImmediateEventBus`, `.emit()`, `.subscribe()`, `.unsubscribe()`, `PipelineRunTrackerTest`, `PipelineRunTrackerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
+- **Thin community `Community 133`** (7 nodes): `PipelineOrchestratorMapTest`, `.`executePipeline with MAP execution mode should fan out and aggregate results`()`, `.`MAP execution honors maxConcurrentAgents`()`, `TrackingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorMapTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
+- **Thin community `Community 134`** (7 nodes): `A2aDedupeStore`, `.persist()`, `.prune()`, `.remember()`, `.size()`, `StoredAck`, `A2aDedupeStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
+- **Thin community `Community 135`** (7 nodes): `A2aDedupePersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `SnapshotEntry`, `A2aDedupePersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
+- **Thin community `Community 136`** (7 nodes): `A2aSessionPersistenceStore`, `.dir()`, `.file()`, `.load()`, `.save()`, `Snapshot`, `A2aSessionPersistenceStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
+- **Thin community `Community 137`** (7 nodes): `DurableResumeCoordinator`, `.approve()`, `.buildContext()`, `.continueRun()`, `.forkRun()`, `.inspect()`, `DurableResumeCoordinator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
+- **Thin community `Community 139`** (7 nodes): `FileReaderPlugin`, `.execute()`, `.executionRoot()`, `.parseMaxBytes()`, `.resolveInsideRoot()`, `.validateInput()`, `FileReaderPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
+- **Thin community `Community 140`** (7 nodes): `OpenAIPlugin`, `.buildMessage()`, `.execute()`, `.extractContent()`, `.resolveApiKey()`, `.validateInput()`, `OpenAIPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
+- **Thin community `Community 141`** (7 nodes): `InteractiveCommandCompleter`, `.complete()`, `.completeIncludeValue()`, `.completeSimpleArgValue()`, `.completionValues()`, `.suggest()`, `InteractiveCommandCompleter.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
+- **Thin community `Community 144`** (6 nodes): `DirectChatServiceTest`, `isProcessAlive()`, `oneChunkHangingServer()`, `waitForFile()`, `waitUntilNotAlive()`, `DirectChatServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
+- **Thin community `Community 145`** (6 nodes): `DesktopStateStoreTest`, `readSqliteCollection()`, `readSqliteCollectionUpdatedAt()`, `saveLegacyJsonState()`, `writeSqliteCollection()`, `DesktopStateStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
+- **Thin community `Community 146`** (6 nodes): `DesktopAppServiceRuntimeDispositionSchedulerTest`, `runtimeDispositionCompany()`, `runtimeDispositionGoal()`, `runtimeDispositionIssue()`, `seedRuntimeDispositionWorkspace()`, `DesktopAppServiceRuntimeDispositionSchedulerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
+- **Thin community `Community 147`** (6 nodes): `bindSingleIssueForRuntimeDisposition()`, `CompanyRuntimeBindingServiceTest`, `runtimeDispositionIssue()`, `runtimeDispositionTask()`, `testCompany()`, `CompanyRuntimeBindingServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
+- **Thin community `Community 148`** (6 nodes): `ProductionReliabilityBaselineTest`, `.`app server exposes explicit health and readiness endpoints`()`, `.`docker entrypoint generates runtime token for non-loopback app server`()`, `.`docker image runs long-lived app server with health probe`()`, `.`release workflow tracks master branch and publishes artifacts`()`, `ProductionReliabilityBaselineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
+- **Thin community `Community 149`** (6 nodes): `PipelineContextTest`, `.agentResult()`, `.`getAllOutputs caps large execution history output aggregation`()`, `.`getAllOutputs preserves small outputs in execution order`()`, `.`getSuccessfulOutputs excludes failed outputs before applying aggregation cap`()`, `PipelineContextTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
+- **Thin community `Community 151`** (6 nodes): `PipelineOrchestratorConditionalTest`, `RecordingAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `.executionCount()`, `PipelineOrchestratorConditionalTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
+- **Thin community `Community 152`** (6 nodes): `DesktopCommandProcessTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `DesktopCommandProcessTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (6 nodes): `AuthCommandTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `AuthCommandTest.kt`
+- **Thin community `Community 153`** (6 nodes): `AuthCommandTest`, `executableScript()`, `isProcessAlive()`, `waitForFile()`, `waitUntilNotAlive()`, `AuthCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
+- **Thin community `Community 154`** (6 nodes): `CompanyVerificationDecision`, `CompanyVerifierService`, `.requiresExecutionEvidence()`, `.shouldIgnoreReviewVerdictsForCompletion()`, `.verifyIssueCompletion()`, `CompanyVerifierService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
+- **Thin community `Community 155`** (6 nodes): `NetworkEndpointPolicy`, `.isPrivateOrLocalAddress()`, `.isPrivateOrLocalHost()`, `.parseIpv4()`, `.requirePublicHttpUrl()`, `NetworkEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
+- **Thin community `Community 156`** (6 nodes): `GitHubControlPlaneService`, `.inspectPullRequest()`, `.listEvents()`, `.listPullRequests()`, `.recordSnapshot()`, `GitHubControlPlaneService.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
+- **Thin community `Community 157`** (6 nodes): `QaVerificationPlugin`, `.detectCommand()`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `QaVerificationPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
+- **Thin community `Community 158`** (6 nodes): `CommandPlugin`, `.execute()`, `.jsonString()`, `.parseArgvJson()`, `.validateInput()`, `CommandPlugin.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
+- **Thin community `Community 160`** (6 nodes): `DefaultResultAggregator`, `.aggregate()`, `.mergeOutputs()`, `ResultAggregator`, `.aggregate()`, `ResultAggregator.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
+- **Thin community `Community 161`** (6 nodes): `CodexDashboardCommand`, `.promptLine()`, `.renderTimeline()`, `.run()`, `resolvePromptInput()`, `CodexDashboardCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
+- **Thin community `Community 162`** (6 nodes): `PluginCommand`, `.run()`, `PluginInitCommand`, `.createScaffold()`, `.run()`, `PluginCommand.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
+- **Thin community `Community 163`** (6 nodes): `PolicyEngine`, `.before()`, `.decisions()`, `.evaluate()`, `.matches()`, `PolicyEngine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
+- **Thin community `Community 164`** (5 nodes): `assertOpenCodeRunCommand()`, `localRoutingServer()`, `OpenCodePluginTest`, `respondJson()`, `OpenCodePluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
+- **Thin community `Community 165`** (5 nodes): `PromptHandoffPluginTest`, `RecordingPromptProcessManager`, `.executeProcess()`, `.extractPromptFilePath()`, `PromptHandoffPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
+- **Thin community `Community 166`** (5 nodes): `PipelineOrchestratorOutputPropagationTest`, `.`dag mode caps combined dependency outputs before dependent stage input`()`, `.orchestratorWithExecutor()`, `.`sequential mode caps implicit previous output before next stage input`()`, `PipelineOrchestratorOutputPropagationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
+- **Thin community `Community 167`** (5 nodes): `MappedDelayedAgentExecutor`, `.executeAgent()`, `.executeWithRetry()`, `PipelineOrchestratorTimeoutTest`, `PipelineOrchestratorTimeoutTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
+- **Thin community `Community 168`** (5 nodes): `assertSnapshot()`, `CliGoldenSnapshotTest`, `createDoctorFixture()`, `normalize()`, `CliGoldenSnapshotTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
+- **Thin community `Community 169`** (5 nodes): `DesktopEndpointPolicy`, `.isLoopback()`, `.remoteAllowed()`, `.resolveA2aEndpoint()`, `DesktopEndpointPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
+- **Thin community `Community 170`** (5 nodes): `EvidencePathPolicy`, `.canonicalize()`, `.evidenceRoots()`, `.requireAllowedFilePath()`, `EvidencePathPolicy.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
+- **Thin community `Community 171`** (5 nodes): `CompanyRuntimeMachine`, `.normalizedExecutionAgentName()`, `.planGoalDecomposition()`, `.planIssueStarts()`, `CompanyRuntimeMachine.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
+- **Thin community `Community 172`** (5 nodes): `WorkQueue`, `.drain()`, `.enqueue()`, `.isEmpty()`, `WorkQueue.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 174`** (5 nodes): `CheckpointGraphStore`, `.appendCheckpoint()`, `.updateStatus()`, `.upsertRun()`, `CheckpointGraphStore.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -1901,11 +1899,11 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 199`** (4 nodes): `StateRepository`, `.load()`, `.save()`, `StateRepository.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
+- **Thin community `Community 201`** (4 nodes): `DurableRuntimeFlags`, `.enable()`, `.isEnabled()`, `DurableRuntimeFlags.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
+- **Thin community `Community 204`** (4 nodes): `TimelineCollector`, `.runWithTimeline()`, `TimelineResult`, `TimelineCollector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
+- **Thin community `Community 205`** (4 nodes): `StageConflictDetector`, `.conflictKeys()`, `.conflictSafeBatches()`, `StageConflictDetector.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 207`** (4 nodes): `SimpleCLI`, `.printHelp()`, `.run()`, `SimpleCLI.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2017,161 +2015,163 @@ Nodes (1): RealtimeEvent
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 263`** (2 nodes): `DesktopStateStoreLockTest`, `DesktopStateStoreLockTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
+- **Thin community `Community 264`** (2 nodes): `DesktopUpdateStatusTest`, `DesktopUpdateStatusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
+- **Thin community `Community 265`** (2 nodes): `DesktopEndpointPolicyTest`, `DesktopEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
+- **Thin community `Community 266`** (2 nodes): `ExecutionBackendsTest`, `ExecutionBackendsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
+- **Thin community `Community 267`** (2 nodes): `CodexAppServerManagerTest`, `CodexAppServerManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `LocalPlaywrightDependencyTest`, `LocalPlaywrightDependencyTest.kt`
+- **Thin community `Community 268`** (2 nodes): `DesktopAppServiceMergeConfirmationTest`, `DesktopAppServiceMergeConfirmationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
+- **Thin community `Community 269`** (2 nodes): `LocalPlaywrightDependencyTest`, `LocalPlaywrightDependencyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
+- **Thin community `Community 270`** (2 nodes): `DesktopAppServiceDashboardPrCleanupTest`, `DesktopAppServiceDashboardPrCleanupTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
+- **Thin community `Community 271`** (2 nodes): `AutonomousDiscoveryServiceTest`, `AutonomousDiscoveryServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
+- **Thin community `Community 272`** (2 nodes): `SkillModelsTest`, `SkillModelsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
+- **Thin community `Community 273`** (2 nodes): `CompanyRuntimeMachineTest`, `CompanyRuntimeMachineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
+- **Thin community `Community 274`** (2 nodes): `WorkQueueTest`, `WorkQueueTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
+- **Thin community `Community 275`** (2 nodes): `ChatTranscriptWriterTest`, `ChatTranscriptWriterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
+- **Thin community `Community 276`** (2 nodes): `ChatSessionTest`, `ChatSessionTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
+- **Thin community `Community 277`** (2 nodes): `NetworkEndpointPolicyTest`, `NetworkEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
+- **Thin community `Community 278`** (2 nodes): `SecurityValidatorTest`, `SecurityValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
+- **Thin community `Community 279`** (2 nodes): `A2aArtifactStoreTest`, `A2aArtifactStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
+- **Thin community `Community 280`** (2 nodes): `A2aApiTest`, `A2aApiTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
+- **Thin community `Community 281`** (2 nodes): `A2aSessionStoreTest`, `A2aSessionStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
+- **Thin community `Community 282`** (2 nodes): `A2aPersistenceTest`, `A2aPersistenceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
+- **Thin community `Community 283`** (2 nodes): `A2aDedupeStoreTest`, `A2aDedupeStoreTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
+- **Thin community `Community 284`** (2 nodes): `RecoveryExecutorTest`, `RecoveryExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
+- **Thin community `Community 285`** (2 nodes): `GitHubControlPlaneServiceTest`, `GitHubControlPlaneServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
+- **Thin community `Community 286`** (2 nodes): `DurableRuntimeServiceTest`, `DurableRuntimeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
+- **Thin community `Community 287`** (2 nodes): `DurableResumeCoordinatorTest`, `DurableResumeCoordinatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
+- **Thin community `Community 288`** (2 nodes): `AtomicFileWriterTest.kt`, `AtomicFileWriterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
+- **Thin community `Community 289`** (2 nodes): `LinearClientEndpointPolicyTest`, `LinearClientEndpointPolicyTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
+- **Thin community `Community 290`** (2 nodes): `VerificationBundleServiceTest.kt`, `VerificationBundleServiceTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
+- **Thin community `Community 291`** (2 nodes): `KnowledgeServiceTest`, `KnowledgeServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
+- **Thin community `Community 292`** (2 nodes): `LocalModelDefaultsTest`, `LocalModelDefaultsTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
+- **Thin community `Community 293`** (2 nodes): `ObservabilityServiceTest`, `ObservabilityServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
+- **Thin community `Community 294`** (2 nodes): `FileConfigRepositoryTest`, `FileConfigRepositoryTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
+- **Thin community `Community 295`** (2 nodes): `QaTestGenerationFixtureTest`, `QaTestGenerationFixtureTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
+- **Thin community `Community 296`** (2 nodes): `ConfigRepositoryImportTest`, `ConfigRepositoryImportTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
+- **Thin community `Community 297`** (2 nodes): `ExampleConfigSmokeTest`, `ExampleConfigSmokeTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
+- **Thin community `Community 298`** (2 nodes): `YamlParserTest`, `YamlParserTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
+- **Thin community `Community 299`** (2 nodes): `CodexPluginTest`, `CodexPluginTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
+- **Thin community `Community 300`** (2 nodes): `ProcessManagerTest`, `ProcessManagerTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
+- **Thin community `Community 301`** (2 nodes): `ErrorHelperTest`, `ErrorHelperTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
+- **Thin community `Community 302`** (2 nodes): `ResultAggregatorTest`, `ResultAggregatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
+- **Thin community `Community 303`** (2 nodes): `ConditionEvaluatorTest`, `ConditionEvaluatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
+- **Thin community `Community 304`** (2 nodes): `AgentExecutorTest`, `AgentExecutorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
+- **Thin community `Community 305`** (2 nodes): `StuckDetectorTest`, `StuckDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
+- **Thin community `Community 306`** (2 nodes): `PipelineGuardServiceTest`, `PipelineGuardServiceTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
+- **Thin community `Community 307`** (2 nodes): `PipelineOrchestratorDagValidationTest`, `PipelineOrchestratorDagValidationTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
+- **Thin community `Community 308`** (2 nodes): `StageConflictDetectorTest`, `StageConflictDetectorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
+- **Thin community `Community 309`** (2 nodes): `PipelineOrchestratorTemplatingTest`, `PipelineOrchestratorTemplatingTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
+- **Thin community `Community 310`** (2 nodes): `CoroutineEventBusTest`, `CoroutineEventBusTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
+- **Thin community `Community 311`** (2 nodes): `WebServerTest.kt`, `WebServerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
+- **Thin community `Community 312`** (2 nodes): `CompletionCommandTest`, `CompletionCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
+- **Thin community `Community 313`** (2 nodes): `HelpCommandTest`, `HelpCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
+- **Thin community `Community 314`** (2 nodes): `AppServerCommandTest`, `AppServerCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
+- **Thin community `Community 315`** (2 nodes): `StarterAgentResolverTest`, `StarterAgentResolverTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
+- **Thin community `Community 316`** (2 nodes): `InteractiveCommandCompleterTest`, `InteractiveCommandCompleterTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
+- **Thin community `Community 317`** (2 nodes): `AgentCommandTest`, `AgentCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
+- **Thin community `Community 318`** (2 nodes): `PluginCommandTest`, `PluginCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
+- **Thin community `Community 319`** (2 nodes): `HelloCommandTest`, `HelloCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
+- **Thin community `Community 320`** (2 nodes): `LintCommandTest`, `LintCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
+- **Thin community `Community 321`** (2 nodes): `CompanyCommandTest`, `CompanyCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
+- **Thin community `Community 322`** (2 nodes): `InteractiveCommandTest`, `InteractiveCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
+- **Thin community `Community 323`** (2 nodes): `StatsCommandTest`, `StatsCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
+- **Thin community `Community 324`** (2 nodes): `CodexDashboardCommandTest`, `CodexDashboardCommandTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
+- **Thin community `Community 325`** (2 nodes): `StatsManagerTest.kt`, `StatsManagerTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
+- **Thin community `Community 326`** (2 nodes): `PipelineValidatorTest.kt`, `PipelineValidatorTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (2 nodes): `LinterTest.kt`, `LinterTest`
+- **Thin community `Community 327`** (2 nodes): `PipelineValidatorExtTest.kt`, `PipelineValidatorExtTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
+- **Thin community `Community 328`** (2 nodes): `LinterTest.kt`, `LinterTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 329`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
+- **Thin community `Community 329`** (2 nodes): `DefaultOutputValidatorTest`, `DefaultOutputValidatorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 330`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
+- **Thin community `Community 330`** (2 nodes): `PolicyEngineTest`, `PolicyEngineTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 333`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
+- **Thin community `Community 331`** (2 nodes): `RiskApprovalInterceptorTest`, `RiskApprovalInterceptorTest.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 336`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+- **Thin community `Community 334`** (2 nodes): `CheckpointConfig`, `CheckpointConfig.kt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 337`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
+- **Thin community `Community 337`** (2 nodes): `CotorProperties`, `CotorProperties.kt`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 338`** (2 nodes): `RealtimeEvent.kt`, `RealtimeEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 11`, `Community 17`, `Community 21`?**
-  _High betweenness centrality (0.082) - this node is a cross-community bridge._
-- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 5`, `Community 8`, `Community 16`, `Community 19`?**
+- **Why does `DesktopStore` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 9`, `Community 18`?**
+  _High betweenness centrality (0.077) - this node is a cross-community bridge._
+- **Why does `DesktopTextKey` connect `Community 6` to `Community 1`?**
   _High betweenness centrality (0.029) - this node is a cross-community bridge._
-- **Why does `DesktopTextKey` connect `Community 8` to `Community 1`, `Community 5`?**
-  _High betweenness centrality (0.029) - this node is a cross-community bridge._
+- **Why does `language` connect `Community 1` to `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 10`, `Community 19`?**
+  _High betweenness centrality (0.027) - this node is a cross-community bridge._
 - **Are the 39 inferred relationships involving `DesktopStore` (e.g. with `.selectedCompanyAgentPerformanceFiltersAndCountsScoreableAgents()` and `.bootstrapRetriesEmptySuccessfulDashboardBeforeSettling()`) actually correct?**
   _`DesktopStore` has 39 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 14 inferred relationships involving `DesktopAPI` (e.g. with `.desktopAPIEncodesDynamicPathSegments()` and `.desktopAPIPreservesConfiguredBasePathWhenBuildingRoutes()`) actually correct?**
   _`DesktopAPI` has 14 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `repositoryMap`, `browserQA`, `marketing` to the rest of the system?**
-  _1016 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **What connects `invalidResponse`, `DesktopTaskStatus`, `AgentRunStatus` to the rest of the system?**
+  _1038 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.0 - nodes in this community are weakly interconnected._

--- a/macos/Sources/CotorDesktopApp/ContentView.swift
+++ b/macos/Sources/CotorDesktopApp/ContentView.swift
@@ -119,7 +119,7 @@ private enum MeetingRoomSurface: CaseIterable, Identifiable {
 }
 
 struct CompanySidebarDisclosureState {
-    var isCompanyDraftExpanded = false
+    var isCompanyDraftExpanded = true
     var isAdvancedSettingsExpanded = false
     var isAgentAdvancedDetailsExpanded = false
 }
@@ -1052,9 +1052,9 @@ private struct SidebarView: View {
 
     private var companySection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            companySelectionSection
-            companyQuickActionsSection
             companyDraftSection
+            companyQuickActionsSection
+            companySelectionSection
             if store.selectedCompany != nil {
                 advancedCompanySettingsSection
             }
@@ -1142,6 +1142,16 @@ private struct SidebarView: View {
                         .pickerStyle(.menu)
                     }
 
+                    Button {
+                        Task { await store.createCompany() }
+                    } label: {
+                        Label(l("Create Company", "회사 생성"), systemImage: "building.2.crop.circle")
+                            .frame(maxWidth: .infinity)
+                            .lineLimit(1)
+                    }
+                    .buttonStyle(ShellTopBarButtonStyle(prominent: true))
+                    .disabled(store.newCompanyName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.newCompanyRootPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
                     VStack(alignment: .leading, spacing: 8) {
                         Text(l("Optional cost guardrails (USD)", "선택 사항: 비용 상한 (USD)"))
                             .font(.system(size: 11, weight: .semibold))
@@ -1162,7 +1172,7 @@ private struct SidebarView: View {
         VStack(alignment: .leading, spacing: 12) {
             sectionTitle(
                 title: l("Quick Actions", "빠른 동작"),
-                subtitle: l("Create from the draft and control the selected company runtime from one compact area.", "초안으로 회사를 만들고 선택한 회사 런타임을 한곳에서 빠르게 제어합니다.")
+                subtitle: l("Control the selected company runtime from one compact area.", "선택한 회사 런타임을 한곳에서 빠르게 제어합니다.")
             )
 
             companySubpanel {
@@ -1201,16 +1211,6 @@ private struct SidebarView: View {
                             .foregroundStyle(ShellPalette.muted)
                             .fixedSize(horizontal: false, vertical: true)
                     }
-
-                    Button {
-                        Task { await store.createCompany() }
-                    } label: {
-                        Label(l("Create Company", "회사 생성"), systemImage: "building.2.crop.circle")
-                            .frame(maxWidth: .infinity)
-                            .lineLimit(1)
-                    }
-                    .buttonStyle(ShellTopBarButtonStyle(prominent: true))
-                    .disabled(store.newCompanyName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || store.newCompanyRootPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
                     if let company = store.selectedCompany, shouldShowGitHubQuickConnect(for: company) {
                         companyGitHubQuickConnectPrompt(company: company)

--- a/macos/Sources/CotorDesktopApp/DesktopAPI.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopAPI.swift
@@ -227,6 +227,10 @@ struct DesktopAPI {
         return payload.status?.lowercased() == "ok"
     }
 
+    func desktopUpdateStatus() async throws -> DesktopUpdateStatusPayload {
+        try await get(path: "api/app/update-status")
+    }
+
     func helpGuide(languageCode: String) async throws -> HelpGuidePayload {
         try await get(path: "api/app/help-guide", query: [URLQueryItem(name: "lang", value: languageCode)])
     }

--- a/macos/Sources/CotorDesktopApp/DesktopStore.swift
+++ b/macos/Sources/CotorDesktopApp/DesktopStore.swift
@@ -111,6 +111,8 @@ final class DesktopStore: ObservableObject {
     @Published var codexOAuthAuthenticated = false
     @Published var codexOAuthHomePath = ""
     @Published var codexOAuthStatusMessage: String?
+    @Published var desktopUpdateStatus: DesktopUpdateStatusPayload?
+    @Published var isRefreshingDesktopUpdateStatus = false
     @Published var companyLinearSyncEnabled = false
     @Published var companyLinearEndpoint = ""
     @Published var companyLinearTeamID = ""
@@ -539,6 +541,21 @@ final class DesktopStore: ObservableObject {
         self.theme = theme
         UserDefaults.standard.set(theme.rawValue, forKey: Self.themeDefaultsKey)
         objectWillChange.send()
+    }
+
+    func refreshDesktopUpdateStatus() async {
+        guard !isRefreshingDesktopUpdateStatus else { return }
+        isRefreshingDesktopUpdateStatus = true
+        defer { isRefreshingDesktopUpdateStatus = false }
+        do {
+            desktopUpdateStatus = try await runWithEmbeddedBackendRecovery {
+                try await api.desktopUpdateStatus()
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            AppLogger.warning("Desktop update status refresh failed: \(error.localizedDescription)")
+        }
     }
 
     func setShellMode(_ mode: AppShellMode) {

--- a/macos/Sources/CotorDesktopApp/Models.swift
+++ b/macos/Sources/CotorDesktopApp/Models.swift
@@ -1592,6 +1592,31 @@ struct DesktopLifecycleShutdownPayload: Codable, Equatable {
     let tuiSessionsShutdown: Bool
 }
 
+struct DesktopUpdateStatusPayload: Codable, Hashable {
+    let health: HealthPayload
+    let backendOwner: String
+    let currentVersion: String
+    let currentBuild: String
+    let sourceCommit: String?
+    let installedAppPath: String?
+    let brewFormula: String
+    let updateCommand: String
+    let updateAvailable: Bool?
+    let latestVersion: String?
+    let latestCommit: String?
+    let checkedAtEpochMillis: Int64
+    let status: String
+    let message: String
+}
+
+struct HealthPayload: Codable, Hashable {
+    let ok: Bool
+    let service: String
+    let owner: String
+    let version: String
+    let build: String
+}
+
 extension DashboardPayload {
     static let empty = DashboardPayload(
         repositories: [],

--- a/macos/Sources/CotorDesktopApp/NewChatSheet.swift
+++ b/macos/Sources/CotorDesktopApp/NewChatSheet.swift
@@ -14,7 +14,7 @@ struct NewChatSheet: View {
 
     @State private var title: String = ""
     @State private var selectedProvider: String = "ollama"
-    @State private var customModel: String = "gemma3"
+    @State private var customModel: String = ""
     @State private var systemPrompt: String = ""
     @State private var baseUrl: String = ""
     @State private var isCreating: Bool = false
@@ -231,7 +231,7 @@ struct NewChatSheet: View {
         if selectedProvider != provider.id {
             selectedProvider = provider.id
         }
-        if customModel.isEmpty || customModel == "model-name" {
+        if customModel.isEmpty || customModel == "model-name" || customModel == "gemma3" {
             customModel = provider.defaultModel
         }
         if baseUrl.isEmpty {

--- a/macos/Sources/CotorDesktopApp/SettingsView.swift
+++ b/macos/Sources/CotorDesktopApp/SettingsView.swift
@@ -38,6 +38,9 @@ struct SettingsView: View {
                 .padding(24)
             }
         }
+        .task {
+            await store.refreshDesktopUpdateStatus()
+        }
     }
 
     private var hero: some View {
@@ -411,10 +414,87 @@ struct SettingsView: View {
             title: store.text(.desktopInstaller),
             subtitle: store.text(.desktopInstallerSubtitle)
         ) {
-            valueRow(store.text(.installer), "cotor install / cotor update / cotor delete")
+            HStack(spacing: 10) {
+                updateStatusBadge(store.desktopUpdateStatus)
+                Spacer()
+                Button {
+                    Task { await store.refreshDesktopUpdateStatus() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 13, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(ShellPalette.text)
+                .background(
+                    RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous)
+                        .fill(ShellPalette.panelAlt)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous)
+                        .stroke(ShellPalette.border)
+                )
+                .disabled(store.isRefreshingDesktopUpdateStatus)
+                .help(store.language("Check desktop update status", "데스크톱 업데이트 상태 확인"))
+            }
+
+            if let status = store.desktopUpdateStatus {
+                valueRow(store.language("Health", "상태"), status.health.ok ? "ok" : "failed")
+                valueRow(store.language("Backend", "백엔드"), "\(status.backendOwner) / \(status.currentVersion) / \(status.currentBuild)")
+                if let sourceCommit = status.sourceCommit, !sourceCommit.isEmpty {
+                    valueRow(store.language("Source commit", "소스 커밋"), sourceCommit)
+                }
+                valueRow(store.language("Installed app", "설치된 앱"), status.installedAppPath ?? store.language("Not found", "찾을 수 없음"))
+                valueRow(store.language("Brew formula", "Brew formula"), status.brewFormula)
+                valueRow(store.language("Update command", "업데이트 명령"), status.updateCommand)
+                if !status.message.isEmpty {
+                    valueRow(store.language("Update note", "업데이트 메모"), status.message)
+                }
+            } else {
+                valueRow(store.language("Update status", "업데이트 상태"), store.language("Not checked yet", "아직 확인 안 됨"))
+            }
+
+            valueRow(store.text(.installer), "cotor install / cotor update --verify / cotor upgrade --verify / cotor delete")
             valueRow(store.text(.appLocation), "/Applications/Cotor Desktop.app or ~/Applications/Cotor Desktop.app")
             valueRow(store.text(.downloadArchive), "~/Downloads/Cotor-Desktop-macOS.dmg")
         }
+    }
+
+    private func updateStatusBadge(_ status: DesktopUpdateStatusPayload?) -> some View {
+        let text: String
+        let color: Color
+        if store.isRefreshingDesktopUpdateStatus {
+            text = store.language("Checking", "확인 중")
+            color = ShellPalette.muted
+        } else if status?.updateAvailable == true {
+            text = store.language("Update available", "업데이트 있음")
+            color = ShellPalette.warning
+        } else if status?.updateAvailable == false {
+            text = store.language("Up to date", "최신 상태")
+            color = ShellPalette.success
+        } else {
+            text = store.language("Unknown", "확인 필요")
+            color = ShellPalette.muted
+        }
+
+        return HStack(spacing: 7) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(text.uppercased())
+                .font(.system(size: 10, weight: .bold, design: .rounded))
+                .foregroundStyle(ShellPalette.text)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(
+            RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous)
+                .fill(ShellPalette.panelAlt)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: ShellMetrics.radiusSmall, style: .continuous)
+                .stroke(color.opacity(0.55), lineWidth: 1)
+        )
     }
 
     @ViewBuilder

--- a/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/DesktopStoreTests.swift
@@ -386,16 +386,16 @@ struct DesktopStoreTests {
                 availableAgentModels: [
                     "opencode": ["opencode/big-pickle", "opencode/deepseek-v4-flash-free"],
                     "codex": ["openai/gpt-5.5"],
-                    "gemma4": ["gemma4:e2b"],
-                    "ollama": ["gemma4:e2b"],
-                    "lmstudio": ["gemma4:e2b"]
+                    "gemma4": ["gemma4:12b"],
+                    "ollama": ["gemma4:12b"],
+                    "lmstudio": ["gemma4:12b"]
                 ],
                 defaultAgentModels: [
                     "opencode": "opencode/deepseek-v4-flash-free",
                     "codex": "openai/gpt-5.5",
-                    "gemma4": "gemma4:e2b",
-                    "ollama": "gemma4:e2b",
-                    "lmstudio": "gemma4:e2b"
+                    "gemma4": "gemma4:12b",
+                    "ollama": "gemma4:12b",
+                    "lmstudio": "gemma4:12b"
                 ],
                 recentCompanies: baseSettings.recentCompanies,
                 defaultLaunchMode: baseSettings.defaultLaunchMode,
@@ -432,10 +432,10 @@ struct DesktopStoreTests {
         #expect(store.newCompanyAgentModel == "openai/gpt-5.5")
 
         store.selectNewCompanyAgentCli("gemma4")
-        #expect(store.newCompanyAgentModel == "gemma4:e2b")
+        #expect(store.newCompanyAgentModel == "gemma4:12b")
 
         store.selectNewCompanyAgentCli("lmstudio")
-        #expect(store.newCompanyAgentModel == "gemma4:e2b")
+        #expect(store.newCompanyAgentModel == "gemma4:12b")
     }
 
     @Test
@@ -509,8 +509,8 @@ struct DesktopStoreTests {
                 ],
                 defaultAgentModels: [
                     "codex": "openai/gpt-5.5",
-                    "gemma4": "gemma4:e2b",
-                    "lmstudio": "gemma4:e2b"
+                    "gemma4": "gemma4:12b",
+                    "lmstudio": "gemma4:12b"
                 ],
                 recentCompanies: baseSettings.recentCompanies,
                 defaultLaunchMode: baseSettings.defaultLaunchMode,
@@ -567,7 +567,7 @@ struct DesktopStoreTests {
                     "gemma4": ["google/gemma-4-31b-it"]
                 ],
                 defaultAgentModels: [
-                    "gemma4": "gemma4:e2b"
+                    "gemma4": "gemma4:12b"
                 ],
                 recentCompanies: baseSettings.recentCompanies,
                 defaultLaunchMode: baseSettings.defaultLaunchMode,

--- a/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
+++ b/macos/Tests/CotorDesktopAppTests/ModelsTests.swift
@@ -16,10 +16,10 @@ struct ModelsTests {
     }
 
     @Test
-    func companySidebarDisclosureStateStartsCollapsed() {
+    func companySidebarDisclosureStateShowsNewCompanyDraftByDefault() {
         var state = CompanySidebarDisclosureState()
 
-        #expect(state.isCompanyDraftExpanded == false)
+        #expect(state.isCompanyDraftExpanded == true)
         #expect(state.isAdvancedSettingsExpanded == false)
 
         state.isCompanyDraftExpanded = true
@@ -347,6 +347,43 @@ struct ModelsTests {
 
         #expect(ok)
         #expect(capturedPath == "/prefix/api/app/health")
+    }
+
+    @Test
+    func desktopUpdateStatusPayloadDecodesAndUsesStableRoutePath() throws {
+        let url = try DesktopAPI.makeURL(
+            baseURL: try #require(URL(string: "http://127.0.0.1:8787/prefix")),
+            path: "api/app/update-status"
+        )
+        let status = try JSONDecoder().decode(
+            DesktopUpdateStatusPayload.self,
+            from: Data(
+                """
+                {
+                  "health": {"ok": true, "service": "cotor-app-server", "owner": "cotor-desktop", "version": "1.0.6", "build": "20260608082842"},
+                  "backendOwner": "cotor-desktop",
+                  "currentVersion": "1.0.6",
+                  "currentBuild": "20260608082842",
+                  "sourceCommit": "abc1234",
+                  "installedAppPath": "/Applications/Cotor Desktop.app",
+                  "brewFormula": "bssm-oss/cotor/cotor",
+                  "updateCommand": "cotor update --verify",
+                  "updateAvailable": true,
+                  "latestVersion": null,
+                  "latestCommit": null,
+                  "checkedAtEpochMillis": 1783050000000,
+                  "status": "UPDATE_AVAILABLE",
+                  "message": "A newer Homebrew formula is available."
+                }
+                """.utf8
+            )
+        )
+
+        #expect(url.path == "/prefix/api/app/update-status")
+        #expect(status.updateAvailable == true)
+        #expect(status.backendOwner == "cotor-desktop")
+        #expect(status.health.ok)
+        #expect(status.updateCommand == "cotor update --verify")
     }
 
     @Test

--- a/shell/cotor-merge-pr.sh
+++ b/shell/cotor-merge-pr.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Merge a Cotor PR without forcing the current worktree onto the base branch.
+
+set -euo pipefail
+
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin${PATH:+:$PATH}"
+
+METHOD="squash"
+WAIT_FOR_CHECKS=0
+DELETE_BRANCH=0
+DRY_RUN=0
+CHECK_INTERVAL="${COTOR_PR_CHECK_INTERVAL_SECONDS:-10}"
+
+usage() {
+    cat <<'USAGE'
+Usage: shell/cotor-merge-pr.sh [options] <pr-number-or-url>
+
+Options:
+  --wait              Wait for GitHub checks before merging.
+  --delete-branch     Delete the remote head branch after a successful merge.
+  --method <method>   Merge method: squash, merge, or rebase. Default: squash.
+  --dry-run           Print the planned actions without mutating GitHub or git.
+  -h, --help          Show this help.
+
+The helper avoids `gh pr merge` local checkout behavior. It merges through the
+GitHub API, then locates the worktree that owns the PR base branch and runs
+`git pull --ff-only` there.
+USAGE
+}
+
+PR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --wait)
+            WAIT_FOR_CHECKS=1
+            shift
+            ;;
+        --delete-branch)
+            DELETE_BRANCH=1
+            shift
+            ;;
+        --method)
+            METHOD="${2:-}"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -n "$PR" ]]; then
+                echo "Unexpected argument: $1"
+                usage
+                exit 2
+            fi
+            PR="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PR" ]]; then
+    usage
+    exit 2
+fi
+
+case "$METHOD" in
+    squash|merge|rebase) ;;
+    *)
+        echo "Unsupported merge method: $METHOD"
+        exit 2
+        ;;
+esac
+
+REPO="$(gh repo view --json owner,name --jq '.owner.login + "/" + .name')"
+BASE_BRANCH="$(gh pr view "$PR" --json baseRefName --jq '.baseRefName')"
+HEAD_BRANCH="$(gh pr view "$PR" --json headRefName --jq '.headRefName')"
+PR_TITLE="$(gh pr view "$PR" --json title --jq '.title')"
+MERGED_AT="$(gh pr view "$PR" --json mergedAt --jq '.mergedAt // ""')"
+
+find_base_worktree() {
+    git worktree list --porcelain | awk -v branch="refs/heads/$BASE_BRANCH" '
+        $1 == "worktree" { path = substr($0, 10) }
+        $1 == "branch" && $2 == branch { print path; exit }
+    '
+}
+
+BASE_WORKTREE="$(find_base_worktree || true)"
+
+echo "Cotor PR ship helper"
+echo "  Repo:   $REPO"
+echo "  PR:     $PR"
+echo "  Base:   $BASE_BRANCH"
+echo "  Head:   $HEAD_BRANCH"
+echo "  Method: $METHOD"
+if [[ -n "$BASE_WORKTREE" ]]; then
+    echo "  Base worktree: $BASE_WORKTREE"
+else
+    echo "  Base worktree: not found locally"
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "Dry run complete."
+    exit 0
+fi
+
+if [[ "$WAIT_FOR_CHECKS" == "1" ]]; then
+    gh pr checks "$PR" --watch --interval "$CHECK_INTERVAL"
+fi
+
+if [[ -z "$MERGED_AT" ]]; then
+    api_args=(
+        -X PUT \
+        "repos/$REPO/pulls/$PR/merge" \
+        -f "merge_method=$METHOD"
+    )
+    if [[ "$METHOD" != "rebase" ]]; then
+        api_args+=(-f "commit_title=$PR_TITLE")
+    fi
+    gh api \
+        "${api_args[@]}" \
+        --jq '.sha'
+else
+    echo "PR is already merged at $MERGED_AT."
+fi
+
+if [[ "$DELETE_BRANCH" == "1" ]]; then
+    git push origin --delete "$HEAD_BRANCH" || true
+fi
+
+if [[ -n "$BASE_WORKTREE" ]]; then
+    if [[ -n "$(git -C "$BASE_WORKTREE" status --short)" ]]; then
+        echo "Base worktree has local changes; refusing to pull there:"
+        git -C "$BASE_WORKTREE" status --short
+        exit 1
+    fi
+    git -C "$BASE_WORKTREE" fetch origin "$BASE_BRANCH"
+    git -C "$BASE_WORKTREE" pull --ff-only origin "$BASE_BRANCH"
+else
+    echo "No local worktree owns $BASE_BRANCH; remote merge is complete, but local sync was skipped."
+fi

--- a/shell/test-installed-desktop-app.sh
+++ b/shell/test-installed-desktop-app.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Verify that the installed macOS desktop bundle is signed, launchable, and healthy.
+
+set -euo pipefail
+
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin${PATH:+:$PATH}"
+
+APP_NAME="Cotor Desktop"
+BUNDLE_NAME="$APP_NAME.app"
+HEALTH_URL="${COTOR_DESKTOP_HEALTH_URL:-http://127.0.0.1:8787/health}"
+TIMEOUT_SECONDS="${COTOR_DESKTOP_SMOKE_TIMEOUT_SECONDS:-45}"
+
+if [[ -n "${COTOR_DESKTOP_APP_PATH:-}" ]]; then
+    APP_PATH="$COTOR_DESKTOP_APP_PATH"
+elif [[ -d "/Applications/$BUNDLE_NAME" ]]; then
+    APP_PATH="/Applications/$BUNDLE_NAME"
+elif [[ -d "$HOME/Applications/$BUNDLE_NAME" ]]; then
+    APP_PATH="$HOME/Applications/$BUNDLE_NAME"
+else
+    echo "Missing installed Cotor Desktop bundle."
+    echo "Checked: /Applications/$BUNDLE_NAME and $HOME/Applications/$BUNDLE_NAME"
+    exit 1
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+    echo "Installed bundle does not exist: $APP_PATH"
+    exit 1
+fi
+
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+
+echo "Verifying installed Cotor Desktop bundle"
+echo "  App:    $APP_PATH"
+echo "  Health: $HEALTH_URL"
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+if [[ -f "$INFO_PLIST" ]]; then
+    echo "  Executable: $(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$INFO_PLIST" 2>/dev/null || true)"
+    echo "  Version:    $(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST" 2>/dev/null || true)"
+    echo "  Build:      $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || true)"
+fi
+
+if [[ "${COTOR_DESKTOP_SKIP_LAUNCH:-0}" != "1" ]]; then
+    if [[ "${COTOR_DESKTOP_SKIP_QUIT:-0}" != "1" ]]; then
+        osascript -e "tell application \"$APP_NAME\" to quit" >/dev/null 2>&1 || true
+        sleep 1
+    fi
+    open "$APP_PATH"
+else
+    echo "Skipping app launch because COTOR_DESKTOP_SKIP_LAUNCH=1."
+fi
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+last_error=""
+while (( SECONDS < deadline )); do
+    if body="$(curl -fsS --max-time 2 "$HEALTH_URL" 2>&1)"; then
+        echo "Health response: $body"
+        if [[ "$body" == *'"ok":true'* || "$body" == *'"status":"ok"'* ]]; then
+            echo "Installed Cotor Desktop smoke check passed."
+            exit 0
+        fi
+        last_error="$body"
+    else
+        last_error="$body"
+    fi
+    sleep 1
+done
+
+echo "Timed out waiting for installed Cotor Desktop health after ${TIMEOUT_SECONDS}s."
+if [[ -n "$last_error" ]]; then
+    echo "Last health result: $last_error"
+fi
+exit 1

--- a/shell/update-desktop-app.sh
+++ b/shell/update-desktop-app.sh
@@ -4,6 +4,29 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY=0
+INSTALL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --verify)
+            VERIFY=1
+            shift
+            ;;
+        *)
+            INSTALL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
 
 echo "🔄 Updating Cotor Desktop..."
-exec "$SCRIPT_DIR/install-desktop-app.sh" "$@"
+if [[ "${#INSTALL_ARGS[@]}" -gt 0 ]]; then
+    "$SCRIPT_DIR/install-desktop-app.sh" "${INSTALL_ARGS[@]}"
+else
+    "$SCRIPT_DIR/install-desktop-app.sh"
+fi
+
+if [[ "$VERIFY" == "1" ]]; then
+    "$SCRIPT_DIR/test-installed-desktop-app.sh"
+fi

--- a/src/main/kotlin/com/cotor/Main.kt
+++ b/src/main/kotlin/com/cotor/Main.kt
@@ -39,7 +39,7 @@ fun main(args: Array<String>) {
         // Simple mode - just run pipeline directly
         if (!args[0].startsWith("-")) {
             when (args[0]) {
-                "hello", "help", "init", "list", "status", "version", "run", "validate", "test", "dash", "interactive", "template", "resume", "checkpoint", "stats", "doctor", "web", "lint", "explain", "plugin", "agent", "company", "auth", "app-server", "install", "update", "delete", "completion", "policy", "capability", "provider", "skill", "browser", "video", "evidence", "github", "knowledge", "verification", "runtime", "mcp" -> {
+                "hello", "help", "init", "list", "status", "version", "run", "validate", "test", "dash", "interactive", "template", "resume", "checkpoint", "stats", "doctor", "web", "lint", "explain", "plugin", "agent", "company", "auth", "app-server", "install", "update", "upgrade", "delete", "completion", "policy", "capability", "provider", "skill", "browser", "video", "evidence", "github", "knowledge", "verification", "runtime", "mcp" -> {
                     // Use full CLI for these commands
                 }
                 else -> {
@@ -90,6 +90,7 @@ fun main(args: Array<String>) {
                 McpCommand(),
                 InstallCommand(),
                 UpdateCommand(),
+                UpgradeCommand(),
                 DeleteCommand(),
                 VersionCommand(),
                 CompletionCommand()

--- a/src/main/kotlin/com/cotor/app/AppApiModels.kt
+++ b/src/main/kotlin/com/cotor/app/AppApiModels.kt
@@ -534,6 +534,24 @@ data class HealthResponse(
 )
 
 @Serializable
+data class DesktopUpdateStatusResponse(
+    val health: HealthResponse,
+    val backendOwner: String,
+    val currentVersion: String,
+    val currentBuild: String,
+    val sourceCommit: String? = null,
+    val installedAppPath: String? = null,
+    val brewFormula: String = "bssm-oss/cotor/cotor",
+    val updateCommand: String = "cotor update --verify",
+    val updateAvailable: Boolean? = null,
+    val latestVersion: String? = null,
+    val latestCommit: String? = null,
+    val checkedAtEpochMillis: Long,
+    val status: String,
+    val message: String
+)
+
+@Serializable
 data class DesktopLifecycleStartupResponse(
     val stateWarmed: Boolean,
     val companyCount: Int,

--- a/src/main/kotlin/com/cotor/app/AppServer.kt
+++ b/src/main/kotlin/com/cotor/app/AppServer.kt
@@ -374,7 +374,8 @@ internal fun Application.cotorAppModule(
     durableResumeCoordinator: DurableResumeCoordinator? = null,
     controlToken: String? = null,
     readOnlyMode: Boolean = false,
-    shutdownHandler: (() -> Unit)? = null
+    shutdownHandler: (() -> Unit)? = null,
+    desktopUpdateStatusProvider: () -> DesktopUpdateStatusResponse = ::desktopUpdateStatusResponse
 ) {
     val ktorJson = Json {
         encodeDefaults = true
@@ -436,6 +437,11 @@ internal fun Application.cotorAppModule(
             get("/health") {
                 if (!requireToken(token)) return@get
                 call.respond(appServerHealthResponse())
+            }
+
+            get("/update-status") {
+                if (!requireToken(token)) return@get
+                call.respond(desktopUpdateStatusProvider())
             }
 
             get("/help-guide") {
@@ -2403,6 +2409,7 @@ internal fun Application.cotorAppModule(
         durableRuntimeService = null,
         durableResumeCoordinator = null,
         controlToken = null,
+        desktopUpdateStatusProvider = ::desktopUpdateStatusResponse,
         shutdownHandler = shutdownHandler
     )
 }
@@ -2422,6 +2429,7 @@ internal fun Application.cotorAppModule(
         durableRuntimeService = null,
         durableResumeCoordinator = null,
         controlToken = null,
+        desktopUpdateStatusProvider = ::desktopUpdateStatusResponse,
         shutdownHandler = shutdownHandler
     )
 }
@@ -2786,7 +2794,7 @@ private fun isBearerTokenMatch(header: String?, expected: String): Boolean {
     return constantTimeEquals(actual, expected)
 }
 
-private fun appServerHealthResponse(): HealthResponse =
+internal fun appServerHealthResponse(): HealthResponse =
     HealthResponse(ok = true, service = "cotor-app-server").copy(
         owner = "cotor-desktop",
         version = CotorProperties.version,

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -6125,6 +6125,7 @@ class DesktopAppService(
                 companyId = companyId,
                 includeAllCompanies = referencesAllCompanies(normalized),
                 requestedModel = modelUpdate.requestedModel,
+                appliedAgentCli = modelUpdate.appliedAgentCli,
                 appliedModel = modelUpdate.appliedModel
             )
             summary = buildOperatorCompanySummary(companyId)
@@ -6631,8 +6632,11 @@ class DesktopAppService(
             "planner-repair" -> 45_000L
             else -> 60_000L
         }
-        val localGemmaModel = discoverGemma4ModelsCached().firstOrNull()
-        if (localGemmaModel != null) {
+        val discoveredLocalGemmaModel = discoverGemma4ModelsCached().firstOrNull()
+        val shouldTryLocalGemma = discoveredLocalGemmaModel != null ||
+            commandAvailability(resolveBuiltinExecutableAlias("ollama"))
+        if (shouldTryLocalGemma) {
+            val localGemmaModel = discoveredLocalGemmaModel ?: LocalModelDefaults.GEMMA4_MODEL
             val agent = AgentConfig(
                 name = "operator-chat-$purpose",
                 pluginClass = "com.cotor.data.plugin.LocalModelPlugin",
@@ -6643,20 +6647,18 @@ class DesktopAppService(
                 ),
                 timeout = timeoutMs
             )
-            val workingDirectory = stateStore.appHome().resolve("operator-chat-llm").also { Files.createDirectories(it) }
-            val result = agentExecutor.executeAgent(
-                agent = agent,
-                input = prompt,
-                metadata = AgentExecutionMetadata(
-                    agentId = "company-operator",
-                    workingDirectory = workingDirectory
+            try {
+                return executeOperatorChatAgent(
+                    agent = agent,
+                    prompt = prompt,
+                    failureMessage = "operator local model failed",
+                    emptyMessage = "operator local model returned empty output"
                 )
-            )
-            if (!result.isSuccess) {
-                throw IllegalStateException(result.error ?: "operator local model failed")
-            }
-            return result.output?.trim().orEmpty().ifBlank {
-                throw IllegalStateException("operator local model returned empty output")
+            } catch (error: CancellationException) {
+                throw error
+            } catch (ignored: Throwable) {
+                // Fall back to the company's configured execution model when Gemma 4 12B
+                // is not installed yet or the local server is temporarily unavailable.
             }
         }
         val requestedModel = OpenCodeDefaults.normalizeModel(selected.model)
@@ -6680,6 +6682,20 @@ class DesktopAppService(
                 timeout = timeoutMs
             )
         }
+        return executeOperatorChatAgent(
+            agent = agent,
+            prompt = prompt,
+            failureMessage = "operator LLM failed",
+            emptyMessage = "operator LLM returned empty output"
+        )
+    }
+
+    private suspend fun executeOperatorChatAgent(
+        agent: AgentConfig,
+        prompt: String,
+        failureMessage: String,
+        emptyMessage: String
+    ): String {
         val workingDirectory = stateStore.appHome().resolve("operator-chat-llm").also { Files.createDirectories(it) }
         val result = agentExecutor.executeAgent(
             agent = agent,
@@ -6690,10 +6706,10 @@ class DesktopAppService(
             )
         )
         if (!result.isSuccess) {
-            throw IllegalStateException(result.error ?: "operator LLM failed")
+            throw IllegalStateException(result.error ?: failureMessage)
         }
         return result.output?.trim().orEmpty().ifBlank {
-            throw IllegalStateException("operator LLM returned empty output")
+            throw IllegalStateException(emptyMessage)
         }
     }
 
@@ -6719,8 +6735,8 @@ class DesktopAppService(
             appendLine("""JSON: {"reply":"상태를 확인해볼게요.","toolCalls":[{"tool":"inspect_runtime","reason":"User asked whether agents/runtime are working.","args":{}}],"answerSourceHints":["company-summary"]}""")
             appendLine("""User: 막힌 일 왜 그래?""")
             appendLine("""JSON: {"reply":"막힌 이슈를 확인해볼게요.","toolCalls":[{"tool":"inspect_blocked","reason":"User asked about blocked work.","args":{}}],"answerSourceHints":["issue"]}""")
-            appendLine("""User: opencode/deepseek-v4-flash-free로 바꿔""")
-            appendLine("""JSON: {"reply":"모델 변경을 적용해볼게요.","toolCalls":[{"tool":"update_agent_models","reason":"User requested model update.","args":{"model":"opencode/deepseek-v4-flash-free"}}],"answerSourceHints":["agent-models"]}""")
+            appendLine("""User: gemma4 12b로 바꿔""")
+            appendLine("""JSON: {"reply":"Gemma 4 12B 모델 변경을 적용해볼게요.","toolCalls":[{"tool":"update_agent_models","reason":"User requested Gemma 4 12B.","args":{"model":"gemma4:12b"}}],"answerSourceHints":["agent-models"]}""")
             appendLine("""User: 브라우저로 http://localhost:3000 확인해줘""")
             appendLine("""JSON: {"reply":"브라우저 스킬로 확인해볼게요.","toolCalls":[{"tool":"run_skill","reason":"User asked for browser evidence.","args":{"skill":"browser-smoke","url":"http://localhost:3000"}}],"answerSourceHints":["skill-run"]}""")
             appendLine("""User: 리포 구조 알려줘""")
@@ -6753,13 +6769,18 @@ class DesktopAppService(
                     ?: userMessage
                 val modelUpdate = resolveOperatorModelUpdate(requested)
                     ?: resolveOperatorModelUpdate("opencode $requested model")
-                    ?: OperatorModelUpdate(requestedModel = requested, appliedModel = OpenCodeDefaults.DEFAULT_MODEL)
+                    ?: OperatorModelUpdate(
+                        requestedModel = requested,
+                        appliedAgentCli = "opencode",
+                        appliedModel = OpenCodeDefaults.DEFAULT_MODEL
+                    )
                 val includeAllCompanies = toolCall.args["includeAllCompanies"]?.toBooleanStrictOrNull()
                     ?: referencesAllCompanies(userMessage.lowercase())
                 val action = updateOperatorAgentModels(
                     companyId = companyId,
                     includeAllCompanies = includeAllCompanies,
                     requestedModel = modelUpdate.requestedModel,
+                    appliedAgentCli = modelUpdate.appliedAgentCli,
                     appliedModel = modelUpdate.appliedModel
                 )
                 OperatorChatToolExecution(
@@ -7655,6 +7676,7 @@ class DesktopAppService(
 
     private data class OperatorModelUpdate(
         val requestedModel: String,
+        val appliedAgentCli: String,
         val appliedModel: String
     )
 
@@ -7662,6 +7684,7 @@ class DesktopAppService(
         companyId: String,
         includeAllCompanies: Boolean,
         requestedModel: String,
+        appliedAgentCli: String,
         appliedModel: String
     ): OperatorCommandAction = stateMutex.withLock {
         val state = stateStore.load()
@@ -7684,7 +7707,7 @@ class DesktopAppService(
         val nextDefinitions = state.companyAgentDefinitions.map { definition ->
             if (definition.id in updatedDefinitionIds && definition.companyId in targetCompanyIds) {
                 definition.copy(
-                    agentCli = "opencode",
+                    agentCli = appliedAgentCli,
                     model = appliedModel,
                     updatedAt = now
                 )
@@ -7715,7 +7738,7 @@ class DesktopAppService(
         OperatorCommandAction(
             type = "agent-model-update",
             title = "Agent models updated",
-            detail = "${targetDefinitions.size} agent(s) were moved to opencode with $appliedModel across ${targetCompanies.size} company scope(s). Requested model: $requestedModel. Applied model: $appliedModel.",
+            detail = "${targetDefinitions.size} agent(s) were moved to $appliedAgentCli with $appliedModel across ${targetCompanies.size} company scope(s). Requested model: $requestedModel. Applied model: $appliedModel.",
             status = "DONE"
         )
     }
@@ -8319,9 +8342,33 @@ class DesktopAppService(
     private fun resolveOperatorModelUpdate(rawText: String): OperatorModelUpdate? {
         val text = rawText.lowercase()
         val mentionsOpenCode = text.contains("opencode")
+        val mentionsGemma = containsAny(text, "gemma", "젬마")
         val mentionsModelChange =
-            containsAny(text, "model", "모델", "바꿔", "변경", "change", "set", "update", "deepseek", "nemotron", "free", "무료")
-        if (!mentionsOpenCode || !mentionsModelChange) {
+            containsAny(text, "model", "모델", "바꿔", "변경", "change", "set", "update", "deepseek", "nemotron", "free", "무료", "12b")
+        if (!mentionsModelChange) {
+            return null
+        }
+        if (mentionsGemma) {
+            Regex("""\b(?:gemma4:[a-z0-9._:-]+|google/gemma-4-[a-z0-9._:-]+)\b""")
+                .find(text)
+                ?.value
+                ?.let { explicit ->
+                    val normalized = LocalModelDefaults.normalizeModel(explicit)
+                    if (normalized?.let(LocalModelDefaults::isGemma4Model) == true) {
+                        return OperatorModelUpdate(
+                            requestedModel = explicit,
+                            appliedAgentCli = "gemma4",
+                            appliedModel = normalized
+                        )
+                    }
+                }
+            return OperatorModelUpdate(
+                requestedModel = "gemma4 12b",
+                appliedAgentCli = "gemma4",
+                appliedModel = LocalModelDefaults.GEMMA4_MODEL
+            )
+        }
+        if (!mentionsOpenCode) {
             return null
         }
 
@@ -8331,13 +8378,18 @@ class DesktopAppService(
             ?.let { explicit ->
                 val normalized = OpenCodeDefaults.normalizeModel(explicit)
                 if (normalized?.let(OpenCodeDefaults::isSelectableModel) == true) {
-                    return OperatorModelUpdate(requestedModel = explicit, appliedModel = normalized)
+                    return OperatorModelUpdate(
+                        requestedModel = explicit,
+                        appliedAgentCli = "opencode",
+                        appliedModel = normalized
+                    )
                 }
             }
 
         if (text.contains("deepseek")) {
             return OperatorModelUpdate(
                 requestedModel = "opencode deepseek",
+                appliedAgentCli = "opencode",
                 appliedModel = OpenCodeDefaults.DEEPSEEK_FLASH_MODEL
             )
         }
@@ -8345,12 +8397,14 @@ class DesktopAppService(
         if (containsAny(text, "nemotron", "free", "무료")) {
             return OperatorModelUpdate(
                 requestedModel = "opencode free",
+                appliedAgentCli = "opencode",
                 appliedModel = OpenCodeDefaults.DEFAULT_MODEL
             )
         }
 
         return OperatorModelUpdate(
             requestedModel = "opencode default",
+            appliedAgentCli = "opencode",
             appliedModel = OpenCodeDefaults.DEFAULT_MODEL
         )
     }

--- a/src/main/kotlin/com/cotor/app/DesktopUpdateStatus.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopUpdateStatus.kt
@@ -1,0 +1,168 @@
+package com.cotor.app
+
+import com.cotor.data.config.CotorProperties
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+
+private const val COTOR_BREW_FORMULA = "bssm-oss/cotor/cotor"
+private const val BUNDLED_DESKTOP_APP_NAME = "Cotor Desktop.app"
+private const val UPDATE_STATUS_TIMEOUT_SECONDS = 8L
+private const val UPDATE_STATUS_OUTPUT_LIMIT_CHARS = 16 * 1024
+
+internal fun desktopUpdateStatusResponse(
+    environment: Map<String, String> = System.getenv(),
+    homeDirectoryProvider: () -> Path = {
+        Paths.get(System.getProperty("user.home") ?: ".").toAbsolutePath().normalize()
+    },
+    commandRunner: (List<String>, Path?) -> UpdateStatusCommandResult = ::runUpdateStatusCommand
+): DesktopUpdateStatusResponse {
+    val health = appServerHealthResponse()
+    val installedAppPath = resolveInstalledDesktopAppPath(environment, homeDirectoryProvider)
+    val sourceCommit = resolveSourceCommit(commandRunner)
+    val brewStatus = resolveBrewUpdateStatus(commandRunner)
+
+    return DesktopUpdateStatusResponse(
+        health = health,
+        backendOwner = health.owner,
+        currentVersion = CotorProperties.version,
+        currentBuild = System.getProperty("cotor.build", CotorProperties.version),
+        sourceCommit = sourceCommit,
+        installedAppPath = installedAppPath?.toString(),
+        brewFormula = COTOR_BREW_FORMULA,
+        updateCommand = "cotor update --verify",
+        updateAvailable = brewStatus.updateAvailable,
+        latestVersion = brewStatus.latestVersion,
+        latestCommit = null,
+        checkedAtEpochMillis = System.currentTimeMillis(),
+        status = brewStatus.status,
+        message = brewStatus.message
+    )
+}
+
+private data class BrewStatus(
+    val updateAvailable: Boolean?,
+    val latestVersion: String?,
+    val status: String,
+    val message: String
+)
+
+internal data class UpdateStatusCommandResult(
+    val exitCode: Int,
+    val output: String
+)
+
+private fun resolveBrewUpdateStatus(
+    commandRunner: (List<String>, Path?) -> UpdateStatusCommandResult
+): BrewStatus {
+    val installed = commandRunner(listOf("/usr/bin/env", "brew", "list", "--versions", COTOR_BREW_FORMULA), null)
+    if (installed.exitCode != 0) {
+        return BrewStatus(
+            updateAvailable = null,
+            latestVersion = null,
+            status = "UNKNOWN",
+            message = "Homebrew formula is not installed or brew is unavailable."
+        )
+    }
+
+    val outdated = commandRunner(listOf("/usr/bin/env", "brew", "outdated", "--formula", "--quiet", COTOR_BREW_FORMULA), null)
+    val outdatedLines = outdated.output
+        .lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toList()
+    if (outdatedLines.isNotEmpty()) {
+        return BrewStatus(
+            updateAvailable = true,
+            latestVersion = null,
+            status = "UPDATE_AVAILABLE",
+            message = "A newer Homebrew formula is available. Run cotor update --verify."
+        )
+    }
+    if (outdated.exitCode != 0) {
+        return BrewStatus(
+            updateAvailable = null,
+            latestVersion = null,
+            status = "UNKNOWN",
+            message = "Could not check Homebrew update status."
+        )
+    }
+
+    val installedVersion = installed.output.trim().ifBlank { COTOR_BREW_FORMULA }
+    return BrewStatus(
+        updateAvailable = false,
+        latestVersion = null,
+        status = "UP_TO_DATE",
+        message = "Homebrew reports Cotor is up to date: $installedVersion"
+    )
+}
+
+private fun resolveSourceCommit(
+    commandRunner: (List<String>, Path?) -> UpdateStatusCommandResult
+): String? {
+    val cwd = Paths.get("").toAbsolutePath().normalize()
+    if (!cwd.resolve(".git").exists()) {
+        return null
+    }
+    val result = commandRunner(listOf("/usr/bin/env", "git", "rev-parse", "--short", "HEAD"), cwd)
+    return result.output.trim().takeIf { result.exitCode == 0 && it.isNotBlank() }
+}
+
+private fun resolveInstalledDesktopAppPath(
+    environment: Map<String, String>,
+    homeDirectoryProvider: () -> Path
+): Path? {
+    environment["COTOR_DESKTOP_APP_PATH"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let { Paths.get(it).toAbsolutePath().normalize() }
+        ?.takeIf { it.isDirectory() }
+        ?.let { return it }
+
+    val candidates = buildList {
+        environment["COTOR_DESKTOP_INSTALL_ROOT"]
+            ?.takeIf { it.isNotBlank() }
+            ?.let { add(Paths.get(it).toAbsolutePath().normalize().resolve(BUNDLED_DESKTOP_APP_NAME)) }
+        add(Paths.get("/Applications").resolve(BUNDLED_DESKTOP_APP_NAME))
+        add(homeDirectoryProvider().resolve("Applications").resolve(BUNDLED_DESKTOP_APP_NAME))
+    }
+    return candidates.firstOrNull { it.isDirectory() }
+}
+
+private fun runUpdateStatusCommand(command: List<String>, workingDirectory: Path?): UpdateStatusCommandResult {
+    val process = runCatching {
+        ProcessBuilder(command)
+            .redirectErrorStream(true)
+            .apply {
+                workingDirectory?.let { directory(it.toFile()) }
+            }
+            .start()
+    }.getOrElse { error ->
+        return UpdateStatusCommandResult(127, error.message ?: error::class.simpleName.orEmpty())
+    }
+
+    val output = StringBuilder()
+    val reader = Thread {
+        runCatching {
+            process.inputStream.bufferedReader().useLines { lines ->
+                lines.forEach { line ->
+                    if (output.length < UPDATE_STATUS_OUTPUT_LIMIT_CHARS) {
+                        output.appendLine(line)
+                    }
+                }
+            }
+        }
+    }
+    reader.isDaemon = true
+    reader.start()
+
+    val finished = process.waitFor(UPDATE_STATUS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    if (!finished) {
+        process.destroyForcibly()
+        reader.join(500)
+        return UpdateStatusCommandResult(124, "Command timed out: ${command.joinToString(" ")}")
+    }
+    reader.join(500)
+    return UpdateStatusCommandResult(process.exitValue(), output.toString())
+}

--- a/src/main/kotlin/com/cotor/app/ProviderModels.kt
+++ b/src/main/kotlin/com/cotor/app/ProviderModels.kt
@@ -1,5 +1,6 @@
 package com.cotor.app
 
+import com.cotor.model.LocalModelDefaults
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -98,8 +99,8 @@ fun directChatProviderCatalog(): List<DirectChatProviderCatalogEntry> = listOf(
         providerId = "ollama",
         displayName = "Ollama (local)",
         iconSystemName = "cpu.fill",
-        defaultModel = "gemma3",
-        defaultBaseUrl = "http://127.0.0.1:11434",
+        defaultModel = LocalModelDefaults.GEMMA4_MODEL,
+        defaultBaseUrl = LocalModelDefaults.OLLAMA_BASE_URL,
         allowsBaseUrl = true,
         supportsModelDiscovery = true
     ),
@@ -108,8 +109,8 @@ fun directChatProviderCatalog(): List<DirectChatProviderCatalogEntry> = listOf(
         providerId = "lm-studio",
         displayName = "LM Studio (local)",
         iconSystemName = "server.rack",
-        defaultModel = "model-name",
-        defaultBaseUrl = "http://127.0.0.1:1234",
+        defaultModel = LocalModelDefaults.GEMMA4_12B_HUGGING_FACE_INSTRUCT_MODEL,
+        defaultBaseUrl = LocalModelDefaults.LM_STUDIO_BASE_URL.removeSuffix("/v1"),
         allowsBaseUrl = true
     ),
     DirectChatProviderCatalogEntry(

--- a/src/main/kotlin/com/cotor/model/LocalModelDefaults.kt
+++ b/src/main/kotlin/com/cotor/model/LocalModelDefaults.kt
@@ -4,7 +4,10 @@ package com.cotor.model
  * Defaults for local OpenAI-compatible and Ollama model servers.
  */
 object LocalModelDefaults {
-    const val GEMMA4_MODEL = "gemma4:e2b"
+    const val GEMMA4_12B_OLLAMA_MODEL = "gemma4:12b"
+    const val GEMMA4_12B_HUGGING_FACE_MODEL = "google/gemma-4-12B"
+    const val GEMMA4_12B_HUGGING_FACE_INSTRUCT_MODEL = "google/gemma-4-12B-it"
+    const val GEMMA4_MODEL = GEMMA4_12B_OLLAMA_MODEL
     const val OLLAMA_BASE_URL = "http://127.0.0.1:11434"
     const val LM_STUDIO_BASE_URL = "http://127.0.0.1:1234/v1"
 
@@ -30,7 +33,17 @@ object LocalModelDefaults {
 
     fun preferredInstalledGemmaModels(models: List<String>): List<String> {
         val normalized = models.mapNotNull(::normalizeModel).distinct()
-        val gemma4Models = normalized.filter(::isGemma4Model)
+        val preferredGemma4Models = listOf(
+            GEMMA4_12B_OLLAMA_MODEL,
+            GEMMA4_12B_HUGGING_FACE_INSTRUCT_MODEL,
+            GEMMA4_12B_HUGGING_FACE_MODEL
+        )
+        val preferredMatches = preferredGemma4Models.mapNotNull { preferred ->
+            normalized.firstOrNull { it.equals(preferred, ignoreCase = true) }
+        }
+        val gemma4Models = preferredMatches + normalized.filter { model ->
+            isGemma4Model(model) && preferredMatches.none { it.equals(model, ignoreCase = true) }
+        }
         val otherGemmaModels = normalized.filter { isGemmaFamilyModel(it) && !isGemma4Model(it) }
         return gemma4Models + otherGemmaModels
     }

--- a/src/main/kotlin/com/cotor/model/OpenCodeDefaults.kt
+++ b/src/main/kotlin/com/cotor/model/OpenCodeDefaults.kt
@@ -9,7 +9,7 @@ package com.cotor.model
 object OpenCodeDefaults {
     const val DEFAULT_MODEL = "opencode/deepseek-v4-flash-free"
     const val DEEPSEEK_FLASH_MODEL = "opencode-go/deepseek-v4-flash"
-    const val LOCAL_OLLAMA_GEMMA_MODEL = "ollama/gemma3:4b"
+    const val LOCAL_OLLAMA_GEMMA_MODEL = "ollama/gemma4:12b"
     const val LOCAL_OLLAMA_EXECUTION_MODE = "local-ollama-opencode"
     const val LOCAL_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1"
 

--- a/src/main/kotlin/com/cotor/presentation/cli/DesktopInstalledAppVerification.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/DesktopInstalledAppVerification.kt
@@ -1,0 +1,142 @@
+package com.cotor.presentation.cli
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+
+private const val DEFAULT_DESKTOP_HEALTH_URL = "http://127.0.0.1:8787/health"
+private const val DEFAULT_DESKTOP_SMOKE_TIMEOUT_SECONDS = 45L
+private const val DESKTOP_VERIFICATION_OUTPUT_LIMIT_CHARS = 64 * 1024
+
+internal fun runInstalledDesktopAppVerification(
+    layout: DesktopInstallLayout,
+    environment: Map<String, String> = System.getenv(),
+    homeDirectoryProvider: () -> Path = {
+        desktopInstallHomeDirectory(environment)
+    }
+): DesktopScriptResult {
+    if (layout.kind == DesktopInstallLayoutKind.SOURCE_CHECKOUT) {
+        val sourceScript = layout.root.resolve("shell").resolve("test-installed-desktop-app.sh")
+        if (sourceScript.exists()) {
+            return runDesktopScript(layout.root, "test-installed-desktop-app.sh")
+        }
+    }
+
+    val appPath = resolveInstalledDesktopAppPath(environment, homeDirectoryProvider)
+        ?: return DesktopScriptResult(
+            exitCode = 1,
+            output = buildString {
+                appendLine("Missing installed Cotor Desktop bundle.")
+                appendLine("Checked: /Applications/$BUNDLED_DESKTOP_APP_NAME and ${homeDirectoryProvider().resolve("Applications").resolve(BUNDLED_DESKTOP_APP_NAME)}")
+            }
+        )
+
+    val healthUrl = environment["COTOR_DESKTOP_HEALTH_URL"]
+        ?.takeIf { it.isNotBlank() }
+        ?: DEFAULT_DESKTOP_HEALTH_URL
+    val timeoutSeconds = environment["COTOR_DESKTOP_SMOKE_TIMEOUT_SECONDS"]
+        ?.toLongOrNull()
+        ?.coerceAtLeast(1)
+        ?: DEFAULT_DESKTOP_SMOKE_TIMEOUT_SECONDS
+
+    val output = StringBuilder()
+    output.appendLine("Verifying installed Cotor Desktop bundle")
+    output.appendLine("  App:    $appPath")
+    output.appendLine("  Health: $healthUrl")
+
+    val codesign = runVerificationCommand(
+        listOf("/usr/bin/codesign", "--verify", "--deep", "--strict", "--verbose=2", appPath.toString()),
+        timeoutSeconds = 30
+    )
+    output.append(codesign.output)
+    if (codesign.exitCode != 0) {
+        return DesktopScriptResult(codesign.exitCode, output.toString())
+    }
+
+    if (environment["COTOR_DESKTOP_SKIP_LAUNCH"] != "1") {
+        if (environment["COTOR_DESKTOP_SKIP_QUIT"] != "1") {
+            val quit = runVerificationCommand(
+                listOf("/usr/bin/osascript", "-e", "tell application \"Cotor Desktop\" to quit"),
+                timeoutSeconds = 10
+            )
+            if (quit.output.isNotBlank()) {
+                output.append(quit.output)
+            }
+            Thread.sleep(1_000)
+        }
+
+        val launch = runVerificationCommand(
+            listOf("/usr/bin/open", appPath.toString()),
+            timeoutSeconds = 10
+        )
+        output.append(launch.output)
+        if (launch.exitCode != 0) {
+            return DesktopScriptResult(launch.exitCode, output.toString())
+        }
+    } else {
+        output.appendLine("Skipping app launch because COTOR_DESKTOP_SKIP_LAUNCH=1.")
+    }
+
+    val deadline = System.nanoTime() + timeoutSeconds * 1_000_000_000L
+    var lastProbe = ""
+    while (System.nanoTime() < deadline) {
+        val probe = runVerificationCommand(
+            listOf("/usr/bin/curl", "-fsS", "--max-time", "2", healthUrl),
+            timeoutSeconds = 3
+        )
+        if (probe.output.isNotBlank()) {
+            lastProbe = probe.output.trim()
+        }
+        if (probe.exitCode == 0 && (lastProbe.contains("\"ok\":true") || lastProbe.contains("\"status\":\"ok\""))) {
+            output.appendLine("Health response: $lastProbe")
+            output.appendLine("Installed Cotor Desktop smoke check passed.")
+            return DesktopScriptResult(0, output.toString())
+        }
+        Thread.sleep(1_000)
+    }
+
+    output.appendLine("Timed out waiting for installed Cotor Desktop health after ${timeoutSeconds}s.")
+    if (lastProbe.isNotBlank()) {
+        output.appendLine("Last health result: $lastProbe")
+    }
+    return DesktopScriptResult(1, output.toString())
+}
+
+internal fun resolveInstalledDesktopAppPath(
+    environment: Map<String, String> = System.getenv(),
+    homeDirectoryProvider: () -> Path = {
+        desktopInstallHomeDirectory(environment)
+    }
+): Path? {
+    environment["COTOR_DESKTOP_APP_PATH"]
+        ?.takeIf { it.isNotBlank() }
+        ?.let { Paths.get(it).toAbsolutePath().normalize() }
+        ?.takeIf { it.isDirectory() }
+        ?.let { return it }
+
+    val roots = buildList {
+        environment["COTOR_DESKTOP_INSTALL_ROOT"]
+            ?.takeIf { it.isNotBlank() }
+            ?.let { add(Paths.get(it).toAbsolutePath().normalize()) }
+        add(Paths.get("/Applications"))
+        add(homeDirectoryProvider().resolve("Applications"))
+    }
+
+    return roots
+        .map { it.resolve(BUNDLED_DESKTOP_APP_NAME) }
+        .firstOrNull { it.isDirectory() }
+}
+
+private fun runVerificationCommand(
+    command: List<String>,
+    timeoutSeconds: Long
+): DesktopScriptResult =
+    runDesktopCommand(
+        command = command,
+        timeoutSeconds = timeoutSeconds,
+        outputLimitChars = DESKTOP_VERIFICATION_OUTPUT_LIMIT_CHARS,
+        timeoutMessage = { effectiveTimeout ->
+            "Desktop verification command timed out after ${effectiveTimeout}s: ${command.joinToString(" ")}"
+        }
+    )

--- a/src/main/kotlin/com/cotor/presentation/cli/DesktopLifecycleCommand.kt
+++ b/src/main/kotlin/com/cotor/presentation/cli/DesktopLifecycleCommand.kt
@@ -10,6 +10,8 @@ package com.cotor.presentation.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import java.nio.file.Path
 import kotlin.io.path.exists
 
@@ -21,6 +23,7 @@ data class DesktopScriptResult(
 internal typealias DesktopScriptRunner = (Path, String) -> DesktopScriptResult
 internal typealias PackagedDesktopActionRunner = (DesktopInstallLayout, DesktopInstallAction) -> DesktopScriptResult
 internal typealias DesktopLayoutResolver = () -> DesktopInstallLayout?
+internal typealias DesktopVerificationRunner = (DesktopInstallLayout) -> DesktopScriptResult
 internal typealias OsNameProvider = () -> String
 
 internal abstract class DesktopLifecycleCommand(
@@ -29,9 +32,15 @@ internal abstract class DesktopLifecycleCommand(
     private val action: DesktopInstallAction,
     private val scriptRunner: DesktopScriptRunner = ::runDesktopScript,
     private val packagedActionRunner: PackagedDesktopActionRunner = ::runPackagedDesktopAction,
+    private val verificationRunner: DesktopVerificationRunner = ::runInstalledDesktopAppVerification,
     private val layoutResolver: DesktopLayoutResolver = ::detectDesktopInstallLayout,
     private val osNameProvider: OsNameProvider = { System.getProperty("os.name") }
 ) : CliktCommand(name = commandName, help = commandHelp) {
+    private val verify by option(
+        "--verify",
+        help = "After install or update, launch the installed desktop app and verify codesign plus /health."
+    ).flag(default = false)
+
     override fun run() {
         if (!isMacOs(osNameProvider())) {
             echo("This command currently supports macOS only.")
@@ -61,12 +70,30 @@ internal abstract class DesktopLifecycleCommand(
             echo("cotor ${action.actionLabel} failed.")
             throw ProgramResult(result.exitCode)
         }
+
+        if (verify && action != DesktopInstallAction.DELETE) {
+            val verification = verificationRunner(layout)
+            if (verification.output.isNotBlank()) {
+                val lines = verification.output.lines()
+                lines.forEachIndexed { index, line ->
+                    val isTrailingEmptyLine = index == lines.lastIndex && line.isEmpty()
+                    if (!isTrailingEmptyLine) {
+                        echo(line)
+                    }
+                }
+            }
+            if (verification.exitCode != 0) {
+                echo("cotor desktop verification failed.")
+                throw ProgramResult(verification.exitCode)
+            }
+        }
     }
 }
 
 internal class InstallCommand(
     scriptRunner: DesktopScriptRunner = ::runDesktopScript,
     packagedActionRunner: PackagedDesktopActionRunner = ::runPackagedDesktopAction,
+    verificationRunner: DesktopVerificationRunner = ::runInstalledDesktopAppVerification,
     layoutResolver: DesktopLayoutResolver = ::detectDesktopInstallLayout,
     osNameProvider: OsNameProvider = { System.getProperty("os.name") }
 ) : DesktopLifecycleCommand(
@@ -75,6 +102,7 @@ internal class InstallCommand(
     action = DesktopInstallAction.INSTALL,
     scriptRunner = scriptRunner,
     packagedActionRunner = packagedActionRunner,
+    verificationRunner = verificationRunner,
     layoutResolver = layoutResolver,
     osNameProvider = osNameProvider
 )
@@ -82,6 +110,7 @@ internal class InstallCommand(
 internal class UpdateCommand(
     scriptRunner: DesktopScriptRunner = ::runDesktopScript,
     packagedActionRunner: PackagedDesktopActionRunner = ::runPackagedDesktopAction,
+    verificationRunner: DesktopVerificationRunner = ::runInstalledDesktopAppVerification,
     layoutResolver: DesktopLayoutResolver = ::detectDesktopInstallLayout,
     osNameProvider: OsNameProvider = { System.getProperty("os.name") }
 ) : DesktopLifecycleCommand(
@@ -90,6 +119,24 @@ internal class UpdateCommand(
     action = DesktopInstallAction.UPDATE,
     scriptRunner = scriptRunner,
     packagedActionRunner = packagedActionRunner,
+    verificationRunner = verificationRunner,
+    layoutResolver = layoutResolver,
+    osNameProvider = osNameProvider
+)
+
+internal class UpgradeCommand(
+    scriptRunner: DesktopScriptRunner = ::runDesktopScript,
+    packagedActionRunner: PackagedDesktopActionRunner = ::runPackagedDesktopAction,
+    verificationRunner: DesktopVerificationRunner = ::runInstalledDesktopAppVerification,
+    layoutResolver: DesktopLayoutResolver = ::detectDesktopInstallLayout,
+    osNameProvider: OsNameProvider = { System.getProperty("os.name") }
+) : DesktopLifecycleCommand(
+    commandName = "upgrade",
+    commandHelp = "Upgrade Cotor through Homebrew or update the source-installed desktop app.",
+    action = DesktopInstallAction.UPDATE,
+    scriptRunner = scriptRunner,
+    packagedActionRunner = packagedActionRunner,
+    verificationRunner = verificationRunner,
     layoutResolver = layoutResolver,
     osNameProvider = osNameProvider
 )
@@ -97,6 +144,7 @@ internal class UpdateCommand(
 internal class DeleteCommand(
     scriptRunner: DesktopScriptRunner = ::runDesktopScript,
     packagedActionRunner: PackagedDesktopActionRunner = ::runPackagedDesktopAction,
+    verificationRunner: DesktopVerificationRunner = ::runInstalledDesktopAppVerification,
     layoutResolver: DesktopLayoutResolver = ::detectDesktopInstallLayout,
     osNameProvider: OsNameProvider = { System.getProperty("os.name") }
 ) : DesktopLifecycleCommand(
@@ -105,6 +153,7 @@ internal class DeleteCommand(
     action = DesktopInstallAction.DELETE,
     scriptRunner = scriptRunner,
     packagedActionRunner = packagedActionRunner,
+    verificationRunner = verificationRunner,
     layoutResolver = layoutResolver,
     osNameProvider = osNameProvider
 )

--- a/src/main/kotlin/com/cotor/security/DefaultSecurityConfig.kt
+++ b/src/main/kotlin/com/cotor/security/DefaultSecurityConfig.kt
@@ -54,8 +54,10 @@ fun defaultAllowedDirectories(allowedExecutables: Set<String> = defaultAllowedEx
         .split(File.pathSeparator)
         .mapNotNull { it.trim().takeIf(String::isNotBlank) }
         .map { Path(it).toAbsolutePath().normalize() }
-    val executableDirectories = allowedExecutables.mapNotNull { executable ->
-        runCatching { resolveExecutablePath(executable)?.parent }.getOrNull()
+    val executableDirectories = allowedExecutables.flatMap { executable ->
+        runCatching {
+            resolveExecutablePath(executable)?.let { executableAllowedDirectories(it) }.orEmpty()
+        }.getOrDefault(emptyList())
     }
     val userHome = Path(System.getProperty("user.home")).toAbsolutePath().normalize()
     val conventionalDirectories = listOf(
@@ -77,4 +79,28 @@ fun defaultAllowedDirectories(allowedExecutables: Set<String> = defaultAllowedEx
         .map { it.toAbsolutePath().normalize() }
         .filter { Files.exists(it) }
         .distinct()
+}
+
+internal fun executableAllowedDirectories(executablePath: Path): List<Path> {
+    val directories = mutableListOf<Path>()
+    val visited = mutableSetOf<Path>()
+    var current = executablePath.toAbsolutePath().normalize()
+
+    repeat(16) {
+        current.parent?.let(directories::add) ?: return directories.distinct()
+        if (!Files.isSymbolicLink(current)) {
+            return directories.distinct()
+        }
+        if (!visited.add(current)) {
+            return directories.distinct()
+        }
+        val target = Files.readSymbolicLink(current)
+        current = if (target.isAbsolute) {
+            target.normalize()
+        } else {
+            current.parent.resolve(target).normalize()
+        }
+    }
+
+    return directories.distinct()
 }

--- a/src/test/kotlin/com/cotor/app/AppServerTest.kt
+++ b/src/test/kotlin/com/cotor/app/AppServerTest.kt
@@ -84,6 +84,49 @@ class AppServerTest : FunSpec({
         }
     }
 
+    test("update status route returns installed app and Homebrew metadata when authorized") {
+        testApplication {
+            application {
+                cotorAppModule(
+                    token = "secret-token",
+                    desktopService = desktopService,
+                    tuiSessionService = tuiSessionService,
+                    desktopUpdateStatusProvider = {
+                        DesktopUpdateStatusResponse(
+                            health = HealthResponse(
+                                ok = true,
+                                service = "cotor-app-server",
+                                owner = "cotor-desktop",
+                                version = "1.0.6",
+                                build = "20260608082842"
+                            ),
+                            backendOwner = "cotor-desktop",
+                            currentVersion = "1.0.6",
+                            currentBuild = "20260608082842",
+                            sourceCommit = "abc1234",
+                            installedAppPath = "/Applications/Cotor Desktop.app",
+                            updateAvailable = true,
+                            checkedAtEpochMillis = 1_783_050_000_000,
+                            status = "UPDATE_AVAILABLE",
+                            message = "A newer Homebrew formula is available. Run cotor update --verify."
+                        )
+                    }
+                )
+            }
+
+            val response = client.get("/api/app/update-status") {
+                header("Authorization", "Bearer secret-token")
+            }
+            val body = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.OK
+            body shouldContain "\"backendOwner\":\"cotor-desktop\""
+            body shouldContain "\"installedAppPath\":\"/Applications/Cotor Desktop.app\""
+            body shouldContain "\"updateAvailable\":true"
+            body shouldContain "\"updateCommand\":\"cotor update --verify\""
+        }
+    }
+
     test("file origin terminal preflight is allowed for bearer-protected TUI routes") {
         testApplication {
             application {
@@ -555,7 +598,7 @@ class AppServerTest : FunSpec({
                 providerId = "ollama",
                 displayName = "Ollama (local)",
                 iconSystemName = "cpu.fill",
-                defaultModel = "gemma3",
+                defaultModel = "gemma4:12b",
                 defaultBaseUrl = "http://127.0.0.1:11434",
                 supportsModelDiscovery = true
             )

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceAgentModelNormalizationTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceAgentModelNormalizationTest.kt
@@ -101,11 +101,11 @@ class DesktopAppServiceAgentModelNormalizationTest : FunSpec({
             companyId = company.id,
             agentId = builder.id,
             agentCli = "gemma4",
-            model = "gemma4:e2b"
+            model = "gemma4:12b"
         )
 
         updated.agentCli shouldBe "gemma4"
-        updated.model shouldBe "gemma4:e2b"
+        updated.model shouldBe "gemma4:12b"
     }
 })
 

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceAiOnlyIntegrationTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceAiOnlyIntegrationTest.kt
@@ -324,6 +324,13 @@ class DesktopAppServiceAiOnlyIntegrationTest : FunSpec({
                 qaIssue.status shouldBe IssueStatus.PLANNED
                 qaIssue.pullRequestNumber shouldBe 42
                 qaIssue.pullRequestUrl shouldBe "https://github.com/example/cotor/pull/42"
+
+                val executionDetail = service.issueExecutionDetails(issue.id).single()
+                executionDetail.agentCli shouldBe "opencode"
+                executionDetail.branchName shouldBe settledIssue.branchName
+                executionDetail.pullRequestUrl shouldBe "https://github.com/example/cotor/pull/42"
+                executionDetail.publishSummary shouldContain "pr state: OPEN"
+                executionDetail.assignedPrompt shouldContain "Produce code that should open a review queue item."
             } finally {
                 service.shutdown()
             }

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -17,6 +17,7 @@ import com.cotor.integrations.linear.LinearTrackerAdapter
 import com.cotor.model.AgentConfig
 import com.cotor.model.AgentExecutionMetadata
 import com.cotor.model.AgentResult
+import com.cotor.model.LocalModelDefaults
 import com.cotor.model.OpenCodeDefaults
 import com.cotor.model.ProcessExecutionException
 import com.cotor.model.ProcessResult
@@ -126,7 +127,7 @@ class DesktopAppServiceTest : FunSpec({
 
     test("builtin local model and graphify agents are available by default") {
         BuiltinAgentCatalog.names().containsAll(listOf("gemma4", "ollama", "lmstudio", "graphify")) shouldBe true
-        BuiltinAgentCatalog.get("gemma4")!!.parameters["model"] shouldBe "gemma4:e2b"
+        BuiltinAgentCatalog.get("gemma4")!!.parameters["model"] shouldBe "gemma4:12b"
         BuiltinAgentCatalog.get("ollama")!!.parameters["baseUrl"] shouldBe "http://127.0.0.1:11434"
         BuiltinAgentCatalog.get("lmstudio")!!.parameters["baseUrl"] shouldBe "http://127.0.0.1:1234/v1"
         BuiltinAgentCatalog.get("graphify")!!.parameters["argvJson"] shouldBe """["graphify","explain","{input}"]"""
@@ -667,6 +668,29 @@ class DesktopAppServiceTest : FunSpec({
         response.actions.single { it.type == "agent-model-update" }.detail shouldContain "Requested model: opencode/deepseek-v4-flash-free"
     }
 
+    test("operator command switches company agents to Gemma 4 12B from chat") {
+        val appHome = Files.createTempDirectory("operator-gemma4-model-home")
+        val stateStore = DesktopStateStore { appHome }
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = mockk(relaxed = true),
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(name = "Operator Gemma Model", rootPath = appHome.toString())
+
+        val response = service.runOperatorCommand(company.id, "모든 에이전트 gemma4 12b 모델로 바꿔줘")
+        val persisted = service.listCompanyAgentDefinitions(company.id)
+
+        response.actions.any { it.type == "agent-model-update" && it.status == "DONE" } shouldBe true
+        persisted.shouldNotBeEmpty()
+        persisted.all { it.agentCli == "gemma4" } shouldBe true
+        persisted.all { it.model == LocalModelDefaults.GEMMA4_MODEL } shouldBe true
+        response.actions.single { it.type == "agent-model-update" }.detail shouldContain "gemma4"
+        response.actions.single { it.type == "agent-model-update" }.detail shouldContain LocalModelDefaults.GEMMA4_MODEL
+    }
+
     test("operator command routes complex cross-functional work to CEO intake before HR staffing") {
         val appHome = Files.createTempDirectory("operator-work-intake-home")
         val stateStore = DesktopStateStore { appHome }
@@ -863,6 +887,58 @@ class DesktopAppServiceTest : FunSpec({
         response.message shouldContain "운영 채팅 모델이 요청을 해석하지 못했습니다"
         response.blockedActions.single().type shouldBe "operator-chat-planner"
         response.actions.shouldBeEmpty()
+    }
+
+    test("operator chat planner uses Gemma 4 12B local model when Ollama is available") {
+        val appHome = Files.createTempDirectory("operator-chat-gemma4-12b-home")
+        val stateStore = DesktopStateStore { appHome }
+        val capturedAgents = mutableListOf<AgentConfig>()
+        val outputs = ArrayDeque(
+            listOf(
+                """{"reply":"초안을 준비했습니다.","toolCalls":[],"answerSourceHints":["company-summary"]}""",
+                "Gemma 4 12B로 회사 방향을 정리했습니다."
+            )
+        )
+        val service = DesktopAppService(
+            stateStore = stateStore,
+            gitWorkspaceService = mockk(relaxed = true),
+            configRepository = mockk(relaxed = true),
+            agentExecutor = object : AgentExecutor {
+                override suspend fun executeAgent(
+                    agent: AgentConfig,
+                    input: String?,
+                    metadata: AgentExecutionMetadata
+                ): AgentResult {
+                    capturedAgents += agent
+                    return AgentResult(
+                        agentName = agent.name,
+                        isSuccess = true,
+                        output = outputs.removeFirst(),
+                        error = null,
+                        duration = 1,
+                        metadata = emptyMap()
+                    )
+                }
+
+                override suspend fun executeWithRetry(
+                    agent: AgentConfig,
+                    input: String?,
+                    retryPolicy: RetryPolicy,
+                    metadata: AgentExecutionMetadata
+                ): AgentResult = executeAgent(agent, input, metadata)
+            },
+            commandAvailability = { command -> command == "ollama" },
+            autoStartAutomationRefresh = false
+        )
+        val company = service.createCompany(name = "Operator Chat Gemma 12B", rootPath = appHome.toString())
+
+        val response = service.runOperatorChat(company.id, "지금 뭘 건드리면 좋을지 골라줘")
+
+        response.message shouldContain "Gemma 4 12B"
+        capturedAgents.shouldHaveSize(2)
+        capturedAgents.all { it.pluginClass == "com.cotor.data.plugin.LocalModelPlugin" } shouldBe true
+        capturedAgents.all { it.parameters["provider"] == "ollama" } shouldBe true
+        capturedAgents.all { it.parameters["model"] == LocalModelDefaults.GEMMA4_MODEL } shouldBe true
     }
 
     test("operator chat recovers tool choice from non-json LLM planner output") {
@@ -1797,7 +1873,7 @@ class DesktopAppServiceTest : FunSpec({
             companyId = company.id,
             title = "Builder",
             agentCli = "gemma4",
-            model = "gemma4:e2b",
+            model = "gemma4:12b",
             roleSummary = "Build implementation changes.",
             createdAt = now,
             updatedAt = now
@@ -1884,13 +1960,13 @@ class DesktopAppServiceTest : FunSpec({
         capturedAgents.all { it.pluginClass == "com.cotor.data.plugin.OpenCodePlugin" } shouldBe true
         capturedAgents.first().parameters["model"] shouldBe OpenCodeDefaults.LOCAL_OLLAMA_GEMMA_MODEL
         capturedAgents.first().parameters["requestedAgentCli"] shouldBe "gemma4"
-        capturedAgents.first().parameters["requestedModel"] shouldBe "gemma4:e2b"
+        capturedAgents.first().parameters["requestedModel"] shouldBe "gemma4:12b"
         capturedAgents.first().parameters["executionMode"] shouldBe OpenCodeDefaults.LOCAL_OLLAMA_EXECUTION_MODE
         capturedPrompts[1].orEmpty() shouldContain "NO_DIFF_RETRY"
         val run = stateStore.load().runs.single { it.taskId == task.id }
         run.agentName shouldBe "opencode"
         run.requestedAgentCli shouldBe "gemma4"
-        run.requestedModel shouldBe "gemma4:e2b"
+        run.requestedModel shouldBe "gemma4:12b"
         run.effectiveAgentCli shouldBe "opencode"
         run.effectiveModel shouldBe OpenCodeDefaults.LOCAL_OLLAMA_GEMMA_MODEL
         run.executionMode shouldBe OpenCodeDefaults.LOCAL_OLLAMA_EXECUTION_MODE
@@ -1946,7 +2022,7 @@ class DesktopAppServiceTest : FunSpec({
             companyId = company.id,
             title = "Reviewer",
             agentCli = "gemma4",
-            model = "gemma4:e2b",
+            model = "gemma4:12b",
             roleSummary = "Validate without code changes.",
             createdAt = now,
             updatedAt = now
@@ -2024,7 +2100,7 @@ class DesktopAppServiceTest : FunSpec({
 
         capturedAgents.single().name shouldBe "gemma4"
         capturedAgents.single().pluginClass shouldBe "com.cotor.data.plugin.LocalModelPlugin"
-        capturedAgents.single().parameters["model"] shouldBe "gemma4:e2b"
+        capturedAgents.single().parameters["model"] shouldBe "gemma4:12b"
         stateStore.load().runs.single().executionMode shouldBe null
         coVerify(exactly = 0) { gitWorkspaceService.publishRun(any(), any(), any(), any(), any(), any(), any()) }
     }
@@ -15959,7 +16035,7 @@ private suspend fun blockIssueWithFailedTask(
 }
 
 private suspend fun awaitIssueTasksSettled(stateStore: DesktopStateStore, issueId: String) {
-    withTimeout(5_000) {
+    withTimeout(30_000) {
         while (true) {
             val tasks = stateStore.load().tasks.filter { it.issueId == issueId }
             val allSettled = tasks.isEmpty() || tasks.all { task ->

--- a/src/test/kotlin/com/cotor/app/DesktopUpdateStatusTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopUpdateStatusTest.kt
@@ -1,0 +1,31 @@
+package com.cotor.app
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+
+class DesktopUpdateStatusTest : FunSpec({
+    test("Homebrew outdated output marks desktop update available even when brew exits nonzero") {
+        val installRoot = Files.createTempDirectory("cotor-desktop-update-status")
+        val appPath = installRoot.resolve("Cotor Desktop.app")
+        appPath.resolve("Contents").toFile().mkdirs()
+
+        val status = desktopUpdateStatusResponse(
+            environment = mapOf("COTOR_DESKTOP_APP_PATH" to appPath.toString()),
+            homeDirectoryProvider = { installRoot.resolve("home") },
+            commandRunner = { command, _ ->
+                when {
+                    command.contains("list") -> UpdateStatusCommandResult(0, "cotor 1.0.6\n")
+                    command.contains("outdated") -> UpdateStatusCommandResult(1, "bssm-oss/cotor/cotor\n")
+                    command.contains("rev-parse") -> UpdateStatusCommandResult(0, "abc1234\n")
+                    else -> UpdateStatusCommandResult(127, "unexpected command")
+                }
+            }
+        )
+
+        status.installedAppPath shouldBe appPath.toString()
+        status.updateAvailable shouldBe true
+        status.status shouldBe "UPDATE_AVAILABLE"
+        status.updateCommand shouldBe "cotor update --verify"
+    }
+})

--- a/src/test/kotlin/com/cotor/app/ProviderModelsTest.kt
+++ b/src/test/kotlin/com/cotor/app/ProviderModelsTest.kt
@@ -1,5 +1,6 @@
 package com.cotor.app
 
+import com.cotor.model.LocalModelDefaults
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
@@ -39,8 +40,12 @@ class ProviderModelsTest : FunSpec({
         val providers = directChatProviderCatalog()
 
         providers.map { it.id }.distinct().size shouldBe providers.size
-        providers.first { it.id == "ollama" }.supportsModelDiscovery shouldBe true
-        providers.first { it.id == "lmstudio" }.providerId shouldBe "lm-studio"
+        val ollama = providers.first { it.id == "ollama" }
+        val lmStudio = providers.first { it.id == "lmstudio" }
+        ollama.supportsModelDiscovery shouldBe true
+        ollama.defaultModel shouldBe LocalModelDefaults.GEMMA4_MODEL
+        lmStudio.providerId shouldBe "lm-studio"
+        lmStudio.defaultModel shouldBe LocalModelDefaults.GEMMA4_12B_HUGGING_FACE_INSTRUCT_MODEL
         providers.first { it.id == "claude-cli" }.allowsBaseUrl shouldBe false
 
         findDirectChatProvider("lm-studio")?.id shouldBe "lmstudio"

--- a/src/test/kotlin/com/cotor/data/plugin/LocalModelPluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/LocalModelPluginTest.kt
@@ -29,7 +29,7 @@ class LocalModelPluginTest : FunSpec({
                 context = localModelContext(
                     provider = "ollama",
                     baseUrl = "http://127.0.0.1:${server.address.port}",
-                    model = "gemma4:e2b"
+                    model = "gemma4:12b"
                 ),
                 processManager = unusedProcessManager()
             )
@@ -50,8 +50,8 @@ class LocalModelPluginTest : FunSpec({
                 )
                 "/api/chat" -> {
                     val request = exchange.requestBody.bufferedReader().readText()
-                    if (request.contains("\"model\":\"gemma4:e2b\"")) {
-                        exchange.respondJson("""{"error":"model 'gemma4:e2b' not found"}""", status = 404)
+                    if (request.contains("\"model\":\"gemma4:12b\"")) {
+                        exchange.respondJson("""{"error":"model 'gemma4:12b' not found"}""", status = 404)
                     } else {
                         request.contains("\"model\":\"gemma3:4b\"") shouldBe true
                         exchange.respondJson("""{"message":{"content":"fallback gemma ok"}}""")
@@ -65,7 +65,7 @@ class LocalModelPluginTest : FunSpec({
                 context = localModelContext(
                     provider = "ollama",
                     baseUrl = "http://127.0.0.1:${server.address.port}",
-                    model = "gemma4:e2b"
+                    model = "gemma4:12b"
                 ),
                 processManager = unusedProcessManager()
             )
@@ -81,10 +81,10 @@ class LocalModelPluginTest : FunSpec({
             when (exchange.requestURI.path) {
                 "/api/tags" -> exchange.respondJson(
                     """
-                    {"models":[{"name":"gemma3:4b","remote_host":"https://ollama.com:443"},{"name":"gemma4:e2b:cloud"}]}
+                    {"models":[{"name":"gemma3:4b","remote_host":"https://ollama.com:443"},{"name":"gemma4:12b:cloud"}]}
                     """.trimIndent()
                 )
-                "/api/chat" -> exchange.respondJson("""{"error":"model 'gemma4:e2b' not found"}""", status = 404)
+                "/api/chat" -> exchange.respondJson("""{"error":"model 'gemma4:12b' not found"}""", status = 404)
                 else -> exchange.sendResponseHeaders(404, -1)
             }
         }
@@ -94,13 +94,13 @@ class LocalModelPluginTest : FunSpec({
                     context = localModelContext(
                         provider = "ollama",
                         baseUrl = "http://127.0.0.1:${server.address.port}",
-                        model = "gemma4:e2b"
+                        model = "gemma4:12b"
                     ),
                     processManager = unusedProcessManager()
                 )
             }
 
-            error.message.orEmpty() shouldBe "Local model request failed (404): {\"error\":\"model 'gemma4:e2b' not found\"}"
+            error.message.orEmpty() shouldBe "Local model request failed (404): {\"error\":\"model 'gemma4:12b' not found\"}"
         } finally {
             server.stop(0)
         }
@@ -113,7 +113,7 @@ class LocalModelPluginTest : FunSpec({
                 context = localModelContext(
                     provider = "lmstudio",
                     baseUrl = "http://127.0.0.1:${server.address.port}/v1",
-                    model = "gemma4:e2b"
+                    model = "gemma4:12b"
                 ),
                 processManager = unusedProcessManager()
             )
@@ -136,7 +136,7 @@ class LocalModelPluginTest : FunSpec({
                 context = localModelContext(
                     provider = "ollama",
                     baseUrl = "http://127.0.0.1:11434",
-                    model = "gemma4:e2b"
+                    model = "gemma4:12b"
                 ),
                 processManager = unusedProcessManager()
             )
@@ -162,7 +162,7 @@ class LocalModelPluginTest : FunSpec({
                     context = localModelContext(
                         provider = "ollama",
                         baseUrl = "http://127.0.0.1:11434",
-                        model = "gemma4:e2b"
+                        model = "gemma4:12b"
                     ),
                     processManager = unusedProcessManager()
                 )
@@ -189,7 +189,7 @@ class LocalModelPluginTest : FunSpec({
                     context = localModelContext(
                         provider = "ollama",
                         baseUrl = "http://127.0.0.1:${server.address.port}",
-                        model = "gemma4:e2b"
+                        model = "gemma4:12b"
                     ),
                     processManager = unusedProcessManager()
                 )
@@ -224,7 +224,7 @@ class LocalModelPluginTest : FunSpec({
                         context = localModelContext(
                             provider = "ollama",
                             baseUrl = "http://127.0.0.1:${server.address.port}",
-                            model = "gemma4:e2b"
+                            model = "gemma4:12b"
                         ),
                         processManager = unusedProcessManager()
                     )

--- a/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
+++ b/src/test/kotlin/com/cotor/data/plugin/OpenCodePluginTest.kt
@@ -555,7 +555,7 @@ class OpenCodePluginTest : FunSpec({
     test("passes local Ollama Gemma model to opencode without cloud fallback") {
         val server = localRoutingServer { exchange ->
             if (exchange.requestURI.path == "/api/tags") {
-                exchange.respondJson("""{"models":[{"name":"gemma3:4b"},{"name":"gemma3:4b:cloud","remote_host":"https://ollama.com:443"}]}""")
+                exchange.respondJson("""{"models":[{"name":"gemma4:12b"},{"name":"gemma4:12b:cloud","remote_host":"https://ollama.com:443"}]}""")
             } else {
                 exchange.sendResponseHeaders(404, -1)
             }
@@ -621,7 +621,7 @@ class OpenCodePluginTest : FunSpec({
     test("surfaces local Ollama Gemma tool-call incompatibility without fallback") {
         val server = localRoutingServer { exchange ->
             if (exchange.requestURI.path == "/api/tags") {
-                exchange.respondJson("""{"models":[{"name":"gemma3:4b"}]}""")
+                exchange.respondJson("""{"models":[{"name":"gemma4:12b"}]}""")
             } else {
                 exchange.sendResponseHeaders(404, -1)
             }
@@ -640,7 +640,7 @@ class OpenCodePluginTest : FunSpec({
                 return ProcessResult(
                     exitCode = 1,
                     stdout = """
-                        {"type":"error","error":{"name":"APIError","data":{"message":"registry.ollama.ai/library/gemma3:4b does not support tools","statusCode":400}}}
+                        {"type":"error","error":{"name":"APIError","data":{"message":"registry.ollama.ai/library/gemma4:12b does not support tools","statusCode":400}}}
                     """.trimIndent(),
                     stderr = "",
                     isSuccess = false
@@ -695,7 +695,7 @@ class OpenCodePluginTest : FunSpec({
     test("does not fall back to cloud or free OpenCode models when local Ollama Gemma is missing") {
         val server = localRoutingServer { exchange ->
             if (exchange.requestURI.path == "/api/tags") {
-                exchange.respondJson("""{"models":[{"name":"gemma3:4b","remote_host":"https://ollama.com:443"},{"name":"gemma3:4b:cloud"}]}""")
+                exchange.respondJson("""{"models":[{"name":"gemma4:12b","remote_host":"https://ollama.com:443"},{"name":"gemma4:12b:cloud"}]}""")
             } else {
                 exchange.sendResponseHeaders(404, -1)
             }
@@ -714,7 +714,7 @@ class OpenCodePluginTest : FunSpec({
                 return when (command) {
                     listOf("opencode", "models") -> ProcessResult(
                         exitCode = 0,
-                        stdout = "opencode/minimax-m2.5-free\nollama/gemma3:4b:cloud\n",
+                        stdout = "opencode/minimax-m2.5-free\nollama/gemma4:12b:cloud\n",
                         stderr = "",
                         isSuccess = true
                     )
@@ -743,7 +743,7 @@ class OpenCodePluginTest : FunSpec({
                 )
             }
 
-            error.message shouldBe "LOCAL_GEMMA_MODEL_MISSING: local Ollama model gemma3:4b was not discovered."
+            error.message shouldBe "LOCAL_GEMMA_MODEL_MISSING: local Ollama model gemma4:12b was not discovered."
             runInvoked shouldBe false
         } finally {
             server.stop(0)

--- a/src/test/kotlin/com/cotor/model/LocalModelDefaultsTest.kt
+++ b/src/test/kotlin/com/cotor/model/LocalModelDefaultsTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 
 class LocalModelDefaultsTest : FunSpec({
     test("detects Gemma 4 model aliases from local model lists") {
-        LocalModelDefaults.isGemma4Model("gemma4:e2b") shouldBe true
+        LocalModelDefaults.isGemma4Model("gemma4:12b") shouldBe true
         LocalModelDefaults.isGemma4Model("google/gemma-4-31b-it") shouldBe true
         LocalModelDefaults.isGemma4Model("nvidia/google/gemma_4_31b_it") shouldBe true
     }
@@ -17,7 +17,7 @@ class LocalModelDefaultsTest : FunSpec({
     }
 
     test("detects installed Gemma family models for app-managed local fallback") {
-        LocalModelDefaults.isGemmaFamilyModel("gemma4:e2b") shouldBe true
+        LocalModelDefaults.isGemmaFamilyModel("gemma4:12b") shouldBe true
         LocalModelDefaults.isGemmaFamilyModel("gemma3:4b") shouldBe true
         LocalModelDefaults.isGemmaFamilyModel("google/gemma-4-31b-it") shouldBe true
         LocalModelDefaults.isGemmaFamilyModel("notgemma4:latest") shouldBe false
@@ -27,12 +27,12 @@ class LocalModelDefaultsTest : FunSpec({
         LocalModelDefaults.installedGemma4Models(
             listOf(
                 " qwen2.5:3b ",
-                "gemma4:e2b",
+                "gemma4:12b",
                 "google/gemma-4-31b-it",
-                "gemma4:e2b",
+                "gemma4:12b",
                 "gemma3:4b"
             )
-        ) shouldBe listOf("gemma4:e2b", "google/gemma-4-31b-it")
+        ) shouldBe listOf("gemma4:12b", "google/gemma-4-31b-it")
     }
 
     test("preferred installed Gemma models keep Gemma 4 first and then fallback family models") {
@@ -40,10 +40,22 @@ class LocalModelDefaultsTest : FunSpec({
             listOf(
                 " qwen2.5:3b ",
                 "gemma3:4b",
-                "gemma4:e2b",
+                "gemma4:12b",
                 "gemma3:4b",
                 "google/gemma-4-31b-it"
             )
-        ) shouldBe listOf("gemma4:e2b", "google/gemma-4-31b-it", "gemma3:4b")
+        ) shouldBe listOf("gemma4:12b", "google/gemma-4-31b-it", "gemma3:4b")
+    }
+
+    test("preferred installed Gemma models promote Gemma 4 12B ahead of smaller or larger Gemma 4 variants") {
+        LocalModelDefaults.preferredInstalledGemmaModels(
+            listOf(
+                "gemma4:e2b",
+                "google/gemma-4-31b-it",
+                "gemma4:12b",
+                "google/gemma-4-12B-it",
+                "gemma3:4b"
+            )
+        ) shouldBe listOf("gemma4:12b", "google/gemma-4-12B-it", "gemma4:e2b", "google/gemma-4-31b-it", "gemma3:4b")
     }
 })

--- a/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/AgentCommandTest.kt
@@ -165,7 +165,7 @@ class AgentCommandTest : FunSpec({
         added.exists() shouldBe true
         added.readText() shouldContain "pluginClass: com.cotor.data.plugin.LocalModelPlugin"
         added.readText() shouldContain "baseUrl: \"http://127.0.0.1:11434\""
-        added.readText() shouldContain "model: \"gemma4:e2b\""
+        added.readText() shouldContain "model: \"gemma4:12b\""
         added.readText() shouldContain "provider: \"ollama\""
     }
 

--- a/src/test/kotlin/com/cotor/presentation/cli/DesktopLifecycleCommandTest.kt
+++ b/src/test/kotlin/com/cotor/presentation/cli/DesktopLifecycleCommandTest.kt
@@ -117,6 +117,55 @@ class DesktopLifecycleCommandTest : FunSpec({
         calls.single().second shouldBe DesktopInstallAction.UPDATE
     }
 
+    test("update verify runs installed desktop verification after successful source update") {
+        val root = Paths.get("/tmp/cotor-update-verify-test")
+        val lifecycleCalls = mutableListOf<Pair<Path, String>>()
+        val verificationCalls = mutableListOf<DesktopInstallLayout>()
+        val layout = DesktopInstallLayout(DesktopInstallLayoutKind.SOURCE_CHECKOUT, root)
+        val command = UpdateCommand(
+            scriptRunner = { projectRoot, scriptName ->
+                lifecycleCalls += projectRoot to scriptName
+                DesktopScriptResult(exitCode = 0, output = "updated\n")
+            },
+            packagedActionRunner = { _, _ -> error("should not run packaged flow") },
+            verificationRunner = {
+                verificationCalls += it
+                DesktopScriptResult(exitCode = 0, output = "verified\n")
+            },
+            layoutResolver = { layout },
+            osNameProvider = { "Mac OS X" }
+        )
+
+        val result = command.test("--verify")
+
+        result.statusCode shouldBe 0
+        result.output shouldContain "updated"
+        result.output shouldContain "verified"
+        lifecycleCalls shouldBe listOf(root to "update-desktop-app.sh")
+        verificationCalls shouldBe listOf(layout)
+    }
+
+    test("upgrade is a user-facing alias for desktop update") {
+        val root = Paths.get("/tmp/cotor-upgrade-alias-test")
+        val calls = mutableListOf<Pair<Path, String>>()
+        val command = UpgradeCommand(
+            scriptRunner = { projectRoot, scriptName ->
+                calls += projectRoot to scriptName
+                DesktopScriptResult(exitCode = 0, output = "upgraded\n")
+            },
+            packagedActionRunner = { _, _ -> error("should not run packaged flow") },
+            verificationRunner = { DesktopScriptResult(exitCode = 0, output = "") },
+            layoutResolver = { DesktopInstallLayout(DesktopInstallLayoutKind.SOURCE_CHECKOUT, root) },
+            osNameProvider = { "Mac OS X" }
+        )
+
+        val result = command.test("")
+
+        result.statusCode shouldBe 0
+        result.output shouldContain "upgraded"
+        calls shouldBe listOf(root to "update-desktop-app.sh")
+    }
+
     test("runPackagedDesktopAction installs the bundled app into the override root") {
         val packagedRoot = Files.createTempDirectory("cotor-packaged-install")
         val bundle = createPackagedBundle(packagedRoot)
@@ -189,6 +238,22 @@ class DesktopLifecycleCommandTest : FunSpec({
         )
         installRoot.resolve(BUNDLED_DESKTOP_APP_NAME).exists() shouldBe true
         result.output shouldContain "Homebrew package upgraded"
+    }
+
+    test("resolveInstalledDesktopAppPath respects explicit app path and install root") {
+        val installRoot = Files.createTempDirectory("cotor-resolve-installed-app")
+        val appPath = installRoot.resolve(BUNDLED_DESKTOP_APP_NAME)
+        appPath.resolve("Contents").createDirectories()
+
+        resolveInstalledDesktopAppPath(
+            environment = mapOf("COTOR_DESKTOP_APP_PATH" to appPath.toString()),
+            homeDirectoryProvider = { installRoot.resolve("home") }
+        ) shouldBe appPath
+
+        resolveInstalledDesktopAppPath(
+            environment = mapOf("COTOR_DESKTOP_INSTALL_ROOT" to installRoot.toString()),
+            homeDirectoryProvider = { installRoot.resolve("home") }
+        ) shouldBe appPath
     }
 
     test("runDesktopScript times out hanging source lifecycle scripts") {

--- a/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
+++ b/src/test/kotlin/com/cotor/security/SecurityValidatorTest.kt
@@ -19,6 +19,18 @@ class SecurityValidatorTest : FunSpec({
         config.allowedExecutables.contains("graphify") shouldBe true
     }
 
+    test("default executable directory expansion includes symlink target directory") {
+        val targetDir = Files.createTempDirectory("cotor-codex-package")
+        val binDir = Files.createTempDirectory("cotor-codex-bin")
+        val executable = targetDir.resolve("codex.js").toFile()
+        executable.writeText("#!/usr/bin/env node\n")
+        executable.setExecutable(true)
+        val link = binDir.resolve("codex")
+        link.createSymbolicLinkPointingTo(executable.toPath())
+
+        executableAllowedDirectories(link).toSet() shouldBe setOf(binDir, targetDir)
+    }
+
     test("command whitelist accepts absolute executable path by basename") {
         val validator = DefaultSecurityValidator(
             SecurityConfig(allowedExecutables = setOf("qwen")),


### PR DESCRIPTION
[발견된 버그]
- 데스크톱 업데이트 검증이 `update-desktop-app.sh -> codesign -> app launch -> /health`로 흩어져 있어 실제 설치본 정상 실행 여부를 한 번에 재현하기 어려웠습니다.
- `gh pr merge` 이후 로컬 `master`가 다른 worktree에 묶여 있으면 checkout/pull 단계가 실패하는 운영 리스크가 있었습니다.
- 설치된 앱이 어떤 backend owner/build/source/health/update 상태인지 앱 안에서 바로 확인할 수 없어 최신 master 설치 여부 판단이 느렸습니다.
- 런타임/에이전트 E2E에서 publish detail, agent model routing, capability/security guard, Gemma 4 12B local path 검증이 부족했습니다.

[수정 내용]
- `shell/test-installed-desktop-app.sh`와 `cotor update --verify`/`cotor upgrade --verify`를 추가해 build/install/codesign/launch/`/health`를 자동화했습니다.
- `GET /api/app/update-status`와 Swift Settings UI 상태 배지를 추가해 backend owner, version/build, source commit, health, installed app path, Homebrew update availability를 표시합니다.
- `shell/cotor-merge-pr.sh`를 추가해 PR merge 후 base branch worktree를 감지하고 해당 worktree에서 `pull --ff-only`로 동기화합니다.
- Runtime/agent E2E와 보안 validator 테스트를 보강하고, Gemma 4 12B 로컬 기본값 및 operator model update routing을 정리했습니다.
- README, Korean README, desktop docs, CONTRIBUTING, graphify report를 갱신했습니다.

[재테스트 결과]
- PASS: `git diff --check`
- PASS: `bash -n shell/test-installed-desktop-app.sh shell/update-desktop-app.sh shell/cotor-merge-pr.sh`
- PASS: `./shell/cotor update --help` and `./shell/cotor upgrade --help`
- PASS: `swift test --package-path macos`
- PASS: `./gradlew --no-daemon cleanTest test`
- PASS: `./shell/update-desktop-app.sh --verify`
- PASS: installed app `/health` returned owner `cotor-desktop`
- PASS: authenticated installed app `GET /api/app/update-status` returned `UPDATE_AVAILABLE`
- PASS: manual app launch/settings smoke via macOS UI screenshot

Known risk: SwiftPM reports existing Swift Testing deprecation warnings. No behavior change was made for that warning in this PR.