### PR TITLE
fix(qa): preserve checkout during publish readiness repair

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-06-08)
 
 ## Corpus Check
-- 403 files · ~747,227 words
+- 403 files · ~747,468 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
+++ b/src/main/kotlin/com/cotor/app/GitWorkspaceService.kt
@@ -1603,16 +1603,37 @@ class GitWorkspaceService(
             return false
         }
 
-        val checkoutResult = runGit(
+        val currentBranch = runGit(
             repositoryRoot,
-            "checkout",
-            "-B",
-            baseBranch,
-            remoteTrackingRef,
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
             failOnError = false,
-            timeoutMs = 30_000
-        )
-        if (!checkoutResult.isSuccess) {
+            timeoutMs = 10_000
+        ).stdout.trim()
+
+        val alignResult = if (currentBranch == baseBranch) {
+            runGit(
+                repositoryRoot,
+                "checkout",
+                "-B",
+                baseBranch,
+                remoteTrackingRef,
+                failOnError = false,
+                timeoutMs = 30_000
+            )
+        } else {
+            runGit(
+                repositoryRoot,
+                "branch",
+                "-f",
+                baseBranch,
+                remoteTrackingRef,
+                failOnError = false,
+                timeoutMs = 30_000
+            )
+        }
+        if (!alignResult.isSuccess) {
             logger.warn("Could not align bootstrap-only $baseBranch with $remoteTrackingRef")
             return false
         }

--- a/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/GitWorkspaceServiceTest.kt
@@ -464,8 +464,84 @@ class GitWorkspaceServiceTest : FunSpec({
                     ProcessResult(0, "?? .cotor/\n?? cotor.log\n", "", true)
                 ),
                 FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--abbrev-ref", "HEAD"),
+                    ProcessResult(0, "master\n", "", true)
+                ),
+                FakeProcessManager.Step(
                     listOf("git", "checkout", "-B", "master", "refs/remotes/origin/master"),
                     ProcessResult(0, "Reset branch 'master'\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "merge-base", "master", "refs/remotes/origin/master"),
+                    ProcessResult(0, "abc123\n", "", true)
+                )
+            )
+        )
+        val service = GitWorkspaceService(processManager, mockk(relaxed = true), mockk<Logger>(relaxed = true))
+
+        val readiness = service.ensureGitHubPublishReady(repositoryRoot, "master")
+
+        readiness.ready shouldBe true
+        readiness.originUrl shouldBe "https://github.com/heodongun/cotor.git"
+        readiness.error.shouldBeNull()
+        processManager.remainingSteps() shouldBe 0
+    }
+
+    test("ensureGitHubPublishReady repairs bootstrap base refs without switching a non-base checkout") {
+        val repositoryRoot = Files.createTempDirectory("git-workspace-bootstrap-repair-non-base")
+        val processManager = FakeProcessManager(
+            listOf(
+                FakeProcessManager.Step(
+                    listOf("git", "config", "--get", "remote.origin.url"),
+                    ProcessResult(0, "https://github.com/heodongun/cotor.git\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "config", "--get", "remote.origin.url"),
+                    ProcessResult(0, "https://github.com/heodongun/cotor.git\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "show-ref", "--verify", "--quiet", "refs/heads/master"),
+                    ProcessResult(0, "", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "ls-remote", "--heads", "origin", "master"),
+                    ProcessResult(0, "abc123\trefs/heads/master\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "fetch", "--no-tags", "origin", "refs/heads/master:refs/remotes/origin/master"),
+                    ProcessResult(0, "", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "merge-base", "master", "refs/remotes/origin/master"),
+                    ProcessResult(1, "", "", false)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "rev-list", "--count", "master"),
+                    ProcessResult(0, "1\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "log", "-1", "--format=%s", "master"),
+                    ProcessResult(0, "Initialize repository\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "log", "-1", "--format=%ae", "master"),
+                    ProcessResult(0, "cotor@local\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--git-common-dir"),
+                    ProcessResult(0, ".git\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "status", "--porcelain"),
+                    ProcessResult(0, "?? .cotor/\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "rev-parse", "--abbrev-ref", "HEAD"),
+                    ProcessResult(0, "codex-1\n", "", true)
+                ),
+                FakeProcessManager.Step(
+                    listOf("git", "branch", "-f", "master", "refs/remotes/origin/master"),
+                    ProcessResult(0, "", "", true)
                 ),
                 FakeProcessManager.Step(
                     listOf("git", "merge-base", "master", "refs/remotes/origin/master"),


### PR DESCRIPTION
## 발견된 문제
- GitHub publish readiness가 bootstrap-only base branch를 origin base로 복구할 때 `git checkout -B <base>`를 사용했습니다.
- 이 경로는 사용자가 `codex-1` 같은 non-base 브랜치에서 QA 중이어도 현재 worktree를 base branch로 이동시킬 수 있어, 동시 작업/브랜치 격리 기대와 충돌합니다.

## 수정 내용
- 현재 checkout이 base branch일 때만 기존처럼 `checkout -B`로 working tree를 갱신합니다.
- 현재 checkout이 base branch가 아니면 `git branch -f <base> <origin-ref>`로 base branch ref만 갱신하고, 사용자의 active checkout은 그대로 둡니다.
- `GitWorkspaceServiceTest`에 non-base checkout 회귀 테스트를 추가했습니다.
- `graphify update .`로 구조 그래프를 갱신했습니다.

## 재테스트 결과
- `./gradlew test --tests 'com.cotor.app.GitWorkspaceServiceTest' --console=plain`
- `./gradlew formatCheck --console=plain`
- `graphify update .`
- `./gradlew test --console=plain`
- `swift test --package-path macos`
- `node --test .github/scripts/*.test.js`
- `shell/test-desktop-launcher-runtime.sh`
- `./shell/update-desktop-app.sh --verify`
- `./shell/cotor run codex-hello -c .cotor/codex-demo.yaml --output-format text`
- 설치 앱 health: `http://127.0.0.1:8787/health` returned ok
- 회사 생성 smoke: create -> list -> delete -> deleted count 0
- 새 설치 앱 실행 중 60초 동안 branch가 `codex-1`로 유지됨

## 참고
- Codex smoke에서 첫 attempt가 한 번 120초 timeout 후 재시도되었고, 두 번째 attempt는 성공했습니다. 최종 pipeline은 success로 종료되었습니다.
