### PR TITLE
Sanitize runtime attention references

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-06-10)
 
 ## Corpus Check
-- 405 files · ~758,078 words
+- 405 files · ~758,299 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -24060,6 +24060,14 @@ class DesktopAppService(
 
     private fun DesktopAppState.computeCompanyRuntimes(): List<CompanyRuntimeSnapshot> =
         allKnownCompanyIds().map { companyId ->
+            val companyIssueIds = issues.asSequence()
+                .filter { it.companyId == companyId }
+                .map { it.id }
+                .toSet()
+            val companyReviewQueueItemIds = reviewQueue.asSequence()
+                .filter { it.companyId == companyId }
+                .map { it.id }
+                .toSet()
             val existing = runtimeWithinCurrentBudgetWindow(
                 (
                     companyRuntimes.firstOrNull { it.companyId == companyId }
@@ -24131,6 +24139,9 @@ class DesktopAppService(
                             )
                 },
                 autonomyEnabledGoalCount = goals.count { it.companyId == companyId && it.autonomyEnabled },
+                pendingIssueIds = existing.pendingIssueIds.filter { it in companyIssueIds },
+                blockedIssueIds = existing.blockedIssueIds.filter { it in companyIssueIds },
+                reviewQueueAttentionIds = existing.reviewQueueAttentionIds.filter { it in companyReviewQueueItemIds },
                 todaySpentCents = budgetWindow.todaySpentCents,
                 monthSpentCents = budgetWindow.monthSpentCents,
                 budgetPausedAt = budgetPausedAt

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -11444,10 +11444,69 @@ class DesktopAppServiceTest : FunSpec({
         state.reviewQueue.firstOrNull { it.issueId == issue.id } shouldBe null
         state.signals.firstOrNull { it.issueId == issue.id } shouldBe null
         val runtime = state.companyRuntimes.single { it.companyId == company.id }
-        runtime.pendingIssueIds shouldBe listOf("other-pending-issue")
-        runtime.blockedIssueIds shouldBe listOf("other-blocked-issue")
-        runtime.reviewQueueAttentionIds shouldBe listOf("other-review")
+        runtime.pendingIssueIds shouldBe emptyList()
+        runtime.blockedIssueIds shouldBe emptyList()
+        runtime.reviewQueueAttentionIds shouldBe emptyList()
         issueFile.exists() shouldBe false
+    }
+
+    test("runtimeStatus filters orphan runtime attention references") {
+        val appHome = Files.createTempDirectory("desktop-runtime-orphan-attention-home")
+        val repoRoot = Files.createDirectories(Files.createTempDirectory("desktop-runtime-orphan-attention-test").resolve("repo"))
+        val stateStore = DesktopStateStore { appHome }
+        seedWorkspace(stateStore, repoRoot)
+        val service = testService(
+            processManager = FakeGitProcessManager(
+                repoRoot = repoRoot,
+                remoteUrl = "https://github.com/heodongun/cotor.git",
+                defaultBranch = "master"
+            ),
+            stateStore = stateStore
+        )
+
+        val company = service.createCompany(
+            name = "Runtime Orphan Co",
+            rootPath = repoRoot.toString(),
+            defaultBaseBranch = "master"
+        )
+        val goal = service.createGoal(
+            companyId = company.id,
+            title = "Keep runtime attention scoped",
+            description = "Existing runtime snapshots may contain IDs for deleted issues.",
+            autonomyEnabled = false
+        )
+        val issue = service.listIssues(goal.id).first()
+        stateStore.save(
+            stateStore.load().copy(
+                reviewQueue = listOf(
+                    ReviewQueueItem(
+                        id = "runtime-valid-review",
+                        companyId = company.id,
+                        issueId = issue.id,
+                        runId = "runtime-valid-run",
+                        status = ReviewQueueStatus.AWAITING_QA,
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    )
+                ),
+                companyRuntimes = listOf(
+                    CompanyRuntimeSnapshot(
+                        companyId = company.id,
+                        status = CompanyRuntimeStatus.RUNNING,
+                        pendingIssueIds = listOf(issue.id, "missing-pending-issue"),
+                        blockedIssueIds = listOf("missing-blocked-issue"),
+                        reviewQueueAttentionIds = listOf("runtime-valid-review", "missing-review")
+                    )
+                )
+            )
+        )
+
+        val runtime = service.runtimeStatus(company.id)
+        runtime.pendingIssueIds.contains(issue.id) shouldBe true
+        runtime.pendingIssueIds.contains("missing-pending-issue") shouldBe false
+        runtime.blockedIssueIds.contains("missing-blocked-issue") shouldBe false
+        runtime.blockedIssueIds shouldBe emptyList()
+        runtime.reviewQueueAttentionIds.contains("missing-review") shouldBe false
     }
 
     test("createIssue creates a company-scoped manual issue for the selected goal") {


### PR DESCRIPTION
## Summary
- filter runtime pending and blocked issue IDs to existing company issues
- filter runtime review attention IDs to existing company review queue items
- add regression coverage for orphan runtime attention references
- refresh graphify output after code/test changes

## Root Cause
Some demo state already had runtime blockedIssueIds pointing at issues that had since been deleted. The delete cleanup fix handles future deletes, but existing persisted orphan references still needed to be sanitized during runtime projection.

## Validation
- ./gradlew test --tests 'com.cotor.app.DesktopAppServiceTest' -x jacocoTestReport -x jacocoTestCoverageVerification
- ./gradlew test -x jacocoTestReport -x jacocoTestCoverageVerification
- graphify update .
- git diff --check
- ./gradlew shadowJar -x test -x jacocoTestReport -x jacocoTestCoverageVerification