### PR TITLE
Clear provider blocks on blocked retry

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - cotor  (2026-06-10)
 
 ## Corpus Check
-- 405 files · ~758,299 words
+- 405 files · ~758,327 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary

--- a/src/main/kotlin/com/cotor/app/DesktopAppService.kt
+++ b/src/main/kotlin/com/cotor/app/DesktopAppService.kt
@@ -8268,6 +8268,8 @@ class DesktopAppService(
                     status = IssueStatus.PLANNED,
                     transitionReason = "Company Operator reopened this blocked issue for autonomous retry.",
                     blockedBy = emptyList(),
+                    approvalPauseId = null,
+                    providerBlockReason = null,
                     runtimeDisposition = null,
                     updatedAt = now
                 )

--- a/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
+++ b/src/test/kotlin/com/cotor/app/DesktopAppServiceTest.kt
@@ -1443,6 +1443,8 @@ class DesktopAppServiceTest : FunSpec({
             title = "Blocked full-auto implementation",
             description = "Needs retry.",
             status = IssueStatus.BLOCKED,
+            approvalPauseId = "stale-opencode-approval",
+            providerBlockReason = "Capability SHELL_EXEC requires approval for agent.exec agent=opencode.",
             createdAt = now,
             updatedAt = now
         )
@@ -1468,7 +1470,10 @@ class DesktopAppServiceTest : FunSpec({
         retryResponse.shouldHideRawOperatorInternals()
         hardGateResponse.shouldHideRawOperatorInternals()
         retryResponse.actions.any { it.type == "blocked-issue-retry" && it.status == "DONE" } shouldBe true
-        stateStore.load().issues.first { it.id == issue.id }.status shouldBe IssueStatus.PLANNED
+        val retriedIssue = stateStore.load().issues.first { it.id == issue.id }
+        retriedIssue.status shouldBe IssueStatus.PLANNED
+        retriedIssue.approvalPauseId shouldBe null
+        retriedIssue.providerBlockReason shouldBe null
         hardGateResponse.blockedActions.single().type shouldBe "hard-gate"
     }
 


### PR DESCRIPTION
## Summary
- clear stale approval pause IDs when blocked issues are reopened for retry
- clear stale provider block reasons when blocked issues are reopened for retry
- add regression coverage to the operator retry flow
- refresh graphify output after code/test changes

## Root Cause
The operator retry flow changed blocked issues back to PLANNED but left providerBlockReason and approvalPauseId intact. Old opencode approval failures could keep appearing on the issue and make a Gemma retry look blocked by opencode.

## Validation
- ./gradlew test --tests 'com.cotor.app.DesktopAppServiceTest' -x jacocoTestReport -x jacocoTestCoverageVerification
- ./gradlew test -x jacocoTestReport -x jacocoTestCoverageVerification
- graphify update .
- git diff --check
- ./gradlew shadowJar -x test -x jacocoTestReport -x jacocoTestCoverageVerification