### PR TITLE
Run source lifecycle commands from a copied jar

### DIFF
--- a/shell/cotor
+++ b/shell/cotor
@@ -228,6 +228,32 @@ if [ "${1:-}" = "app-server" ]; then
     exit $?
 fi
 
+uses_source_lifecycle_command() {
+    case "${1:-}" in
+        install|update|upgrade|delete)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+if uses_source_lifecycle_command "$@"; then
+    TMPDIR_VALUE="${TMPDIR:-/tmp}"
+    CLI_RUNTIME_DIR="$(/usr/bin/mktemp -d "${TMPDIR_VALUE%/}/cotor-cli-runtime.XXXXXX")" || exit 1
+    CLI_RUNTIME_JAR="$CLI_RUNTIME_DIR/cotor-cli.jar"
+    /bin/cp "$JAR_PATH" "$CLI_RUNTIME_JAR" || {
+        /bin/rm -rf "$CLI_RUNTIME_DIR" >/dev/null 2>&1 || true
+        exit 1
+    }
+    cleanup_cli_runtime_jar() {
+        /bin/rm -rf "$CLI_RUNTIME_DIR" >/dev/null 2>&1 || true
+    }
+    trap cleanup_cli_runtime_jar EXIT TERM INT HUP
+    JAR_PATH="$CLI_RUNTIME_JAR"
+fi
+
 # Run the JAR with all arguments passed to this script
 export COTOR_PROJECT_ROOT="$PROJECT_ROOT"
 "$JAVA_CMD" -jar "$JAR_PATH" "$@"


### PR DESCRIPTION
## Summary
- Run source-checkout desktop lifecycle commands (`install`, `update`, `upgrade`, `delete`) from a temporary copy of the shaded CLI JAR.
- Prevent the running CLI process from losing late-loaded classes when `update` rebuilds or touches `build/libs/cotor-*-all.jar` before Koin shutdown.

## Validation
- `bash -n shell/cotor`
- `./shell/cotor version`
- `graphify update .`
- `git diff --check`
- `./shell/cotor update --verify`
